### PR TITLE
Fix MCP Tool Execution Error Handling

### DIFF
--- a/src/skillberry_store/fast_api/tools_api.py
+++ b/src/skillberry_store/fast_api/tools_api.py
@@ -606,14 +606,29 @@ def register_tools_api(
                 parameters=exec_parameters, env_id=env_id
             )
             
-            # Record successful execution metrics only if no error
-            if not (isinstance(result, dict) and "error" in result):
-                duration = time.time() - start_time
-                execute_successfully_tool_counter.labels(name=name).inc()
-                execute_successfully_tool_latency.labels(name=name).observe(duration)
-                logger.info(f"Tool '{name}' executed successfully with result: {result}")
-            else:
-                logger.error(f"Tool '{name}' execution failed with error: {result.get('error')}")
+            # Check if the result contains an error payload
+            if isinstance(result, dict) and "error" in result:
+                error_message = result.get("error", "Unknown error")
+                logger.error(f"Tool '{name}' execution failed with error: {error_message}")
+                
+                # Determine appropriate HTTP status code based on error message
+                # Tool not found on MCP server -> 404
+                # Connection/timeout/other MCP errors -> 500
+                if "not found" in error_message.lower():
+                    status_code = 404
+                else:
+                    status_code = 500
+                
+                raise HTTPException(
+                    status_code=status_code,
+                    detail=error_message
+                )
+            
+            # Record successful execution metrics
+            duration = time.time() - start_time
+            execute_successfully_tool_counter.labels(name=name).inc()
+            execute_successfully_tool_latency.labels(name=name).observe(duration)
+            logger.info(f"Tool '{name}' executed successfully with result: {result}")
             
             return result
 


### PR DESCRIPTION
# Fix MCP Tool Execution Error Handling

## Problem
The `test_mcp_tool_not_found` test was failing because when an MCP tool execution failed (e.g., tool not found, connection timeout, server unreachable), the API was returning HTTP 200 with an error payload `{"error": "..."}` instead of the expected HTTP error status (404 or 500).

## Root Cause
The `execute_tool()` endpoint in `tools_api.py` was returning error dictionaries from `FileExecutor.execute_file()` directly without converting them to HTTP exceptions. The `execute_python_file_in_mcp_server()` method returns error payloads like:
- `{"error": "Timeout connecting to MCP server..."}` 
- `{"error": "Error calling MCP tool '...'..."}`

These were being returned with HTTP 200, causing tests to fail.

## Solution
Modified `execute_tool()` to detect error payloads and convert them to appropriate HTTP exceptions:

1. After `file_executor.execute_file()`, check if result contains an `"error"` key
2. Extract the error message
3. Map to appropriate HTTP status:
   - **404**: Error message contains "not found" (tool missing on MCP server)
   - **500**: All other errors (connection failures, timeouts, execution errors)
4. Raise `HTTPException` with the status code and error message
5. Only record success metrics when there's no error

## Changes
- Modified `src/skillberry_store/fast_api/tools_api.py`:
  - Added error detection logic after line 605
  - Converts error payloads to HTTP exceptions
  - Proper status code mapping (404 for not found, 500 for other errors)
  - Success metrics only recorded on actual success

## Testing
The `test_mcp_tool_not_found` test now:
1. Creates an MCP tool pointing to non-existent server
2. Attempts to execute the tool
3. Receives proper HTTP error status (404 or 500) instead of 200
4. Test assertion passes
