### PR TITLE
 Add Conditional Debug Logging for Tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -8,5 +8,8 @@ def pytest_configure(config):
     if os.getenv("SBS_TEST_DEBUG", "").lower() == "true":
         config.option.log_cli = True
         config.option.log_cli_level = "DEBUG"
+    else:
+        # Explicitly disable CLI logging when not in debug mode
+        config.option.log_cli = False
 
 # Made with Bob

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,12 @@
+"""Root conftest.py for pytest configuration."""
+import os
+
+
+def pytest_configure(config):
+    """Configure pytest based on environment variables."""
+    # Enable debug logging if SBS_TEST_DEBUG is set to true
+    if os.getenv("SBS_TEST_DEBUG", "").lower() == "true":
+        config.option.log_cli = True
+        config.option.log_cli_level = "DEBUG"
+
+# Made with Bob

--- a/docs/config-env-vars.md
+++ b/docs/config-env-vars.md
@@ -37,3 +37,20 @@ This table lists embedding configuration used by SBS service, along with the env
 | Model search k  | 5                                                 | `EMBEDDING_MODEL_SEARCH_K`     |
 
 > You can override the default values by setting the corresponding environment variables in your deployment configuration.
+
+
+This table lists test configuration used by SBS service, along with the environment variables that can be used to override them.
+
+| Configuration   | Default value | Environment Variables Override | Notes                                    |
+|-----------------|---------------|--------------------------------|------------------------------------------|
+| Test debug mode | False         | `SBS_TEST_DEBUG`               | If True - enable debug logging for tests |
+
+> You can override the default values by setting the corresponding environment variables in your deployment configuration.
+
+### Example: Running tests with debug logs enabled
+
+To enable debug logging when running tests with make:
+
+```bash
+SBS_TEST_DEBUG=true make test
+```

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,6 @@
 pythonpath  = .
 markers =
     integration: marks tests as integration tests (require running service, deselect with '-m "not integration"')
-log_cli = true
-log_cli_level = DEBUG
+; log_cli = true
+; log_cli_level = DEBUG
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,3 @@
 pythonpath  = .
 markers =
     integration: marks tests as integration tests (require running service, deselect with '-m "not integration"')
-; log_cli = true
-; log_cli_level = DEBUG
-


### PR DESCRIPTION
# Add Conditional Debug Logging for Tests

## Summary
Implements conditional debug logging for pytest via the `SBS_TEST_DEBUG` environment variable, reducing verbose output during normal test runs.

## Changes
- **pytest.ini**: Removed hardcoded `log_cli` settings
- **conftest.py**: Added new root-level configuration that enables debug logging only when `SBS_TEST_DEBUG=true`

## Behavior
- **Default**: Tests run quietly without CLI logging
- **Debug mode**: Set `SBS_TEST_DEBUG=true` to enable verbose debug output

## Usage
```bash
# Normal test run (quiet)
make test

# Debug test run (verbose)
SBS_TEST_DEBUG=true make test
```

## Benefits
- Cleaner test output by default
- Easy debugging when needed
- No changes required to existing test code