### PR TITLE
WIP: Add external MCPs, plugins framework, and Agent Connect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .env
 **.venv-wsl
 **.claude
+CLAUDE.md
 
 .idea/
 

--- a/skillberry-common/scripts/check-multiarch.sh
+++ b/skillberry-common/scripts/check-multiarch.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 
 set -u

--- a/src/skillberry_store/fast_api/admin_api.py
+++ b/src/skillberry_store/fast_api/admin_api.py
@@ -219,6 +219,28 @@ def register_admin_api(app: FastAPI, tags: str = "admin"):
             "vector_indexes_reset": vector_indexes_reset,
         }
 
+    @app.get("/admin/server-info", tags=[tags])
+    def get_server_info():
+        """Get server connection information for MCP clients.
+
+        Returns:
+            dict: Server host, port, MCP endpoint URLs, and API docs URL.
+        """
+        settings = app.settings
+        host = settings.display_host
+        port = settings.sbs_port
+        agent_mcp_port = settings.agent_mcp_port
+
+        agent_mcp_running = hasattr(app, 'agent_mcp') and app.agent_mcp is not None
+        return {
+            "host": host,
+            "port": port,
+            "agent_mcp_port": agent_mcp_port,
+            "agent_mcp_url": f"http://{host}:{agent_mcp_port}/sse" if agent_mcp_running else None,
+            "control_mcp_url": f"http://{host}:{port}/control_sse",
+            "api_docs": f"http://{host}:{port}/docs",
+        }
+
     @app.get("/health", tags=[tags])
     def health_check():
         """Health check endpoint.
@@ -227,6 +249,95 @@ def register_admin_api(app: FastAPI, tags: str = "admin"):
             dict: Health status of the service.
         """
         return {"status": "healthy"}
+
+    @app.get("/plugins", tags=[tags])
+    def list_plugins():
+        """List all installed plugins with their current enabled state and UI manifests."""
+        from skillberry_store.plugins import installed_plugins, read_enabled
+
+        enabled_ids = set(read_enabled())
+        items = []
+        for p in installed_plugins():
+            is_enabled = p.id in enabled_ids
+            items.append({
+                "id": p.id,
+                "name": p.name,
+                "description": p.description,
+                "enabled": is_enabled,
+                "requires_restart": getattr(p, "requires_restart", False),
+                "ui_manifest": p.ui_manifest.to_dict() if is_enabled else None,
+            })
+        return {"plugins": items}
+
+    @app.post("/plugins/{plugin_id}/enable", tags=[tags])
+    def enable_plugin(plugin_id: str):
+        """Enable a plugin.
+
+        For plugins with `requires_restart=False`, routes are mounted live.
+        Otherwise `enabled.json` is updated but the response signals that a
+        store restart is required for the change to take effect.
+        """
+        from skillberry_store.plugins import (
+            get_plugin,
+            is_enabled,
+            mount_plugin,
+            set_enabled,
+        )
+
+        plugin = get_plugin(plugin_id)
+        if plugin is None:
+            raise HTTPException(status_code=404, detail=f"Plugin '{plugin_id}' not installed")
+
+        already = is_enabled(plugin_id)
+        set_enabled(plugin_id, True)
+
+        if plugin.requires_restart:
+            return {"plugin_id": plugin_id, "enabled": True, "restart_required": True}
+
+        if not already:
+            try:
+                if hasattr(plugin, "bind_app"):
+                    plugin.bind_app(app)
+                mount_plugin(app, plugin)
+            except Exception as e:
+                logger.error(f"Failed to mount plugin '{plugin_id}': {e}")
+                raise HTTPException(status_code=500, detail=f"Mount failed: {e}")
+
+        return {"plugin_id": plugin_id, "enabled": True, "restart_required": False}
+
+    @app.post("/plugins/{plugin_id}/disable", tags=[tags])
+    def disable_plugin(plugin_id: str):
+        """Disable a plugin.
+
+        For plugins with `requires_restart=False`, routes are removed live.
+        Otherwise `enabled.json` is updated but the response signals that a
+        store restart is required for the change to take effect.
+        """
+        from skillberry_store.plugins import (
+            get_plugin,
+            is_enabled,
+            set_enabled,
+            unmount_plugin,
+        )
+
+        plugin = get_plugin(plugin_id)
+        if plugin is None:
+            raise HTTPException(status_code=404, detail=f"Plugin '{plugin_id}' not installed")
+
+        was_enabled = is_enabled(plugin_id)
+        set_enabled(plugin_id, False)
+
+        if plugin.requires_restart:
+            return {"plugin_id": plugin_id, "enabled": False, "restart_required": True}
+
+        if was_enabled:
+            try:
+                unmount_plugin(app, plugin)
+            except Exception as e:
+                logger.error(f"Failed to unmount plugin '{plugin_id}': {e}")
+                raise HTTPException(status_code=500, detail=f"Unmount failed: {e}")
+
+        return {"plugin_id": plugin_id, "enabled": False, "restart_required": False}
 
     @app.get("/health/ready", tags=[tags])
     def readiness_check():

--- a/src/skillberry_store/fast_api/agent_mcp_server.py
+++ b/src/skillberry_store/fast_api/agent_mcp_server.py
@@ -1,0 +1,796 @@
+"""Curated Agent MCP Server for Skillberry Store.
+
+Provides clean, well-named MCP tools for AI agents to manage the store.
+Runs on its own port (default 9999) using FastMCP with SSE transport.
+"""
+
+import json
+import logging
+import socket
+import threading
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+import uvicorn
+from mcp.server.fastmcp import FastMCP
+from starlette.middleware.cors import CORSMiddleware
+
+from skillberry_store.modules.file_handler import FileHandler
+from skillberry_store.modules.file_executor import FileExecutor
+from skillberry_store.modules.description import Description
+from skillberry_store.modules.external_mcp_manager import normalize_mcp_input
+from skillberry_store.modules.tool_health import (
+    find_dependents as _find_dependents,
+    list_broken_tools as _list_broken_tools,
+)
+from skillberry_store.tools.configure import (
+    get_tools_directory,
+    get_files_directory_path,
+    get_skills_directory,
+    get_snippets_directory,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def create_agent_mcp_server(app, port: int = 9999):
+    """Create and start the curated Agent MCP server.
+
+    Args:
+        app: The SBS FastAPI application instance (provides access to app.state).
+        port: Port to run the MCP server on.
+
+    Returns:
+        The FastMCP server instance.
+    """
+    mcp = FastMCP(name="skillberry-agent", port=port)
+
+    tool_handler = FileHandler(get_tools_directory())
+    file_handler = FileHandler(get_files_directory_path())
+    skill_handler = FileHandler(get_skills_directory())
+    snippet_handler = FileHandler(get_snippets_directory())
+
+    tools_descriptions: Optional[Description] = getattr(app.state, "tools_descriptions", None)
+
+    # ---- Tool management ----
+
+    @mcp.tool()
+    def list_tools() -> str:
+        """List all tools in the store with their name, description, and state."""
+        tools = []
+        for filename in tool_handler.list_files():
+            if not filename.endswith(".json"):
+                continue
+            content = tool_handler.read_file(filename, raw_content=True)
+            if isinstance(content, str):
+                d = json.loads(content)
+                tools.append({
+                    "name": d.get("name"),
+                    "description": d.get("description"),
+                    "state": d.get("state"),
+                    "version": d.get("version"),
+                    "packaging_format": d.get("packaging_format"),
+                    "tags": d.get("tags", []),
+                })
+        return json.dumps(tools, indent=2)
+
+    @mcp.tool()
+    def get_tool_metadata(name: str) -> str:
+        """Get the full metadata manifest for a tool."""
+        content = tool_handler.read_file(f"{name}.json", raw_content=True)
+        if isinstance(content, str):
+            return content
+        return json.dumps({"error": f"Tool '{name}' not found"})
+
+    @mcp.tool()
+    def get_tool_code(name: str) -> str:
+        """Get the Python source code of a tool."""
+        content = tool_handler.read_file(f"{name}.json", raw_content=True)
+        if not isinstance(content, str):
+            return f"Error: Tool '{name}' not found"
+        d = json.loads(content)
+        module_name = d.get("module_name")
+        if not module_name:
+            return f"Error: Tool '{name}' has no module file"
+        code = file_handler.read_file(module_name, raw_content=True)
+        if isinstance(code, str):
+            return code
+        return f"Error: Could not read module file '{module_name}'"
+
+    @mcp.tool()
+    def update_tool_code(name: str, code: str) -> str:
+        """Update the source code of a tool.
+
+        Args:
+            name: The tool name.
+            code: The new Python source code.
+        """
+        content = tool_handler.read_file(f"{name}.json", raw_content=True)
+        if not isinstance(content, str):
+            return f"Error: Tool '{name}' not found"
+        d = json.loads(content)
+        if d.get("packaging_format") == "mcp":
+            return "Error: Cannot update source code for MCP-packaged tools"
+
+        # Dependent-safe guard — refuse if any other tool lists this one as a
+        # dependency, since the new code could break those callers.
+        dependents = _find_dependents(name, tool_handler)
+        if dependents:
+            return json.dumps({
+                "error": "tool_has_dependents",
+                "tool": name,
+                "dependents": dependents,
+                "suggestion": (
+                    f"Tool '{name}' is used by the listed tools. Changing its "
+                    "code would break them. Create a new tool with a different "
+                    "name, or remove/update the dependents first."
+                ),
+            })
+
+        module_name = d.get("module_name")
+        if not module_name:
+            return f"Error: Tool '{name}' has no module file"
+        file_handler.write_file_content(module_name, code)
+        d["modified_at"] = datetime.now(timezone.utc).isoformat()
+        tool_handler.write_file_content(f"{name}.json", json.dumps(d, indent=4))
+        return f"Source code for tool '{name}' updated successfully."
+
+    @mcp.tool()
+    def update_tool_metadata(
+        name: str,
+        description: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        state: Optional[str] = None,
+        version: Optional[str] = None,
+    ) -> str:
+        """Selectively update metadata fields of a tool.
+
+        Args:
+            name: The tool name.
+            description: New description (optional).
+            tags: New tags list (optional).
+            state: New state - one of unknown, new, checked, approved (optional).
+            version: New version string (optional).
+        """
+        content = tool_handler.read_file(f"{name}.json", raw_content=True)
+        if not isinstance(content, str):
+            return f"Error: Tool '{name}' not found"
+        d = json.loads(content)
+        old_desc = d.get("description")
+        if description is not None:
+            d["description"] = description
+        if tags is not None:
+            d["tags"] = tags
+        if state is not None:
+            d["state"] = state
+        if version is not None:
+            d["version"] = version
+        d["modified_at"] = datetime.now(timezone.utc).isoformat()
+        tool_handler.write_file_content(f"{name}.json", json.dumps(d, indent=4))
+        if tools_descriptions and description and description != old_desc:
+            try:
+                tools_descriptions.update_description(name, description)
+            except Exception:
+                try:
+                    tools_descriptions.write_description(name, description)
+                except Exception:
+                    pass
+        return f"Metadata for tool '{name}' updated successfully."
+
+    @mcp.tool()
+    def create_tool(name: str, code: str, description: str, tags: Optional[List[str]] = None) -> str:
+        """Create a new tool from Python code.
+
+        Args:
+            name: The tool name.
+            code: The Python source code.
+            description: A description of what the tool does.
+            tags: Optional list of tags.
+        """
+        tool_filename = f"{name}.json"
+        if tool_filename in tool_handler.list_files():
+            return f"Error: Tool '{name}' already exists"
+        import uuid as uuid_mod
+        module_name = f"{name}.py"
+        manifest = {
+            "name": name,
+            "uuid": str(uuid_mod.uuid4()),
+            "version": "1.0.0",
+            "description": description,
+            "state": "approved",
+            "tags": tags or [],
+            "extra": {},
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "modified_at": datetime.now(timezone.utc).isoformat(),
+            "module_name": module_name,
+            "programming_language": "python",
+            "packaging_format": "code",
+            "params": {"type": "object", "properties": {}, "required": [], "optional": []},
+            "returns": None,
+            "dependencies": None,
+        }
+        file_handler.write_file_content(module_name, code)
+        tool_handler.write_file_content(tool_filename, json.dumps(manifest, indent=4))
+        if tools_descriptions:
+            try:
+                tools_descriptions.write_description(name, description)
+            except Exception:
+                pass
+        return json.dumps({"message": f"Tool '{name}' created successfully.", "uuid": manifest["uuid"]})
+
+    @mcp.tool()
+    def execute_tool(name: str, parameters: Optional[Dict[str, Any]] = None) -> str:
+        """Execute a tool by name with the provided parameters.
+
+        Args:
+            name: The tool name.
+            parameters: Optional dictionary of parameters.
+        """
+        content = tool_handler.read_file(f"{name}.json", raw_content=True)
+        if not isinstance(content, str):
+            return f"Error: Tool '{name}' not found"
+        d = json.loads(content)
+        module_name = d.get("module_name")
+        if not module_name:
+            return f"Error: Tool '{name}' has no module file"
+        try:
+            executor = FileExecutor(get_files_directory_path())
+            result = executor.execute_python_file(module_name, parameters or {})
+            return json.dumps(result)
+        except Exception as e:
+            return f"Error executing tool '{name}': {str(e)}"
+
+    @mcp.tool()
+    def search_tools(query: str, max_results: int = 5) -> str:
+        """Search for tools by semantic description.
+
+        Args:
+            query: The search query.
+            max_results: Maximum number of results to return.
+        """
+        if not tools_descriptions:
+            return json.dumps({"error": "Search not available — no description index configured"})
+        try:
+            results = tools_descriptions.search(query, max_results)
+            return json.dumps(results, indent=2)
+        except Exception as e:
+            return f"Error searching tools: {str(e)}"
+
+    # ---- Skill management ----
+
+    @mcp.tool()
+    def list_skills() -> str:
+        """List all skills in the store."""
+        skills = []
+        for filename in skill_handler.list_files():
+            if not filename.endswith(".json"):
+                continue
+            content = skill_handler.read_file(filename, raw_content=True)
+            if isinstance(content, str):
+                d = json.loads(content)
+                skills.append({
+                    "name": d.get("name"),
+                    "description": d.get("description"),
+                    "state": d.get("state"),
+                    "version": d.get("version"),
+                    "tags": d.get("tags", []),
+                    "tool_uuids": d.get("tool_uuids", []),
+                    "snippet_uuids": d.get("snippet_uuids", []),
+                })
+        return json.dumps(skills, indent=2)
+
+    @mcp.tool()
+    def get_skill(name: str) -> str:
+        """Get a skill with its resolved tools and snippets."""
+        content = skill_handler.read_file(f"{name}.json", raw_content=True)
+        if not isinstance(content, str):
+            return json.dumps({"error": f"Skill '{name}' not found"})
+        d = json.loads(content)
+        # Resolve tool names from UUIDs
+        tools_list = []
+        for uuid in d.get("tool_uuids", []):
+            for tf in tool_handler.list_files():
+                if not tf.endswith(".json"):
+                    continue
+                tc = tool_handler.read_file(tf, raw_content=True)
+                if isinstance(tc, str):
+                    td = json.loads(tc)
+                    if td.get("uuid") == uuid:
+                        tools_list.append({"name": td["name"], "description": td.get("description"), "uuid": uuid})
+                        break
+        d["tools"] = tools_list
+        return json.dumps(d, indent=2)
+
+    @mcp.tool()
+    def create_skill(
+        name: str,
+        description: str,
+        tool_names: Optional[List[str]] = None,
+        tags: Optional[List[str]] = None,
+        from_mcps: Optional[List[str]] = None,
+        from_mcps_mode: str = "bundled_related",
+    ) -> str:
+        """Create a new skill.
+
+        Mirrors the Create Skill UI modal: you can either pass explicit
+        `tool_names`, or specify `from_mcps` to bulk-add every tool that
+        touches those external MCP server(s), or both (results are merged;
+        duplicates are skipped).
+
+        Args:
+            name: The skill name.
+            description: Description of the skill.
+            tool_names: Optional list of tool names to include explicitly.
+            tags: Optional list of tags.
+            from_mcps: Optional list of external MCP server names. If given,
+                every tool associated with those MCPs (per `from_mcps_mode`)
+                is added in one step after the skill is created.
+            from_mcps_mode: One of
+                - 'primitives'       — only MCP primitives (tool.mcp_server in from_mcps)
+                - 'related'          — primitives + every composite whose mcp_dependencies intersects from_mcps
+                - 'bundled_related'  — same as 'related' but skips tools with bundled_with_mcps==False
+                  (if you want those included, pick 'related' instead)
+        """
+        skill_filename = f"{name}.json"
+        if skill_filename in skill_handler.list_files():
+            return f"Error: Skill '{name}' already exists"
+        if from_mcps and from_mcps_mode not in ("primitives", "related", "bundled_related"):
+            return f"Error: from_mcps_mode must be one of primitives|related|bundled_related (got {from_mcps_mode!r})"
+
+        import uuid as uuid_mod
+        tool_uuids: List[str] = []
+        if tool_names:
+            for tn in tool_names:
+                tc = tool_handler.read_file(f"{tn}.json", raw_content=True)
+                if isinstance(tc, str):
+                    td = json.loads(tc)
+                    tool_uuids.append(td.get("uuid", ""))
+                else:
+                    return f"Error: Tool '{tn}' not found"
+
+        # Bulk-add from MCPs (same logic as bulk_add_tools_from_mcps — we run
+        # it here against the seed tool_uuids set before the skill is first
+        # persisted, so duplicates against the `tool_names` list are skipped.)
+        bulk_summary: Optional[Dict[str, Any]] = None
+        if from_mcps:
+            mcp_set = set(from_mcps)
+            existing_uuids = set(tool_uuids)
+            added: List[Dict[str, str]] = []
+            skipped_duplicate: List[str] = []
+            skipped_broken: List[Dict[str, str]] = []
+            skipped_unbundled: List[str] = []
+            for fname in tool_handler.list_files():
+                if not fname.endswith(".json"):
+                    continue
+                try:
+                    d = json.loads(tool_handler.read_file(fname, raw_content=True))
+                except Exception:
+                    continue
+                tool_mcp = d.get("mcp_server")
+                tool_deps = set(d.get("mcp_dependencies") or [])
+                if not ((tool_mcp in mcp_set) or (tool_deps & mcp_set)):
+                    continue
+                if from_mcps_mode == "primitives" and tool_mcp not in mcp_set:
+                    continue
+                if from_mcps_mode == "bundled_related" and d.get("bundled_with_mcps") is False:
+                    skipped_unbundled.append(d.get("name") or fname[:-5])
+                    continue
+                if d.get("state") == "broken":
+                    skipped_broken.append({"name": d.get("name"), "reason": d.get("broken_reason") or "broken"})
+                    continue
+                if d.get("uuid") in existing_uuids:
+                    skipped_duplicate.append(d.get("name") or fname[:-5])
+                    continue
+                existing_uuids.add(d["uuid"])
+                added.append({"name": d["name"], "uuid": d["uuid"]})
+            tool_uuids = sorted(existing_uuids)
+            bulk_summary = {
+                "requested_mcps": sorted(mcp_set),
+                "mode": from_mcps_mode,
+                "added": added,
+                "skipped_duplicate": skipped_duplicate,
+                "skipped_broken": skipped_broken,
+                "skipped_unbundled": skipped_unbundled,
+            }
+
+        manifest = {
+            "name": name,
+            "uuid": str(uuid_mod.uuid4()),
+            "version": "1.0.0",
+            "description": description,
+            "state": "approved",
+            "tags": tags or [],
+            "extra": {},
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "modified_at": datetime.now(timezone.utc).isoformat(),
+            "tool_uuids": tool_uuids,
+            "snippet_uuids": [],
+        }
+        skill_handler.write_file_content(skill_filename, json.dumps(manifest, indent=4))
+        response: Dict[str, Any] = {
+            "message": f"Skill '{name}' created successfully.",
+            "uuid": manifest["uuid"],
+            "tool_count": len(tool_uuids),
+        }
+        if bulk_summary is not None:
+            response["mcp_bulk_add"] = bulk_summary
+        return json.dumps(response, indent=2)
+
+    @mcp.tool()
+    def add_tool_to_skill(skill_name: str, tool_name: str) -> str:
+        """Add a tool to a skill by name.
+
+        Args:
+            skill_name: The skill name.
+            tool_name: The tool name to add.
+        """
+        sc = skill_handler.read_file(f"{skill_name}.json", raw_content=True)
+        if not isinstance(sc, str):
+            return f"Error: Skill '{skill_name}' not found"
+        tc = tool_handler.read_file(f"{tool_name}.json", raw_content=True)
+        if not isinstance(tc, str):
+            return f"Error: Tool '{tool_name}' not found"
+        skill = json.loads(sc)
+        tool_uuid = json.loads(tc).get("uuid", "")
+        if tool_uuid in skill.get("tool_uuids", []):
+            return f"Tool '{tool_name}' is already in skill '{skill_name}'"
+        skill.setdefault("tool_uuids", []).append(tool_uuid)
+        skill["modified_at"] = datetime.now(timezone.utc).isoformat()
+        skill_handler.write_file_content(f"{skill_name}.json", json.dumps(skill, indent=4))
+        return f"Tool '{tool_name}' added to skill '{skill_name}'."
+
+    @mcp.tool()
+    def remove_tool_from_skill(skill_name: str, tool_name: str) -> str:
+        """Remove a tool from a skill by name.
+
+        Args:
+            skill_name: The skill name.
+            tool_name: The tool name to remove.
+        """
+        sc = skill_handler.read_file(f"{skill_name}.json", raw_content=True)
+        if not isinstance(sc, str):
+            return f"Error: Skill '{skill_name}' not found"
+        tc = tool_handler.read_file(f"{tool_name}.json", raw_content=True)
+        if not isinstance(tc, str):
+            return f"Error: Tool '{tool_name}' not found"
+        skill = json.loads(sc)
+        tool_uuid = json.loads(tc).get("uuid", "")
+        uuids = skill.get("tool_uuids", [])
+        if tool_uuid not in uuids:
+            return f"Tool '{tool_name}' is not in skill '{skill_name}'"
+        uuids.remove(tool_uuid)
+        skill["modified_at"] = datetime.now(timezone.utc).isoformat()
+        skill_handler.write_file_content(f"{skill_name}.json", json.dumps(skill, indent=4))
+        return f"Tool '{tool_name}' removed from skill '{skill_name}'."
+
+    # ---- VMCP Server management ----
+
+    @mcp.tool()
+    def create_vmcp_server(skill_name: str, port: Optional[int] = None) -> str:
+        """Create and start a Virtual MCP Server for a skill.
+
+        Args:
+            skill_name: The skill to expose via MCP.
+            port: Optional port number. If not specified, an available port is auto-selected.
+        """
+        sc = skill_handler.read_file(f"{skill_name}.json", raw_content=True)
+        if not isinstance(sc, str):
+            return f"Error: Skill '{skill_name}' not found"
+        skill = json.loads(sc)
+        vmcp_manager = getattr(app.state, "vmcp_server_manager", None)
+        if not vmcp_manager:
+            return "Error: VMCP server manager not available"
+
+        tool_names: List[str] = []
+        for tool_uuid in skill.get("tool_uuids", []):
+            for filename in tool_handler.list_files():
+                if not filename.endswith(".json"):
+                    continue
+                content = tool_handler.read_file(filename, raw_content=True)
+                if isinstance(content, str):
+                    td = json.loads(content)
+                    if td.get("uuid") == tool_uuid:
+                        tool_names.append(td.get("name"))
+                        break
+
+        snippet_names: List[str] = []
+        for snippet_uuid in skill.get("snippet_uuids", []):
+            for filename in snippet_handler.list_files():
+                if not filename.endswith(".json"):
+                    continue
+                content = snippet_handler.read_file(filename, raw_content=True)
+                if isinstance(content, str):
+                    sd = json.loads(content)
+                    if sd.get("uuid") == snippet_uuid:
+                        snippet_names.append(sd.get("name"))
+                        break
+
+        try:
+            server = vmcp_manager.add_server(
+                name=skill_name,
+                description=f"VMCP server for skill '{skill_name}'",
+                port=port,
+                tools=tool_names,
+                snippets=snippet_names,
+            )
+            server_port = server.port if hasattr(server, "port") else port
+            return json.dumps({
+                "message": f"VMCP server '{skill_name}' created and started.",
+                "port": server_port,
+                "connect_command": f"claude mcp add {skill_name} -s user -t sse http://localhost:{server_port}/sse",
+            })
+        except Exception as e:
+            return f"Error creating VMCP server: {str(e)}"
+
+    # ---- External MCP server management ----
+
+    @mcp.tool()
+    async def add_external_mcp(config_json: str) -> str:
+        """Register and start one or more external MCP servers from a config.
+
+        Accepts any of the five supported shapes (Claude-Desktop-style
+        `{"mcpServers": {...}}`, a bare name→entry dict, a list of entries, a
+        single entry, or `{"source_url": "..."}`). For each server, the store
+        starts the transport (stdio subprocess, SSE connection, or streamable
+        HTTP session), lists its tools, and registers each as a primitive
+        named `<server>__<remote_name>`.
+
+        Args:
+            config_json: JSON string in any of the five shapes above.
+        """
+        mgr = getattr(app.state, "external_mcp_manager", None)
+        if mgr is None:
+            return json.dumps({"error": "External MCP manager is not initialized"})
+        try:
+            data = json.loads(config_json)
+        except Exception as e:
+            return json.dumps({"error": f"invalid JSON: {e}"})
+        try:
+            entries = normalize_mcp_input(data)
+        except ValueError as e:
+            return json.dumps({"error": str(e)})
+        results = []
+        for entry in entries:
+            try:
+                res = await mgr.start(entry, persist=True)
+            except Exception as e:  # noqa: BLE001
+                res = {"name": entry.get("name"), "status": "error", "error": str(e)}
+            results.append(res)
+        return json.dumps({"count": len(results), "results": results}, indent=2)
+
+    @mcp.tool()
+    def list_external_mcps() -> str:
+        """List registered external MCP servers with status, transport, and tool count."""
+        mgr = getattr(app.state, "external_mcp_manager", None)
+        if mgr is None:
+            return json.dumps({"error": "External MCP manager is not initialized"})
+        return json.dumps(mgr.list_servers(), indent=2)
+
+    @mcp.tool()
+    async def remove_external_mcp(name: str) -> str:
+        """Stop and unregister an external MCP server; delete all its primitives.
+
+        Composites that depended on those primitives are NOT deleted — the
+        universal health pass will flag them `state="broken"` so you can
+        inspect, fix, or delete them.
+
+        Args:
+            name: The external MCP server name.
+        """
+        mgr = getattr(app.state, "external_mcp_manager", None)
+        if mgr is None:
+            return json.dumps({"error": "External MCP manager is not initialized"})
+        try:
+            result = await mgr.remove(name)
+            return json.dumps(result, indent=2)
+        except Exception as e:  # noqa: BLE001
+            return json.dumps({"error": str(e)})
+
+    @mcp.tool()
+    async def restart_external_mcp(name: str) -> str:
+        """Restart an external MCP server and reconcile its primitives.
+
+        Use when the upstream server has changed (new tools, schema updates)
+        or after a transient network/process failure.
+
+        Args:
+            name: The external MCP server name.
+        """
+        mgr = getattr(app.state, "external_mcp_manager", None)
+        if mgr is None:
+            return json.dumps({"error": "External MCP manager is not initialized"})
+        try:
+            result = await mgr.restart(name)
+            return json.dumps(result, indent=2)
+        except Exception as e:  # noqa: BLE001
+            return json.dumps({"error": str(e)})
+
+    @mcp.tool()
+    async def list_remote_external_mcp_tools(name: str) -> str:
+        """Introspect tools exposed by a running external MCP server.
+
+        Pass-through over `list_tools()` on the live session. Handy for
+        previewing what a server offers before relying on its primitives.
+
+        Args:
+            name: The external MCP server name.
+        """
+        mgr = getattr(app.state, "external_mcp_manager", None)
+        if mgr is None:
+            return json.dumps({"error": "External MCP manager is not initialized"})
+        try:
+            tools = await mgr.list_remote_tools(name)
+            return json.dumps(tools, indent=2, default=str)
+        except Exception as e:  # noqa: BLE001
+            return json.dumps({"error": str(e)})
+
+    @mcp.tool()
+    def list_broken_tools() -> str:
+        """List every tool currently in `state='broken'` with its broken_reason.
+
+        Useful for agent-driven repair loops after an external MCP server's
+        upstream changes (schema drift, tool removal, server unavailable).
+        """
+        return json.dumps(_list_broken_tools(tool_handler), indent=2)
+
+    @mcp.tool()
+    def set_tool_bundled_with_mcps(name: str, bundled: bool) -> str:
+        """Toggle whether this tool is included by default when skills are
+        built from its MCP server(s).
+
+        Only meaningful for MCP primitives and composites that depend on MCPs.
+        When `bundled=false`, the tool is skipped from bulk 'add all tools of
+        MCP X' operations (it can still be added manually). Useful while
+        optimizing an MCP: mark a noisy primitive as unbundled, then agent-built
+        skills stop pulling it in automatically.
+
+        Args:
+            name: The tool name.
+            bundled: Whether this tool should be included by default.
+        """
+        content = tool_handler.read_file(f"{name}.json", raw_content=True)
+        if not isinstance(content, str):
+            return json.dumps({"error": f"Tool '{name}' not found"})
+        d = json.loads(content)
+        if not (d.get("mcp_server") or d.get("mcp_dependencies")):
+            return json.dumps({
+                "error": (
+                    f"Tool '{name}' has no MCP association. The bundled_with_mcps "
+                    "flag is only meaningful for MCP primitives and composites "
+                    "that depend on MCPs."
+                ),
+            })
+        d["bundled_with_mcps"] = bool(bundled)
+        d["modified_at"] = datetime.now(timezone.utc).isoformat()
+        tool_handler.write_file_content(f"{name}.json", json.dumps(d, indent=4))
+        return json.dumps({"name": name, "bundled_with_mcps": d["bundled_with_mcps"]})
+
+    @mcp.tool()
+    def bulk_add_tools_from_mcps(
+        skill_name: str,
+        mcps: List[str],
+        mode: str = "bundled_related",
+    ) -> str:
+        """Add tools to a skill in bulk, based on which external MCP(s) they touch.
+
+        Args:
+            skill_name: Target skill.
+            mcps: External MCP server names whose tools should be pulled in (non-empty).
+            mode: One of
+                - 'primitives'       — only MCP primitives (tool.mcp_server in mcps)
+                - 'related'          — primitives + every composite whose mcp_dependencies intersects mcps
+                - 'bundled_related'  — same as 'related' but skips tools with bundled_with_mcps==False
+                  (if you want those included, use 'related' instead)
+
+        Returns a JSON summary with added, skipped_duplicate, skipped_broken,
+        skipped_unbundled lists.
+        """
+        if not mcps:
+            return json.dumps({"error": "`mcps` must be non-empty"})
+        if mode not in ("primitives", "related", "bundled_related"):
+            return json.dumps({
+                "error": f"`mode` must be one of primitives|related|bundled_related (got {mode!r})"
+            })
+        mcp_set = set(mcps)
+
+        try:
+            skill_raw = skill_handler.read_file(f"{skill_name}.json", raw_content=True)
+        except Exception:
+            return json.dumps({"error": f"Skill '{skill_name}' not found"})
+        if not isinstance(skill_raw, str):
+            return json.dumps({"error": f"Invalid content for skill '{skill_name}'"})
+        skill_dict = json.loads(skill_raw)
+        existing_uuids = set(skill_dict.get("tool_uuids") or [])
+
+        added, skipped_duplicate, skipped_broken, skipped_unbundled = [], [], [], []
+        for fname in tool_handler.list_files():
+            if not fname.endswith(".json"):
+                continue
+            try:
+                d = json.loads(tool_handler.read_file(fname, raw_content=True))
+            except Exception:
+                continue
+            tool_mcp = d.get("mcp_server")
+            tool_deps = set(d.get("mcp_dependencies") or [])
+            if not ((tool_mcp in mcp_set) or (tool_deps & mcp_set)):
+                continue
+            if mode == "primitives" and tool_mcp not in mcp_set:
+                continue
+            if mode == "bundled_related" and d.get("bundled_with_mcps") is False:
+                skipped_unbundled.append(d.get("name") or fname[:-5])
+                continue
+            if d.get("state") == "broken":
+                skipped_broken.append({"name": d.get("name"), "reason": d.get("broken_reason") or "broken"})
+                continue
+            if d.get("uuid") in existing_uuids:
+                skipped_duplicate.append(d.get("name") or fname[:-5])
+                continue
+            existing_uuids.add(d["uuid"])
+            added.append({"name": d["name"], "uuid": d["uuid"]})
+
+        if added:
+            skill_dict["tool_uuids"] = sorted(existing_uuids)
+            skill_dict["modified_at"] = datetime.now(timezone.utc).isoformat()
+            skill_handler.write_file_content(
+                f"{skill_name}.json", json.dumps(skill_dict, indent=4)
+            )
+
+        return json.dumps({
+            "skill": skill_name,
+            "mode": mode,
+            "requested_mcps": sorted(mcp_set),
+            "added": added,
+            "skipped_duplicate": skipped_duplicate,
+            "skipped_broken": skipped_broken,
+            "skipped_unbundled": skipped_unbundled,
+        }, indent=2)
+
+    @mcp.tool()
+    def get_tool_metrics(name: str) -> str:
+        """Get execution metrics for a tool (count and latency).
+
+        Args:
+            name: The tool name.
+        """
+        try:
+            from prometheus_client import REGISTRY
+            metrics_data = {"tool": name, "execute_count": 0, "success_count": 0, "avg_latency_seconds": None}
+            for metric in REGISTRY.collect():
+                if "execute_tool_counter" in metric.name:
+                    for sample in metric.samples:
+                        if sample.labels.get("name") == name:
+                            metrics_data["execute_count"] = int(sample.value)
+                elif "execute_successfully_tool_counter" in metric.name:
+                    for sample in metric.samples:
+                        if sample.labels.get("name") == name:
+                            metrics_data["success_count"] = int(sample.value)
+                elif "execute_successfully_tool_latency" in metric.name and "_sum" in sample.name:
+                    for sample in metric.samples:
+                        if sample.labels.get("name") == name and "_sum" in sample.name:
+                            total = sample.value
+                            if metrics_data["success_count"] > 0:
+                                metrics_data["avg_latency_seconds"] = round(total / metrics_data["success_count"], 4)
+            return json.dumps(metrics_data, indent=2)
+        except Exception as e:
+            return f"Error getting metrics: {str(e)}"
+
+    # ---- Start the server ----
+
+    def _start():
+        logger.info(f"Starting Agent MCP server on port {port}")
+        sse_app = mcp.sse_app()
+        sse_app.add_middleware(
+            CORSMiddleware,
+            allow_origins=["*"],
+            allow_methods=["GET", "POST", "OPTIONS"],
+            allow_headers=["*"],
+            allow_credentials=True,
+            expose_headers=["*"],
+        )
+        uvicorn.run(sse_app, host="127.0.0.1", port=port, log_level="info")
+
+    server_thread = threading.Thread(target=_start, daemon=True)
+    server_thread.start()
+
+    logger.info(f"Agent MCP server started on port {port}")
+    return mcp

--- a/src/skillberry_store/fast_api/agent_mcp_server.py
+++ b/src/skillberry_store/fast_api/agent_mcp_server.py
@@ -23,6 +23,7 @@ from skillberry_store.modules.tool_health import (
     find_dependents as _find_dependents,
     list_broken_tools as _list_broken_tools,
 )
+from skillberry_store.schemas.name_validation import validate_store_name_message
 from skillberry_store.tools.configure import (
     get_tools_directory,
     get_files_directory_path,
@@ -331,6 +332,11 @@ def create_agent_mcp_server(app, port: int = 9999):
                 - 'bundled_related'  — same as 'related' but skips tools with bundled_with_mcps==False
                   (if you want those included, pick 'related' instead)
         """
+        # Slug validation — names are used as URL segments and `claude mcp add
+        # <name>` arguments, so enforce the Anthropic Agent Skills format.
+        invalid_msg = validate_store_name_message(name, kind="skill")
+        if invalid_msg is not None:
+            return json.dumps({"error": invalid_msg})
         skill_filename = f"{name}.json"
         if skill_filename in skill_handler.list_files():
             return f"Error: Skill '{name}' already exists"

--- a/src/skillberry_store/fast_api/external_mcps_api.py
+++ b/src/skillberry_store/fast_api/external_mcps_api.py
@@ -1,0 +1,118 @@
+"""External MCPs API — manage imported MCP servers and their primitives."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from fastapi import Body, FastAPI, HTTPException, Request
+
+from skillberry_store.modules.external_mcp_manager import (
+    ExternalMCPManager,
+    normalize_mcp_input,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _manager(request: Request) -> ExternalMCPManager:
+    mgr: Optional[ExternalMCPManager] = getattr(
+        request.app.state, "external_mcp_manager", None
+    )
+    if mgr is None:
+        raise HTTPException(
+            status_code=503,
+            detail="External MCP manager is not initialized",
+        )
+    return mgr
+
+
+def register_external_mcps_api(app: FastAPI, tags: str = "external_mcps") -> None:
+    """Register the external MCPs REST endpoints."""
+
+    @app.get("/external-mcps", tags=[tags])
+    async def list_external_mcps(request: Request) -> List[Dict[str, Any]]:
+        """List every imported external MCP server with status + tool count."""
+        return _manager(request).list_servers()
+
+    @app.post("/external-mcps", tags=[tags])
+    async def add_external_mcps(
+        request: Request,
+        config: Any = Body(..., description="Any of the 5 supported input shapes."),
+    ) -> Dict[str, Any]:
+        """
+        Register and start one or more external MCP servers.
+
+        Accepts the standard Claude-Desktop-style `{"mcpServers": {...}}`,
+        a bare name→entry dict, a list of entries, a single entry with
+        `name`, or `{"source_url": "..."}` to fetch a config from a URL.
+        Secrets in the posted body are persisted to disk as-is (plaintext,
+        matching existing `ai_features/settings.json` convention).
+        """
+        try:
+            entries = normalize_mcp_input(config)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+
+        mgr = _manager(request)
+        results: List[Dict[str, Any]] = []
+        for entry in entries:
+            try:
+                result = await mgr.start(entry, persist=True)
+            except Exception as e:
+                logger.error("Failed to register external MCP %s: %s", entry.get("name"), e)
+                result = {"name": entry.get("name"), "status": "error", "error": str(e)}
+            results.append(result)
+        return {"count": len(results), "results": results}
+
+    @app.delete("/external-mcps/{name}", tags=[tags])
+    async def remove_external_mcp(request: Request, name: str) -> Dict[str, Any]:
+        """Stop the server, delete its config, and delete every imported primitive.
+
+        Composites that depended on those primitives are NOT deleted — they
+        are left as regular tools and will be flagged `state="broken"` with
+        `broken_reason="dep_missing:..."` by the universal health pass.
+        """
+        mgr = _manager(request)
+        try:
+            return await mgr.remove(name)
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=str(e))
+
+    @app.post("/external-mcps/{name}/restart", tags=[tags])
+    async def restart_external_mcp(request: Request, name: str) -> Dict[str, Any]:
+        """Stop and restart the server; reconciles primitives against remote list_tools()."""
+        mgr = _manager(request)
+        try:
+            return await mgr.restart(name)
+        except ValueError as e:
+            raise HTTPException(status_code=404, detail=str(e))
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=str(e))
+
+    @app.get("/external-mcps/{name}/remote-tools", tags=[tags])
+    async def list_remote_tools(request: Request, name: str) -> List[Dict[str, Any]]:
+        """Pass-through `list_tools()` on the live session — useful for UI preview."""
+        mgr = _manager(request)
+        try:
+            return await mgr.list_remote_tools(name)
+        except ValueError as e:
+            raise HTTPException(status_code=404, detail=str(e))
+        except RuntimeError as e:
+            raise HTTPException(status_code=409, detail=str(e))
+
+    @app.get("/external-mcps/{name}/dependents", tags=[tags])
+    async def list_dependents(request: Request, name: str) -> Dict[str, Any]:
+        """Tools that will transition to `state="broken"` if this server is removed."""
+        mgr = _manager(request)
+        dependents = mgr.find_dependents(name)
+        return {"name": name, "dependents": dependents}
+
+    @app.get("/external-mcps/{name}", tags=[tags])
+    async def get_external_mcp(request: Request, name: str) -> Dict[str, Any]:
+        """Return config + status for a single external MCP."""
+        mgr = _manager(request)
+        server = mgr.get_server(name)
+        if server is None:
+            raise HTTPException(status_code=404, detail=f"unknown external MCP: {name}")
+        return server

--- a/src/skillberry_store/fast_api/server.py
+++ b/src/skillberry_store/fast_api/server.py
@@ -18,12 +18,19 @@ from skillberry_store.fast_api.snippets_api import register_snippets_api
 from skillberry_store.fast_api.tools_api import register_tools_api
 from skillberry_store.fast_api.admin_api import register_admin_api
 from skillberry_store.fast_api.vmcp_api import register_vmcp_api
+from skillberry_store.fast_api.external_mcps_api import register_external_mcps_api
 from skillberry_store.modules.description import Description
+from skillberry_store.modules.external_mcp_manager import (
+    ExternalMCPManager,
+    set_current_manager,
+)
 from skillberry_store.vdbs.identify_vdb import identify_vector_db
 from skillberry_store.modules.file_handler import FileHandler
 from skillberry_store.tools.configure import (
+    get_external_mcps_directory,
     get_files_directory_path,
     get_tools_descriptions_directory,
+    get_tools_directory,
     get_snippets_descriptions_directory,
     get_skills_descriptions_directory,
     get_vmcp_descriptions_directory,
@@ -58,6 +65,7 @@ class SBSettings(BaseSettings):
     )
     observability: bool = Field(True, validation_alias="OBSERVABILITY")
     sbs_vdb: str = Field("faiss", env="SBS_VDB")
+    agent_mcp_port: int = Field(9999, validation_alias="SBS_AGENT_MCP_PORT")
 
     @property
     def display_host(self) -> str:
@@ -95,10 +103,68 @@ class SBS(FastAPI):
         )
         register_tools_api(self, tags="tools", tools_descriptions=self.state.tools_descriptions)
         register_admin_api(self, tags="admin")
+        register_external_mcps_api(self, tags="external_mcps")
 
-        # Mount MCP server
-        mcp_server = FastApiMCP(self)
-        mcp_server.mount_sse(mount_path="/control_sse")
+        # ---- Plugins ----
+        # Main code has no knowledge of any specific plugin; it iterates the
+        # registry and mounts whatever is currently enabled in
+        # $SBS_BASE_DIR/plugins/enabled.json. Hot toggling is handled by the
+        # /plugins admin endpoints.
+        from skillberry_store.plugins import active_plugins, mount_plugin
+        for plugin in active_plugins():
+            try:
+                if hasattr(plugin, "bind_app"):
+                    plugin.bind_app(self)
+                mount_plugin(self, plugin)
+                logger.info(f"Mounted plugin '{plugin.id}'")
+            except Exception as e:
+                logger.warning(f"Failed to mount plugin '{plugin.id}': {e}")
+
+        # ---- Full MCP server (auto-generated from every FastAPI route) ----
+        # Mirrors the complete HTTP surface as MCP tools over SSE on the main
+        # server port. Broad coverage, larger context footprint — intended for
+        # control-plane and admin-style access.
+        self.full_mcp = FastApiMCP(self)
+        self.full_mcp.mount_sse(mount_path="/control_sse")
+        logger.info(f"Full MCP server mounted at /control_sse on port {self.settings.sbs_port}")
+
+        # ---- Curated Agent MCP server (hand-picked tools on its own port) ----
+        # Smaller, LLM-friendly tool set defined in agent_mcp_server.py.
+        # Intended as the default endpoint for AI agents.
+        from skillberry_store.fast_api.agent_mcp_server import create_agent_mcp_server
+        try:
+            self.agent_mcp = create_agent_mcp_server(self, port=self.settings.agent_mcp_port)
+            logger.info(f"Curated Agent MCP server started on port {self.settings.agent_mcp_port}")
+        except Exception as e:
+            logger.warning(f"Failed to start curated Agent MCP server: {e}")
+            self.agent_mcp = None
+
+        # ---- External MCP server manager ----
+        # Owns imported `mcpServers` entries (stdio/sse/http), holds one
+        # long-lived ClientSession per server, reconciles primitives into
+        # the tools store at boot and on restart.
+        self.state.external_mcp_manager = ExternalMCPManager(
+            tool_handler=FileHandler(get_tools_directory()),
+            file_handler=FileHandler(get_files_directory_path()),
+            config_handler=FileHandler(get_external_mcps_directory()),
+        )
+        set_current_manager(self.state.external_mcp_manager)
+
+        @self.on_event("startup")
+        async def _start_external_mcps() -> None:
+            try:
+                await self.state.external_mcp_manager.start_all()
+                logger.info("External MCP manager: start_all complete")
+            except Exception as e:
+                logger.error(f"External MCP manager failed to start: {e}", exc_info=True)
+
+        @self.on_event("shutdown")
+        async def _stop_external_mcps() -> None:
+            try:
+                await self.state.external_mcp_manager.stop_all()
+                logger.info("External MCP manager: stop_all complete")
+            except Exception as e:
+                logger.warning(f"External MCP manager shutdown issue: {e}")
 
     def configure_fastapi(self):
         """Configures CORS middleware and OpenAPI documentation settings."""

--- a/src/skillberry_store/fast_api/skill_export_utils.py
+++ b/src/skillberry_store/fast_api/skill_export_utils.py
@@ -1,0 +1,138 @@
+"""Shared helpers for assembling skill export payloads.
+
+Used by both the core Anthropic-zip exporter (skills_api.py) and the
+runspace plugin's agentic exporter.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, List, Tuple
+
+from fastapi import HTTPException
+
+from skillberry_store.modules.file_handler import FileHandler
+from skillberry_store.tools.configure import (
+    get_external_mcps_directory,
+    get_files_directory_path,
+    get_skills_directory,
+    get_snippets_directory,
+    get_tools_directory,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def get_skill_export_data(
+    name: str,
+) -> Tuple[
+    Dict[str, Any],
+    List[Dict[str, Any]],
+    List[Dict[str, Any]],
+    Dict[str, str],
+    List[Dict[str, Any]],
+]:
+    """Gather a skill's dict, tools, snippets, tool module source, and
+    external MCP server configs required by any tool in the skill.
+
+    Returns:
+        (skill_dict, tools, snippets, tool_modules, mcp_servers)
+        The `mcp_servers` list is the raw persisted config entries (secrets
+        intact) for every server referenced via `tool.mcp_dependencies` or
+        `tool.mcp_server`. The exporter is responsible for redacting before
+        bundling into a shareable ZIP.
+
+    Raises HTTPException(404) if the skill is missing; HTTPException(500)
+    for other failures.
+    """
+    skill_handler = FileHandler(get_skills_directory())
+    tools_handler = FileHandler(get_tools_directory())
+    snippets_handler = FileHandler(get_snippets_directory())
+    files_handler = FileHandler(get_files_directory_path())
+
+    skill_filename = f"{name}.json"
+    try:
+        content = skill_handler.read_file(skill_filename, raw_content=True)
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail=f"Skill '{name}' not found")
+    if not isinstance(content, str):
+        raise HTTPException(
+            status_code=500, detail=f"Invalid content type for skill '{name}'"
+        )
+    skill_dict = json.loads(content)
+
+    tools: List[Dict[str, Any]] = []
+    tool_modules: Dict[str, str] = {}
+    if skill_dict.get("tool_uuids"):
+        for tool_uuid in skill_dict["tool_uuids"]:
+            for filename in tools_handler.list_files():
+                if not filename.endswith(".json"):
+                    continue
+                try:
+                    tool_content = tools_handler.read_file(filename, raw_content=True)
+                    if not isinstance(tool_content, str):
+                        continue
+                    tool_dict = json.loads(tool_content)
+                    if tool_dict.get("uuid") != tool_uuid:
+                        continue
+                    tools.append(tool_dict)
+                    tool_name = tool_dict["name"]
+                    module_filename = tool_dict.get("module_name")
+                    if not module_filename:
+                        lang = tool_dict.get("programming_language", "python").lower()
+                        ext = ".py" if lang == "python" else ".sh"
+                        module_filename = f"{tool_name}{ext}"
+                    try:
+                        module_content = files_handler.read_file(
+                            module_filename, raw_content=True
+                        )
+                        if isinstance(module_content, str):
+                            tool_modules[tool_name] = module_content
+                    except Exception as e:
+                        logger.warning(
+                            f"Could not read module for tool {tool_name}: {e}"
+                        )
+                    break
+                except Exception as e:
+                    logger.warning(f"Error reading tool file {filename}: {e}")
+
+    snippets: List[Dict[str, Any]] = []
+    if skill_dict.get("snippet_uuids"):
+        for snippet_uuid in skill_dict["snippet_uuids"]:
+            for filename in snippets_handler.list_files():
+                if not filename.endswith(".json"):
+                    continue
+                try:
+                    snippet_content = snippets_handler.read_file(filename, raw_content=True)
+                    if not isinstance(snippet_content, str):
+                        continue
+                    snippet_dict = json.loads(snippet_content)
+                    if snippet_dict.get("uuid") == snippet_uuid:
+                        snippets.append(snippet_dict)
+                        break
+                except Exception as e:
+                    logger.warning(f"Error reading snippet file {filename}: {e}")
+
+    # Aggregate external-MCP configs referenced by any of the skill's tools.
+    required_mcp_names: set = set()
+    for t in tools:
+        if t.get("mcp_server"):
+            required_mcp_names.add(t["mcp_server"])
+        for dep_name in (t.get("mcp_dependencies") or []):
+            required_mcp_names.add(dep_name)
+    mcp_servers: List[Dict[str, Any]] = []
+    if required_mcp_names:
+        try:
+            mcps_handler = FileHandler(get_external_mcps_directory())
+            for server_name in sorted(required_mcp_names):
+                try:
+                    raw = mcps_handler.read_file(f"{server_name}.json", raw_content=True)
+                    if isinstance(raw, str):
+                        mcp_servers.append(json.loads(raw))
+                except Exception as e:
+                    logger.warning(f"Skipping MCP '{server_name}' in export (missing or unreadable): {e}")
+        except Exception as e:
+            logger.warning(f"Could not enumerate external MCPs for export: {e}")
+
+    return skill_dict, tools, snippets, tool_modules, mcp_servers

--- a/src/skillberry_store/fast_api/skills_api.py
+++ b/src/skillberry_store/fast_api/skills_api.py
@@ -2,10 +2,11 @@
 
 import json
 import logging
+import os
 import uuid
 from datetime import datetime, timezone
-from typing import Optional, Annotated
-from fastapi import FastAPI, HTTPException, Query, UploadFile, File, Form
+from typing import Any, Dict, List, Optional, Annotated
+from fastapi import Body, FastAPI, HTTPException, Query, Request, UploadFile, File, Form
 from fastapi.responses import Response
 from prometheus_client import Counter
 
@@ -21,6 +22,7 @@ from skillberry_store.tools.configure import (
     is_auto_detect_dependencies_enabled,
 )
 from skillberry_store.fast_api.search_filters import apply_search_filters
+from skillberry_store.fast_api.skill_export_utils import get_skill_export_data
 
 logger = logging.getLogger(__name__)
 
@@ -413,6 +415,7 @@ def register_skills_api(
 
     @app.post("/skills/import-anthropic", tags=[tags])
     async def import_anthropic_skill(
+        request: Request,
         source_type: str = Form(...),
         github_url: Optional[str] = Form(None),
         zip_file: Optional[UploadFile] = File(None),
@@ -456,8 +459,9 @@ def register_skills_api(
             else:
                 raise HTTPException(status_code=400, detail=f"Invalid source_type: {source_type}. Must be 'url', 'zip', or 'folder'")
             
-            # Import the skill
-            skill_name, skill_description, tools, snippets, ignored_files = import_anthropic_skill(
+            # Import the skill (6-tuple now — the last element is an optional
+            # external-MCP config payload bundled as `mcp-servers.json`).
+            skill_name, skill_description, tools, snippets, ignored_files, mcp_servers_payload = import_anthropic_skill(
                 source_type=source_type,
                 source_data=source_data,
                 snippet_mode=snippet_mode
@@ -578,8 +582,39 @@ def register_skills_api(
             if skills_descriptions and skill_description:
                 skills_descriptions.write_description(skill_name, skill_description)
             
+            # Auto-register any external MCP servers bundled with the skill.
+            # Duplicates (name already registered) are skipped — we never
+            # overwrite a live server's config on import.
+            mcp_results = []
+            if mcp_servers_payload:
+                try:
+                    from skillberry_store.modules.external_mcp_manager import normalize_mcp_input
+                    mgr = getattr(request.app.state, "external_mcp_manager", None)
+                    if mgr is None:
+                        logger.warning("Skill bundles an mcp-servers.json but the external MCP manager is not available.")
+                    else:
+                        try:
+                            entries = normalize_mcp_input(mcp_servers_payload)
+                        except ValueError as e:
+                            logger.warning(f"Skill mcp-servers.json could not be parsed: {e}")
+                            entries = []
+                        existing = {s["name"] for s in mgr.list_servers()}
+                        for entry in entries:
+                            name = entry.get("name")
+                            if name in existing:
+                                mcp_results.append({"name": name, "status": "skipped_duplicate"})
+                                continue
+                            try:
+                                res = await mgr.start(entry, persist=True)
+                                mcp_results.append(res)
+                            except Exception as e:  # noqa: BLE001
+                                logger.error(f"Failed to auto-register MCP '{name}' from skill: {e}")
+                                mcp_results.append({"name": name, "status": "error", "error": str(e)})
+                except Exception as e:
+                    logger.warning(f"mcp-servers.json auto-registration skipped: {e}")
+
             logger.info(f"Successfully imported Anthropic skill: {skill_name}")
-            
+
             return {
                 'success': True,
                 'message': f"Successfully imported Anthropic skill '{skill_name}'",
@@ -588,6 +623,7 @@ def register_skills_api(
                 'tools_created': len(created_tool_uuids),
                 'snippets_created': len(created_snippet_uuids),
                 'ignored_files': ignored_files,
+                'mcp_servers': mcp_results,
             }
             
         except HTTPException:
@@ -598,91 +634,141 @@ def register_skills_api(
                 status_code=500, detail=f"Error importing Anthropic skill: {str(e)}"
             )
 
+    def _get_skill_export_data(name: str):
+        """Gather skill dict, tools, snippets, and tool modules for export."""
+        return get_skill_export_data(name)
+
+    @app.post("/skills/{name}/bulk-add-tools-from-mcps", tags=[tags])
+    def bulk_add_tools_from_mcps(
+        name: str,
+        body: Dict[str, Any] = Body(
+            ...,
+            example={"mcps": ["context7"], "mode": "bundled_related"},
+        ),
+    ) -> Dict[str, Any]:
+        """Add tools to a skill in bulk based on which external MCP(s) they
+        touch.
+
+        Body fields:
+          - `mcps`: list of external MCP server names (required, non-empty)
+          - `mode`: one of
+              * `"primitives"`       — MCP primitives whose `mcp_server` is in `mcps`
+              * `"related"`          — primitives + every composite whose
+                `mcp_dependencies` intersects `mcps` (the transitive closure).
+                Ignores the `bundled_with_mcps` flag entirely.
+              * `"bundled_related"`  — same as `related`, but skips any tool
+                whose `bundled_with_mcps` is explicitly `False`. (If you want
+                those included, use `related` instead.)
+
+        Tools already in the skill are skipped. Broken tools are skipped and
+        reported in the response.
+
+        Returns: `{ skill, mode, requested_mcps, added, skipped_duplicate,
+        skipped_broken, skipped_unbundled }`.
+        """
+        mcps_in = body.get("mcps")
+        mode = (body.get("mode") or "").strip()
+        if not isinstance(mcps_in, list) or not mcps_in:
+            raise HTTPException(400, "`mcps` must be a non-empty list of server names.")
+        if mode not in ("primitives", "related", "bundled_related"):
+            raise HTTPException(
+                400,
+                "`mode` must be one of: primitives, related, bundled_related",
+            )
+        mcp_set = set(mcps_in)
+
+        skill_filename = f"{name}.json"
+        try:
+            skill_raw = skill_handler.read_file(skill_filename, raw_content=True)
+        except Exception:
+            raise HTTPException(404, f"Skill '{name}' not found.")
+        if not isinstance(skill_raw, str):
+            raise HTTPException(500, f"Invalid content for skill '{name}'")
+        skill_dict = json.loads(skill_raw)
+        existing_uuids = set(skill_dict.get("tool_uuids") or [])
+
+        added: List[Dict[str, str]] = []
+        skipped_duplicate: List[str] = []
+        skipped_broken: List[Dict[str, str]] = []
+        skipped_unbundled: List[str] = []
+
+        for fname in tools_handler.list_files():
+            if not fname.endswith(".json"):
+                continue
+            try:
+                d = json.loads(tools_handler.read_file(fname, raw_content=True))
+            except Exception:
+                continue
+
+            tool_mcp = d.get("mcp_server")
+            tool_deps = set(d.get("mcp_dependencies") or [])
+            touches_requested = (tool_mcp in mcp_set) or bool(tool_deps & mcp_set)
+            if not touches_requested:
+                continue
+
+            if mode == "primitives" and tool_mcp not in mcp_set:
+                continue  # composites excluded
+            if mode == "bundled_related" and d.get("bundled_with_mcps") is False:
+                skipped_unbundled.append(d.get("name") or fname[:-5])
+                continue
+            if d.get("state") == "broken":
+                skipped_broken.append({
+                    "name": d.get("name"),
+                    "reason": d.get("broken_reason") or "broken",
+                })
+                continue
+            if d.get("uuid") in existing_uuids:
+                skipped_duplicate.append(d.get("name") or fname[:-5])
+                continue
+
+            existing_uuids.add(d["uuid"])
+            added.append({"name": d["name"], "uuid": d["uuid"]})
+
+        if added:
+            skill_dict["tool_uuids"] = sorted(existing_uuids)
+            skill_dict["modified_at"] = datetime.now(timezone.utc).isoformat()
+            skill_handler.write_file_content(skill_filename, json.dumps(skill_dict, indent=4))
+
+        return {
+            "skill": name,
+            "mode": mode,
+            "requested_mcps": sorted(mcp_set),
+            "added": added,
+            "skipped_duplicate": skipped_duplicate,
+            "skipped_broken": skipped_broken,
+            "skipped_unbundled": skipped_unbundled,
+        }
+
     @app.get("/skills/{name}/export-anthropic", tags=[tags])
     async def export_anthropic_skill(name: str):
         """Export a skill to Anthropic format as a ZIP file.
-        
+
         Args:
             name: The name of the skill to export
-            
+
         Returns:
             ZIP file with the skill in Anthropic format
-            
+
         Raises:
             HTTPException: If skill not found or export fails
         """
         logger.info(f"Request to export skill to Anthropic format: {name}")
-        
+
         try:
             from skillberry_store.tools.anthropic.exporter import export_skill_to_anthropic_format
-            
-            # Get skill
-            skill_filename = f"{name}.json"
-            content = skill_handler.read_file(skill_filename, raw_content=True)
-            if not isinstance(content, str):
-                raise HTTPException(
-                    status_code=500, detail=f"Invalid content type for skill '{name}'"
-                )
-            skill_dict = json.loads(content)
-            
-            # Get tools
-            tools = []
-            tool_modules = {}
-            if 'tool_uuids' in skill_dict and skill_dict['tool_uuids']:
-                for tool_uuid in skill_dict['tool_uuids']:
-                    for filename in tools_handler.list_files():
-                        if filename.endswith('.json'):
-                            try:
-                                tool_content = tools_handler.read_file(filename, raw_content=True)
-                                if isinstance(tool_content, str):
-                                    tool_dict = json.loads(tool_content)
-                                    if tool_dict.get('uuid') == tool_uuid:
-                                        tools.append(tool_dict)
-                                        # Get tool module
-                                        tool_name = tool_dict['name']
-                                        lang = tool_dict.get('programming_language', 'python').lower()
-                                        ext = '.py' if lang == 'python' else '.sh'
-                                        module_filename = f"{tool_name}{ext}"
-                                        try:
-                                            from skillberry_store.tools.configure import get_files_directory_path
-                                            from skillberry_store.modules.file_handler import FileHandler
-                                            files_handler = FileHandler(get_files_directory_path())
-                                            module_content = files_handler.read_file(module_filename, raw_content=True)
-                                            if isinstance(module_content, str):
-                                                tool_modules[tool_name] = module_content
-                                        except Exception as e:
-                                            logger.warning(f"Could not read module for tool {tool_name}: {e}")
-                                        break
-                            except Exception as e:
-                                logger.warning(f"Error reading tool file {filename}: {e}")
-            
-            # Get snippets
-            snippets = []
-            if 'snippet_uuids' in skill_dict and skill_dict['snippet_uuids']:
-                for snippet_uuid in skill_dict['snippet_uuids']:
-                    for filename in snippets_handler.list_files():
-                        if filename.endswith('.json'):
-                            try:
-                                snippet_content = snippets_handler.read_file(filename, raw_content=True)
-                                if isinstance(snippet_content, str):
-                                    snippet_dict = json.loads(snippet_content)
-                                    if snippet_dict.get('uuid') == snippet_uuid:
-                                        snippets.append(snippet_dict)
-                                        break
-                            except Exception as e:
-                                logger.warning(f"Error reading snippet file {filename}: {e}")
-            
-            # Export to Anthropic format
+
+            skill_dict, tools, snippets, tool_modules, mcp_servers = _get_skill_export_data(name)
+
             zip_content = export_skill_to_anthropic_format(
                 skill=skill_dict,
                 tools=tools,
                 snippets=snippets,
-                tool_modules=tool_modules
+                tool_modules=tool_modules,
+                mcp_servers=mcp_servers,
             )
-            
+
             logger.info(f"Successfully exported skill '{name}' to Anthropic format")
-            
-            # Return as downloadable ZIP file
+
             return Response(
                 content=zip_content,
                 media_type='application/zip',
@@ -690,7 +776,7 @@ def register_skills_api(
                     'Content-Disposition': f'attachment; filename="{name}.zip"'
                 }
             )
-            
+
         except HTTPException:
             raise
         except Exception as e:
@@ -698,3 +784,4 @@ def register_skills_api(
             raise HTTPException(
                 status_code=500, detail=f"Error exporting skill: {str(e)}"
             )
+

--- a/src/skillberry_store/fast_api/skills_api.py
+++ b/src/skillberry_store/fast_api/skills_api.py
@@ -23,6 +23,7 @@ from skillberry_store.tools.configure import (
 )
 from skillberry_store.fast_api.search_filters import apply_search_filters
 from skillberry_store.fast_api.skill_export_utils import get_skill_export_data
+from skillberry_store.schemas.name_validation import validate_store_name
 
 logger = logging.getLogger(__name__)
 
@@ -128,6 +129,10 @@ def register_skills_api(
         """
         logger.info(f"Request to create skill: {skill.name}")
         create_skill_counter.inc()
+
+        # Validate the skill name as an MCP-safe slug — spaces / uppercase
+        # would break `claude mcp add <name>` and URL-segment usage.
+        validate_store_name(skill.name, kind="skill")
 
         # Generate UUID if not provided
         if not skill.uuid:

--- a/src/skillberry_store/fast_api/tools_api.py
+++ b/src/skillberry_store/fast_api/tools_api.py
@@ -461,7 +461,17 @@ def register_tools_api(
 
             # Handle MCP packaging format
             if tool_dict.get("packaging_format") == "mcp":
-                # Generate content from MCP tool
+                # New External-MCP primitives (mcp_server set) already carry
+                # the full params in the manifest — build the stub locally,
+                # no SSE round-trip. This also works when the upstream MCP is
+                # down.
+                if tool_dict.get("mcp_server"):
+                    return PlainTextResponse(
+                        content=mcp_content_from_manifest(tool_dict),
+                        media_type="text/plain",
+                    )
+                # Legacy single-tool MCP entries (mcp_url set, no mcp_server)
+                # still fetch live since their params may be stale.
                 tools = await get_mcp_tools(tool_dict)
                 if not tools:
                     raise HTTPException(

--- a/src/skillberry_store/fast_api/tools_api.py
+++ b/src/skillberry_store/fast_api/tools_api.py
@@ -14,9 +14,18 @@ from prometheus_client import Counter, Histogram
 import time
 
 from skillberry_store.modules.file_handler import FileHandler
-from skillberry_store.modules.file_executor import FileExecutor, detect_tool_dependencies
+from skillberry_store.modules.file_executor import (
+    FileExecutor,
+    compute_dependency_hashes,
+    compute_mcp_dependencies,
+    detect_tool_dependencies,
+)
 from skillberry_store.modules.description import Description
 from skillberry_store.modules.lifecycle import LifecycleState
+from skillberry_store.modules.tool_health import (
+    check_all_tools_health,
+    find_dependents,
+)
 from skillberry_store.schemas.tool_schema import ToolSchema, ToolParamsSchema, ToolReturnsSchema
 from skillberry_store.schemas.manifest_schema import ManifestState
 from skillberry_store.tools.configure import (
@@ -138,6 +147,9 @@ delete_tool_counter = Counter(
 update_tool_counter = Counter(
     f"{prom_prefix}update_tool_counter", "Count number of tool update operations"
 )
+update_tool_module_counter = Counter(
+    f"{prom_prefix}update_tool_module_counter", "Count number of tool module update operations"
+)
 execute_tool_counter = Counter(
     f"{prom_prefix}execute_tool_counter",
     "Count number of tool execute operations",
@@ -177,6 +189,60 @@ def register_tools_api(
     # File handler for storing tool module files
     files_directory = get_files_directory_path()
     file_handler = FileHandler(files_directory)
+
+    # ----- Dependent-safe guard + health-pass helpers ----------------------
+    def _assert_no_dependents(tool_name: str) -> None:
+        """Refuse interface-changing mutations if other tools depend on this one."""
+        dependents = find_dependents(tool_name, tool_handler)
+        if dependents:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "error": "tool_has_dependents",
+                    "tool": tool_name,
+                    "dependents": dependents,
+                    "suggestion": (
+                        f"Tool '{tool_name}' is used by the listed tools. "
+                        "Changing or deleting it would break them. Create a "
+                        "new tool with a different name, or remove/update "
+                        "the dependents first."
+                    ),
+                },
+            )
+
+    def _run_health_pass_safely() -> None:
+        try:
+            check_all_tools_health(tool_handler, file_handler)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("Post-mutation health pass failed: %s", e)
+
+    def _load_all_tool_dicts() -> Dict[str, Dict[str, Any]]:
+        out: Dict[str, Dict[str, Any]] = {}
+        for fname in tool_handler.list_files():
+            if not fname.endswith(".json"):
+                continue
+            try:
+                d = json.loads(tool_handler.read_file(fname, raw_content=True))
+            except Exception:
+                continue
+            n = d.get("name")
+            if n:
+                out[n] = d
+        return out
+
+    def _collect_module_sources(tool_dicts: Dict[str, Dict[str, Any]]) -> Dict[str, str]:
+        out: Dict[str, str] = {}
+        for n, d in tool_dicts.items():
+            mod = d.get("module_name")
+            if mod:
+                try:
+                    src = file_handler.read_file(mod, raw_content=True)
+                    out[n] = src if isinstance(src, str) else ""
+                except Exception:
+                    out[n] = ""
+            else:
+                out[n] = ""
+        return out
 
     @app.post("/tools/", tags=[tags])
     async def create_tool(
@@ -246,9 +312,33 @@ def register_tools_api(
                 except Exception as e:
                     logger.warning(f"Failed to auto-detect dependencies: {e}")
 
+            # Populate mcp_dependencies (union across deps) + dependency_hashes
+            # so the universal health pass can detect drift against this tool.
+            try:
+                all_tool_dicts = _load_all_tool_dicts()
+                tool_as_dict = tool.to_dict()
+                tool.mcp_dependencies = compute_mcp_dependencies(
+                    tool_as_dict, all_tool_dicts
+                )
+                module_sources = _collect_module_sources(all_tool_dicts)
+                tool.dependency_hashes = compute_dependency_hashes(
+                    tool_as_dict, all_tool_dicts, module_sources
+                )
+                # Default bundled_with_mcps=True for tools that touch MCPs
+                # (either via mcp_server or via transitive mcp_dependencies).
+                if tool.bundled_with_mcps is None and (
+                    tool.mcp_server or tool.mcp_dependencies
+                ):
+                    tool.bundled_with_mcps = True
+            except Exception as e:
+                logger.warning(f"Failed to compute mcp/dependency hashes for '{tool.name}': {e}")
+
             # Convert tool to JSON and save
             tool_json = json.dumps(tool.to_dict(), indent=4)
             tool_handler.write_file_content(tool_filename, tool_json)
+
+            # Run health pass best-effort to catch drift surfaces.
+            _run_health_pass_safely()
 
             # Write description for search capability
             if tools_descriptions and tool.description:
@@ -420,6 +510,9 @@ def register_tools_api(
         logger.info(f"Request to delete tool: {name}")
         delete_tool_counter.inc()
 
+        # Dependent-safe guard — refuse if any other tool depends on this one.
+        _assert_no_dependents(name)
+
         try:
             tool_filename = f"{name}.json"
 
@@ -456,6 +549,7 @@ def register_tools_api(
                     )
 
             logger.info(f"Tool '{name}' deleted successfully")
+            _run_health_pass_safely()
             return {"message": f"Tool '{name}' deleted successfully."}
         except HTTPException as e:
             # Re-raise HTTPException (like 404) without modification
@@ -465,6 +559,37 @@ def register_tools_api(
             raise HTTPException(
                 status_code=500, detail=f"Error deleting tool: {str(e)}"
             )
+
+    @app.put("/tools/{name}/bundled-with-mcps", tags=[tags])
+    def set_tool_bundled_with_mcps(name: str, value: bool) -> Dict:
+        """Toggle whether this tool is included by default when skills are
+        built from its MCP server(s). Only meaningful for tools with mcp_server
+        set or mcp_dependencies non-empty; persisted on the manifest.
+        """
+        tool_filename = f"{name}.json"
+        try:
+            content = tool_handler.read_file(tool_filename, raw_content=True)
+        except Exception:
+            raise HTTPException(status_code=404, detail=f"Tool '{name}' not found.")
+        if not isinstance(content, str):
+            raise HTTPException(status_code=500, detail=f"Invalid content for tool '{name}'")
+        tool_dict = json.loads(content)
+        if not (tool_dict.get("mcp_server") or tool_dict.get("mcp_dependencies")):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Tool '{name}' has no MCP association — the bundled_with_mcps "
+                    "flag is only meaningful for MCP primitives and composites that "
+                    "depend on MCPs."
+                ),
+            )
+        tool_dict["bundled_with_mcps"] = bool(value)
+        tool_dict["modified_at"] = datetime.now(timezone.utc).isoformat()
+        tool_handler.write_file_content(tool_filename, json.dumps(tool_dict, indent=4))
+        return {
+            "name": name,
+            "bundled_with_mcps": tool_dict["bundled_with_mcps"],
+        }
 
     @app.put("/tools/{name}", tags=[tags])
     def update_tool(name: str, tool: ToolSchema) -> Dict:
@@ -486,18 +611,68 @@ def register_tools_api(
         try:
             tool_filename = f"{name}.json"
 
-            # Check if tool exists
+            # Check if tool exists and get old description for vector DB sync
             existing_tools = tool_handler.list_files()
             if tool_filename not in existing_tools:
                 raise HTTPException(status_code=404, detail=f"Tool '{name}' not found.")
 
+            old_content = tool_handler.read_file(tool_filename, raw_content=True)
+            old_description = None
+            old_dict: Dict[str, Any] = {}
+            if isinstance(old_content, str):
+                old_dict = json.loads(old_content)
+                old_description = old_dict.get("description")
+
+            # Dependent-safe guard: refuse the update if the interface changed
+            # (params / module_name / dependencies) and other tools rely on it.
+            interface_changed = (
+                (old_dict.get("params") or {}) != tool.params.model_dump()
+                or (old_dict.get("module_name") or None) != tool.module_name
+                or (old_dict.get("dependencies") or []) != (tool.dependencies or [])
+            )
+            if interface_changed:
+                _assert_no_dependents(name)
+
             # Update modified timestamp
             tool.modified_at = datetime.now(timezone.utc).isoformat()
+
+            # Recompute mcp_dependencies + dependency_hashes from current store.
+            try:
+                all_tool_dicts = _load_all_tool_dicts()
+                tool_as_dict = tool.to_dict()
+                tool.mcp_dependencies = compute_mcp_dependencies(
+                    tool_as_dict, all_tool_dicts
+                )
+                module_sources = _collect_module_sources(all_tool_dicts)
+                tool.dependency_hashes = compute_dependency_hashes(
+                    tool_as_dict, all_tool_dicts, module_sources
+                )
+                # Preserve explicit bundled_with_mcps choice across updates.
+                # Only set a default when the tool now touches an MCP for the
+                # first time (field was unset previously).
+                if tool.bundled_with_mcps is None and (
+                    tool.mcp_server or tool.mcp_dependencies
+                ):
+                    tool.bundled_with_mcps = old_dict.get("bundled_with_mcps", True)
+            except Exception as e:
+                logger.warning(f"Failed to refresh mcp/dependency hashes for '{name}': {e}")
 
             # Update the tool
             tool_json = json.dumps(tool.to_dict(), indent=4)
             tool_handler.write_file_content(tool_filename, tool_json)
+
+            # Sync vector DB description if changed
+            if tools_descriptions and tool.description and tool.description != old_description:
+                try:
+                    tools_descriptions.update_description(name, tool.description)
+                except Exception:
+                    try:
+                        tools_descriptions.write_description(name, tool.description)
+                    except Exception as desc_err:
+                        logger.warning(f"Failed to sync description for '{name}': {desc_err}")
+
             logger.info(f"Tool '{name}' updated successfully")
+            _run_health_pass_safely()
             return {"message": f"Tool '{name}' updated successfully."}
         except HTTPException:
             raise
@@ -505,6 +680,91 @@ def register_tools_api(
             logger.error(f"Error updating tool '{name}': {e}")
             raise HTTPException(
                 status_code=500, detail=f"Error updating tool: {str(e)}"
+            )
+
+    class UpdateModuleRequest(BaseModel):
+        content: str
+
+    @app.put("/tools/{name}/module", tags=[tags])
+    def update_tool_module(name: str, request: UpdateModuleRequest) -> Dict:
+        """Update the source code module for a tool.
+
+        Args:
+            name: The name of the tool.
+            request: JSON body with 'content' field containing the new source code.
+
+        Returns:
+            dict: Success message.
+
+        Raises:
+            HTTPException: If tool not found (404), tool has no module (400),
+                          tool is MCP-packaged (400), or update fails (500).
+        """
+        logger.info(f"Request to update module for tool: {name}")
+        update_tool_module_counter.inc()
+
+        try:
+            tool_filename = f"{name}.json"
+            existing_tools = tool_handler.list_files()
+            if tool_filename not in existing_tools:
+                raise HTTPException(status_code=404, detail=f"Tool '{name}' not found.")
+
+            content = tool_handler.read_file(tool_filename, raw_content=True)
+            if not isinstance(content, str):
+                raise HTTPException(status_code=500, detail=f"Invalid content for tool '{name}'")
+            tool_dict = json.loads(content)
+
+            if tool_dict.get("packaging_format") == "mcp":
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Cannot update module for MCP-packaged tool '{name}'",
+                )
+
+            module_name = tool_dict.get("module_name")
+            if not module_name:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Tool '{name}' does not have a module file",
+                )
+
+            # Module swap ≡ behavior change: refuse if anything depends on this tool.
+            _assert_no_dependents(name)
+
+            file_handler.write_file_content(module_name, request.content)
+
+            # Refresh dependency hashes for THIS tool (its deps may need a fresh
+            # snapshot so future drift detection is relative to this moment).
+            try:
+                all_tool_dicts = _load_all_tool_dicts()
+                module_sources = _collect_module_sources(all_tool_dicts)
+                tool_dict["dependency_hashes"] = compute_dependency_hashes(
+                    tool_dict, all_tool_dicts, module_sources
+                )
+                tool_dict["mcp_dependencies"] = compute_mcp_dependencies(
+                    tool_dict, all_tool_dicts
+                )
+                # Default bundled_with_mcps only if the tool now touches an MCP
+                # and the field has never been set explicitly.
+                if tool_dict.get("bundled_with_mcps") is None and (
+                    tool_dict.get("mcp_server") or tool_dict.get("mcp_dependencies")
+                ):
+                    tool_dict["bundled_with_mcps"] = True
+            except Exception as e:
+                logger.warning(f"Failed to refresh hashes for '{name}': {e}")
+
+            # Update modified_at on the manifest
+            tool_dict["modified_at"] = datetime.now(timezone.utc).isoformat()
+            tool_handler.write_file_content(tool_filename, json.dumps(tool_dict, indent=4))
+
+            logger.info(f"Module for tool '{name}' updated successfully")
+            _run_health_pass_safely()
+            return {"message": f"Module for tool '{name}' updated successfully."}
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.error(f"Error updating module for tool '{name}': {e}")
+            raise HTTPException(
+                status_code=500, detail=f"Error updating module: {str(e)}"
             )
 
     @app.post("/tools/{name}/execute", tags=[tags])
@@ -862,10 +1122,28 @@ def register_tools_api(
                 modified_at=current_time
             )
 
+            # Populate mcp_dependencies + dependency_hashes so the health pass
+            # can detect drift against this tool's deps.
+            try:
+                all_tool_dicts = _load_all_tool_dicts()
+                tool_as_dict = tool_schema.to_dict()
+                tool_schema.mcp_dependencies = compute_mcp_dependencies(
+                    tool_as_dict, all_tool_dicts
+                )
+                module_sources = _collect_module_sources(all_tool_dicts)
+                tool_schema.dependency_hashes = compute_dependency_hashes(
+                    tool_as_dict, all_tool_dicts, module_sources
+                )
+                if tool_schema.bundled_with_mcps is None and tool_schema.mcp_dependencies:
+                    tool_schema.bundled_with_mcps = True
+            except Exception as e:
+                logger.warning(f"Failed to compute hashes for '{func_name}': {e}")
+
             # Save the manifest
             tool_json = json.dumps(tool_schema.to_dict(), indent=4)
             tool_handler.write_file_content(tool_filename, tool_json)
             logger.info(f"Saved manifest: {tool_filename}")
+            _run_health_pass_safely()
 
             # Write description for search capability
             if tools_descriptions:

--- a/src/skillberry_store/fast_api/vmcp_api.py
+++ b/src/skillberry_store/fast_api/vmcp_api.py
@@ -102,6 +102,11 @@ def register_vmcp_api(
         logger.info(f"Request to create vmcp server: {vmcp.name}")
         create_vmcp_counter.inc()
 
+        # Validate slug — VMCP names are used as `claude mcp add <name>` args
+        # and URL segments so they must match the Anthropic skill format.
+        from skillberry_store.schemas.name_validation import validate_store_name
+        validate_store_name(vmcp.name, kind="VMCP server")
+
         # Generate UUID if not provided
         if not vmcp.uuid:
             vmcp.uuid = str(uuid.uuid4())

--- a/src/skillberry_store/main.py
+++ b/src/skillberry_store/main.py
@@ -68,10 +68,22 @@ def main():
         if not ui_started:
             print("Warning: Failed to start UI server. Backend will run without UI.")
 
+    host = server.settings.display_host
+    port = server.settings.sbs_port
+    agent_mcp_port = server.settings.agent_mcp_port
+    agent_mcp_url = f"http://{host}:{agent_mcp_port}/sse"
+
     print(f"\n{'='*60}")
     if ui_started:
-        print(f"  Skillberry Store UI: http://{server.settings.display_host}:{ui_manager.ui_port}")
-    print(f"  Backend API: http://{server.settings.display_host}:{server.settings.sbs_port}/docs")
+        print(f"  Skillberry Store UI: http://{host}:{ui_manager.ui_port}")
+    print(f"  Backend API: http://{host}:{port}/docs")
+    if hasattr(server, 'agent_mcp') and server.agent_mcp is not None:
+        print(f"  Store MCP:   {agent_mcp_url}")
+        print(f"")
+        print(f"  Connect Claude Code to the Store MCP:")
+        print(f"    claude mcp add skillberry-store -s user -t sse {agent_mcp_url}")
+        print(f"  Remove:")
+        print(f"    claude mcp remove skillberry-store -s user")
     print(f"{'='*60}\n")
     sys.stdout.flush()
 

--- a/src/skillberry_store/modules/external_mcp_manager.py
+++ b/src/skillberry_store/modules/external_mcp_manager.py
@@ -1,0 +1,698 @@
+"""
+External MCP server import — manager, transports, reconciliation.
+
+Maintains one long-lived `ClientSession` per imported external MCP server
+(stdio / sse / streamable-http), reconciles exposed tools into the store as
+`packaging_format="mcp"` primitives, and proxies tool calls over the pooled
+session.
+
+The legacy single-tool MCP path (tools with `packaging_format="mcp"` +
+`mcp_url` but no `mcp_server`) is NOT routed here — it stays on the existing
+transient-SSE path in `file_executor.py` for back-compat.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import uuid
+import urllib.request
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable, Dict, List, Optional
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.sse import sse_client
+from mcp.client.stdio import stdio_client
+from mcp.client.streamable_http import streamablehttp_client
+
+from skillberry_store.modules.file_handler import FileHandler
+from skillberry_store.tools.configure import get_external_mcps_directory
+
+logger = logging.getLogger(__name__)
+
+_VALID_TRANSPORTS = ("stdio", "sse", "http")
+
+# Module-level reference to the active manager. Set during FastAPI startup by
+# server.py so FileExecutor can reach it without threading a dependency through
+# every constructor.
+_current_manager: Optional["ExternalMCPManager"] = None
+
+
+def set_current_manager(manager: Optional["ExternalMCPManager"]) -> None:
+    global _current_manager
+    _current_manager = manager
+
+
+def get_current_manager() -> Optional["ExternalMCPManager"]:
+    return _current_manager
+
+
+# ---------------------------------------------------------------------------
+# Input normalization — accepts five wire shapes, returns list[entry].
+# ---------------------------------------------------------------------------
+
+def _default_fetch_url(url: str) -> Any:
+    """Default URL fetcher for the `source_url` input shape."""
+    with urllib.request.urlopen(url, timeout=15) as resp:
+        return json.loads(resp.read())
+
+
+def normalize_mcp_input(
+    data: Any,
+    fetch_url: Optional[Callable[[str], Any]] = None,
+) -> List[Dict[str, Any]]:
+    """
+    Collapse any of the supported config shapes into a normalized list of
+    server entries.
+
+    Accepted shapes:
+      (1) {"mcpServers": {name: entry, ...}}
+      (2) {name: entry, ...}                        # bare dict
+      (3) [entry_with_name, ...]                    # list form
+      (4) {"name": "...", "type"|"transport": ...}  # single entry
+      (5) {"source_url": "https://..."}             # fetch + recurse
+    """
+    fetch_url = fetch_url or _default_fetch_url
+
+    if isinstance(data, dict) and set(data.keys()) == {"source_url"}:
+        fetched = fetch_url(data["source_url"])
+        return normalize_mcp_input(fetched, fetch_url=fetch_url)
+
+    if isinstance(data, dict) and isinstance(data.get("mcpServers"), dict):
+        return [_normalize_entry(name, entry) for name, entry in data["mcpServers"].items()]
+
+    if isinstance(data, list):
+        out: List[Dict[str, Any]] = []
+        for entry in data:
+            if not isinstance(entry, dict) or "name" not in entry:
+                raise ValueError("list-form entries must each have a 'name' field")
+            out.append(_normalize_entry(entry["name"], entry))
+        return out
+
+    if isinstance(data, dict):
+        if "name" in data and any(k in data for k in ("type", "transport", "command", "url")):
+            return [_normalize_entry(data["name"], data)]
+        if data and all(isinstance(v, dict) for v in data.values()):
+            return [_normalize_entry(name, entry) for name, entry in data.items()]
+
+    raise ValueError("unrecognized mcp-servers input shape")
+
+
+def _normalize_entry(name: str, raw: Dict[str, Any]) -> Dict[str, Any]:
+    transport = raw.get("transport") or raw.get("type")
+    if transport is None:
+        if raw.get("command"):
+            transport = "stdio"
+        elif raw.get("url"):
+            transport = "sse"
+        else:
+            raise ValueError(f"entry '{name}': cannot infer transport")
+
+    if transport not in _VALID_TRANSPORTS:
+        raise ValueError(f"entry '{name}': unknown transport '{transport}'")
+
+    entry: Dict[str, Any] = {
+        "name": name,
+        "transport": transport,
+        "command": raw.get("command"),
+        "args": list(raw.get("args") or []),
+        "env": dict(raw.get("env") or {}),
+        "url": raw.get("url"),
+        "headers": dict(raw.get("headers") or {}),
+        "enabled": bool(raw.get("enabled", True)),
+    }
+
+    if transport == "stdio":
+        if not entry["command"]:
+            raise ValueError(f"entry '{name}': stdio transport requires 'command'")
+    else:
+        if not entry["url"]:
+            raise ValueError(f"entry '{name}': {transport} transport requires 'url'")
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# Helpers — params conversion, manifest building, secret redaction.
+# ---------------------------------------------------------------------------
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def params_from_input_schema(schema: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """
+    Convert an MCP tool's JSON-Schema inputSchema into the store's params
+    shape (`ToolParamsSchema`).
+    """
+    if not schema:
+        return {"type": "object", "properties": {}, "required": [], "optional": []}
+    properties = schema.get("properties") or {}
+    required = list(schema.get("required") or [])
+    return {
+        "type": schema.get("type", "object"),
+        "properties": properties,
+        "required": required,
+        "optional": [k for k in properties.keys() if k not in required],
+    }
+
+
+def build_primitive_manifest(
+    prefixed_name: str,
+    server_name: str,
+    remote_description: str,
+    remote_params: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Create a fresh manifest for a tool imported from an external MCP server.
+
+    Primitives have `mcp_server` set (the source they were imported from) but
+    an empty `mcp_dependencies` list — the latter is reserved for composites
+    that aggregate dependencies across their children. When the health pass
+    and `compute_mcp_dependencies` walk a primitive, they always pull in the
+    `mcp_server` value, so no information is lost.
+    """
+    now = _now_iso()
+    return {
+        "name": prefixed_name,
+        "uuid": str(uuid.uuid4()),
+        "version": "1.0.0",
+        "description": remote_description or "",
+        "state": "approved",
+        "tags": [f"mcp:{server_name}"],
+        "extra": {},
+        "created_at": now,
+        "modified_at": now,
+        "module_name": None,
+        "programming_language": "python",
+        "packaging_format": "mcp",
+        "params": remote_params,
+        "returns": None,
+        "dependencies": None,
+        "mcp_url": None,
+        "mcp_server": server_name,
+        "mcp_dependencies": [],
+        "dependency_hashes": {},
+        "broken_reason": None,
+        "bundled_with_mcps": True,
+    }
+
+
+_SECRET_HEADER_HINTS = ("key", "token", "auth", "secret", "password", "bearer")
+
+
+def redact_entry(entry: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a copy of entry with header values and env values masked."""
+    masked = dict(entry)
+    masked["headers"] = {k: _mask(v) for k, v in (entry.get("headers") or {}).items()}
+    masked["env"] = {k: _mask(v) for k, v in (entry.get("env") or {}).items()}
+    return masked
+
+
+def _mask(value: Any) -> str:
+    if not isinstance(value, str) or not value:
+        return "•••"
+    return value[:2] + "•" * max(4, len(value) - 4) + value[-2:]
+
+
+# ---------------------------------------------------------------------------
+# _ServerRunner — holds one session inside a long-lived task.
+# ---------------------------------------------------------------------------
+
+class _ServerRunner:
+    """
+    Owns the session for a single server.
+
+    A background task enters the transport + ClientSession context managers
+    and then awaits a shutdown event. All MCP calls run from arbitrary caller
+    tasks against `self.session`; the runner only coordinates lifecycle.
+    """
+
+    def __init__(self, entry: Dict[str, Any]):
+        self.entry = entry
+        self.name = entry["name"]
+        self.session: Optional[ClientSession] = None
+        self.status: str = "stopped"
+        self.last_error: Optional[str] = None
+        self._ready = asyncio.Event()
+        self._shutdown = asyncio.Event()
+        self._task: Optional[asyncio.Task] = None
+        self._call_lock = asyncio.Lock()
+
+    async def start(self, startup_timeout: float = 30.0) -> None:
+        self._ready.clear()
+        self._shutdown.clear()
+        self.last_error = None
+        self.status = "starting"
+        self._task = asyncio.create_task(self._run(), name=f"ext-mcp-{self.name}")
+        try:
+            await asyncio.wait_for(self._ready.wait(), timeout=startup_timeout)
+        except asyncio.TimeoutError:
+            self.status = "error"
+            self.last_error = f"startup timeout after {startup_timeout}s"
+            self._shutdown.set()
+            raise RuntimeError(self.last_error)
+        if self.status == "error":
+            raise RuntimeError(f"failed to start {self.name}: {self.last_error}")
+
+    async def stop(self, stop_timeout: float = 10.0) -> None:
+        self._shutdown.set()
+        task = self._task
+        if task is not None:
+            try:
+                await asyncio.wait_for(task, timeout=stop_timeout)
+            except asyncio.TimeoutError:
+                logger.warning("External MCP %s did not stop within %.1fs; cancelling", self.name, stop_timeout)
+                task.cancel()
+                try:
+                    await task
+                except (asyncio.CancelledError, Exception):
+                    pass
+        self._task = None
+        self.session = None
+        if self.status != "error":
+            self.status = "stopped"
+
+    async def _run(self) -> None:
+        try:
+            t = self.entry["transport"]
+            if t == "stdio":
+                params = StdioServerParameters(
+                    command=self.entry["command"],
+                    args=list(self.entry.get("args") or []),
+                    env=self.entry.get("env") or None,
+                )
+                async with stdio_client(params) as (read, write):
+                    await self._run_session(read, write)
+            elif t == "sse":
+                async with sse_client(
+                    self.entry["url"],
+                    headers=self.entry.get("headers") or None,
+                ) as (read, write):
+                    await self._run_session(read, write)
+            elif t == "http":
+                async with streamablehttp_client(
+                    self.entry["url"],
+                    headers=self.entry.get("headers") or None,
+                ) as (read, write, _):
+                    await self._run_session(read, write)
+            else:
+                raise ValueError(f"unknown transport: {t}")
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            self.status = "error"
+            self.last_error = str(e)
+            self._ready.set()
+            logger.error("External MCP %s failed: %s", self.name, e, exc_info=True)
+
+    async def _run_session(self, read, write) -> None:
+        async with ClientSession(read, write) as session:
+            await asyncio.wait_for(session.initialize(), timeout=15.0)
+            self.session = session
+            self.status = "running"
+            self._ready.set()
+            try:
+                await self._shutdown.wait()
+            finally:
+                self.session = None
+
+    async def list_remote_tools(self) -> List[Any]:
+        if self.status != "running" or self.session is None:
+            raise RuntimeError(f"server {self.name} is not running (status={self.status})")
+        result = await asyncio.wait_for(self.session.list_tools(), timeout=15.0)
+        return list(result.tools or [])
+
+    async def call_tool(
+        self,
+        remote_tool_name: str,
+        args: Optional[Dict[str, Any]],
+        timeout: float = 30.0,
+    ) -> str:
+        if self.status != "running" or self.session is None:
+            raise RuntimeError(f"server {self.name} is not running (status={self.status})")
+        async with self._call_lock:
+            result = await asyncio.wait_for(
+                self.session.call_tool(remote_tool_name, arguments=args or {}),
+                timeout=timeout,
+            )
+        content = result.content or []
+        if not content:
+            return ""
+        first = content[0]
+        return getattr(first, "text", str(first))
+
+
+# ---------------------------------------------------------------------------
+# ExternalMCPManager — orchestration layer.
+# ---------------------------------------------------------------------------
+
+class ExternalMCPManager:
+    """
+    Lifecycle and call-site for every imported external MCP server.
+
+    Stored on `app.state.external_mcp_manager`; constructed with the tool and
+    module FileHandlers so it can write primitive manifests directly.
+    """
+
+    def __init__(
+        self,
+        tool_handler: FileHandler,
+        file_handler: FileHandler,
+        config_handler: Optional[FileHandler] = None,
+    ):
+        self._tool_handler = tool_handler
+        self._file_handler = file_handler
+        self._config_handler = config_handler or FileHandler(get_external_mcps_directory())
+        self._runners: Dict[str, _ServerRunner] = {}
+        self._lock = asyncio.Lock()
+
+    # ----- Lifecycle ---------------------------------------------------------
+
+    async def start_all(self) -> None:
+        for fname in self._config_handler.list_files():
+            if not fname.endswith(".json"):
+                continue
+            try:
+                entry = self._read_config(fname)
+            except Exception as e:
+                logger.error("Failed to read external MCP config %s: %s", fname, e)
+                continue
+            if not entry or not entry.get("enabled", True):
+                continue
+            try:
+                await self.start(entry, persist=False)
+            except Exception as e:
+                logger.error("Failed to auto-start external MCP %s: %s", entry.get("name"), e)
+        # Boot-time drift sweep — any composite whose dep changed while the
+        # store was offline gets flagged now. Also unbreaks things that
+        # now match again.
+        self._run_health_pass()
+
+    async def stop_all(self) -> None:
+        async with self._lock:
+            names = list(self._runners.keys())
+            for name in names:
+                try:
+                    await self._runners[name].stop()
+                except Exception as e:
+                    logger.warning("Error stopping external MCP %s: %s", name, e)
+            self._runners.clear()
+
+    async def start(self, entry: Dict[str, Any], persist: bool = True) -> Dict[str, Any]:
+        """Start or restart a server; reconcile its primitives on success."""
+        name = entry["name"]
+        async with self._lock:
+            if name in self._runners:
+                try:
+                    await self._runners[name].stop()
+                except Exception:
+                    pass
+                self._runners.pop(name, None)
+
+            if persist:
+                self._write_config(entry)
+
+            runner = _ServerRunner(entry)
+            self._runners[name] = runner
+
+            try:
+                await runner.start()
+            except Exception as e:
+                logger.error("External MCP %s failed to start: %s", name, e)
+                # Primitives from this server → broken, server_unavailable.
+                self._mark_primitives_unavailable(name)
+                return {"name": name, "status": "error", "error": str(e)}
+
+            reconcile_summary = await self._reconcile(name)
+            # Any primitive add/update/remove may have flipped composites'
+            # drift state — run the universal health pass so we surface it.
+            health = self._run_health_pass()
+            return {
+                "name": name,
+                "status": "running",
+                "reconcile": reconcile_summary,
+                "health": health,
+            }
+
+    async def stop(self, name: str, remove: bool = False) -> None:
+        async with self._lock:
+            runner = self._runners.pop(name, None)
+            if runner:
+                await runner.stop()
+            if remove:
+                fname = f"{name}.json"
+                if fname in self._config_handler.list_files():
+                    self._config_handler.delete_file(fname)
+
+    async def restart(self, name: str) -> Dict[str, Any]:
+        entry = self._read_config(f"{name}.json")
+        if entry is None:
+            raise ValueError(f"unknown external MCP: {name}")
+        return await self.start(entry, persist=False)
+
+    async def remove(self, name: str) -> Dict[str, Any]:
+        """Stop, delete config, delete primitives. Composites → `state=broken`."""
+        await self.stop(name, remove=True)
+        removed_primitives = self._delete_primitives(name)
+        health = self._run_health_pass()
+        return {
+            "name": name,
+            "removed_primitives": removed_primitives,
+            "health": health,
+        }
+
+    # ----- Read-only inspection ---------------------------------------------
+
+    def list_servers(self) -> List[Dict[str, Any]]:
+        servers: List[Dict[str, Any]] = []
+        for fname in self._config_handler.list_files():
+            if not fname.endswith(".json"):
+                continue
+            try:
+                entry = self._read_config(fname)
+            except Exception:
+                continue
+            if entry is None:
+                continue
+            name = entry["name"]
+            runner = self._runners.get(name)
+            status = runner.status if runner else "stopped"
+            last_error = runner.last_error if runner else None
+            servers.append({
+                "name": name,
+                "transport": entry["transport"],
+                "enabled": entry.get("enabled", True),
+                "status": status,
+                "last_error": last_error,
+                "tool_count": self._count_primitives(name),
+                "config": redact_entry(entry),
+            })
+        return servers
+
+    def get_server(self, name: str) -> Optional[Dict[str, Any]]:
+        for s in self.list_servers():
+            if s["name"] == name:
+                return s
+        return None
+
+    async def list_remote_tools(self, name: str) -> List[Dict[str, Any]]:
+        runner = self._runners.get(name)
+        if not runner:
+            raise ValueError(f"unknown external MCP: {name}")
+        remote = await runner.list_remote_tools()
+        return [
+            {
+                "name": t.name,
+                "description": getattr(t, "description", "") or "",
+                "inputSchema": getattr(t, "inputSchema", None) or {},
+            }
+            for t in remote
+        ]
+
+    async def call_tool(
+        self,
+        server_name: str,
+        remote_tool_name: str,
+        args: Optional[Dict[str, Any]] = None,
+        timeout: float = 30.0,
+    ) -> str:
+        runner = self._runners.get(server_name)
+        if not runner:
+            raise RuntimeError(f"unknown external MCP: {server_name}")
+        return await runner.call_tool(remote_tool_name, args, timeout=timeout)
+
+    def find_dependents(self, server_name: str) -> List[str]:
+        """Tools that will transition to `state="broken"` if this server is removed.
+
+        Excludes primitives of the server itself — those are cascade-deleted
+        alongside the server, not flagged broken.
+        """
+        out: List[str] = []
+        for fname in self._tool_handler.list_files():
+            if not fname.endswith(".json"):
+                continue
+            try:
+                d = json.loads(self._tool_handler.read_file(fname, raw_content=True))
+            except Exception:
+                continue
+            # A server's own primitives go away with it — don't list them.
+            if d.get("mcp_server") == server_name:
+                continue
+            deps = d.get("mcp_dependencies") or []
+            if server_name in deps:
+                out.append(d.get("name") or fname.removesuffix(".json"))
+        return out
+
+    # ----- Reconciliation ----------------------------------------------------
+
+    async def _reconcile(self, name: str) -> Dict[str, Any]:
+        """
+        Diff remote tools against stored primitives for `name`:
+         - new upstream → create primitive manifest
+         - changed schema → update params + description in place
+         - removed upstream → delete primitive manifest (+ associated module file)
+        """
+        runner = self._runners.get(name)
+        if runner is None or runner.status != "running":
+            self._mark_primitives_unavailable(name)
+            return {"status": "server_unavailable"}
+
+        try:
+            remote = await runner.list_remote_tools()
+        except Exception as e:
+            logger.error("list_tools failed for %s: %s", name, e)
+            self._mark_primitives_unavailable(name)
+            return {"status": "list_tools_failed", "error": str(e)}
+
+        remote_by_prefixed: Dict[str, Any] = {}
+        for t in remote:
+            prefixed = f"{name}__{t.name}"
+            remote_by_prefixed[prefixed] = t
+
+        stored = self._load_primitives(name)
+
+        added: List[str] = []
+        updated: List[str] = []
+        removed: List[str] = []
+
+        for prefixed, remote_tool in remote_by_prefixed.items():
+            params = params_from_input_schema(getattr(remote_tool, "inputSchema", None))
+            description = getattr(remote_tool, "description", "") or ""
+            if prefixed not in stored:
+                manifest = build_primitive_manifest(
+                    prefixed_name=prefixed,
+                    server_name=name,
+                    remote_description=description,
+                    remote_params=params,
+                )
+                self._tool_handler.write_file_content(
+                    f"{prefixed}.json", json.dumps(manifest, indent=4)
+                )
+                added.append(prefixed)
+            else:
+                existing = stored[prefixed]
+                changed = (
+                    existing.get("params") != params
+                    or (existing.get("description") or "") != description
+                )
+                was_unavailable = str(existing.get("broken_reason") or "").startswith(
+                    "server_unavailable:"
+                )
+                if changed or was_unavailable:
+                    existing["params"] = params
+                    existing["description"] = description
+                    existing["modified_at"] = _now_iso()
+                    if was_unavailable:
+                        existing["state"] = "approved"
+                        existing["broken_reason"] = None
+                    self._tool_handler.write_file_content(
+                        f"{prefixed}.json", json.dumps(existing, indent=4)
+                    )
+                    updated.append(prefixed)
+
+        for prefixed in set(stored) - set(remote_by_prefixed):
+            try:
+                self._tool_handler.delete_file(f"{prefixed}.json")
+                removed.append(prefixed)
+            except Exception as e:
+                logger.warning("Failed to delete stale primitive %s: %s", prefixed, e)
+
+        return {"added": added, "updated": updated, "removed": removed}
+
+    # ----- Primitive bookkeeping --------------------------------------------
+
+    def _load_primitives(self, server_name: str) -> Dict[str, Dict[str, Any]]:
+        out: Dict[str, Dict[str, Any]] = {}
+        for fname in self._tool_handler.list_files():
+            if not fname.endswith(".json"):
+                continue
+            try:
+                d = json.loads(self._tool_handler.read_file(fname, raw_content=True))
+            except Exception:
+                continue
+            if d.get("mcp_server") == server_name:
+                out[d["name"]] = d
+        return out
+
+    def _count_primitives(self, server_name: str) -> int:
+        return len(self._load_primitives(server_name))
+
+    def _mark_primitives_unavailable(self, server_name: str) -> None:
+        reason = f"server_unavailable:{server_name}"
+        for prefixed, d in self._load_primitives(server_name).items():
+            if d.get("broken_reason") == reason and d.get("state") == "broken":
+                continue
+            d["state"] = "broken"
+            d["broken_reason"] = reason
+            d["modified_at"] = _now_iso()
+            self._tool_handler.write_file_content(
+                f"{prefixed}.json", json.dumps(d, indent=4)
+            )
+
+    def _delete_primitives(self, server_name: str) -> List[str]:
+        removed: List[str] = []
+        for prefixed in list(self._load_primitives(server_name).keys()):
+            try:
+                self._tool_handler.delete_file(f"{prefixed}.json")
+                removed.append(prefixed)
+            except Exception as e:
+                logger.warning("Failed to delete primitive %s: %s", prefixed, e)
+        return removed
+
+    # ----- Health pass integration ------------------------------------------
+
+    def _run_health_pass(self) -> Dict[str, Any]:
+        """Run the universal tool health pass; swallow failures."""
+        try:
+            # Local import avoids a circular reference at module-load time.
+            from skillberry_store.modules.tool_health import check_all_tools_health
+            return check_all_tools_health(self._tool_handler, self._file_handler)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("health pass after external MCP mutation failed: %s", e)
+            return {"broken": [], "unbroken": [], "iterations": 0, "error": str(e)}
+
+    # ----- Config file I/O ---------------------------------------------------
+
+    def _read_config(self, filename: str) -> Optional[Dict[str, Any]]:
+        try:
+            content = self._config_handler.read_file(filename, raw_content=True)
+        except Exception:
+            return None
+        if not isinstance(content, str):
+            return None
+        try:
+            return json.loads(content)
+        except Exception:
+            return None
+
+    def _write_config(self, entry: Dict[str, Any]) -> None:
+        name = entry["name"]
+        now = _now_iso()
+        payload = dict(entry)
+        payload.setdefault("created_at", now)
+        payload["modified_at"] = now
+        payload.setdefault("status", "stopped")
+        payload.setdefault("last_error", None)
+        self._config_handler.write_file_content(
+            f"{name}.json", json.dumps(payload, indent=4)
+        )

--- a/src/skillberry_store/modules/external_mcp_manager.py
+++ b/src/skillberry_store/modules/external_mcp_manager.py
@@ -100,6 +100,20 @@ def normalize_mcp_input(
 
 
 def _normalize_entry(name: str, raw: Dict[str, Any]) -> Dict[str, Any]:
+    # External MCP names become primitive prefixes (`<name>__<tool>`) and
+    # are used as URL segments in /external-mcps/{name}; enforce the same
+    # Anthropic slug format we require for skills and VMCPs.
+    from skillberry_store.schemas.name_validation import (
+        is_valid_store_name,
+        format_hint,
+        STORE_NAME_PATTERN,
+    )
+    if not is_valid_store_name(name):
+        raise ValueError(
+            f"entry {name!r}: invalid MCP server name. "
+            f"{format_hint('External MCP')} (pattern: {STORE_NAME_PATTERN})"
+        )
+
     transport = raw.get("transport") or raw.get("type")
     if transport is None:
         if raw.get("command"):

--- a/src/skillberry_store/modules/file_executor.py
+++ b/src/skillberry_store/modules/file_executor.py
@@ -1,4 +1,6 @@
 import ast
+import hashlib
+import json
 import textwrap
 from importlib.metadata import packages_distributions
 import logging
@@ -182,6 +184,95 @@ def detect_tool_dependencies(content: str, function_name: str, available_tools: 
         return []
 
 
+def hash_tool_interface(
+    tool_dict: dict, module_source: str = ""
+) -> Tuple[str, str, str]:
+    """
+    Compute hashes of a tool's interface.
+
+    Returns (params_hash, module_hash, combined_hash) where:
+      - params_hash   = sha256 of canonical JSON of tool_dict["params"]
+      - module_hash   = sha256 of module_source (empty string for MCP primitives)
+      - combined_hash = sha256 of (params_hash || module_hash)
+
+    The health pass stores combined_hash on dependents to detect drift, and
+    can use (params_hash, module_hash) to attribute drift to schema vs code.
+    """
+    params = tool_dict.get("params") or {}
+    params_json = json.dumps(params, sort_keys=True, default=str)
+    params_hash = hashlib.sha256(params_json.encode("utf-8")).hexdigest()
+    module_hash = hashlib.sha256((module_source or "").encode("utf-8")).hexdigest()
+    combined_hash = hashlib.sha256(
+        (params_hash + module_hash).encode("utf-8")
+    ).hexdigest()
+    return params_hash, module_hash, combined_hash
+
+
+def compute_mcp_dependencies(
+    tool_dict: dict,
+    all_tools_as_dict: Dict[str, dict],
+    _visited: Optional[set] = None,
+) -> List[str]:
+    """
+    Union of external MCP server names this tool requires at runtime.
+
+    For MCP primitives: their own mcp_server (and any explicit mcp_dependencies).
+    For composites: recursive union across every entry in tool_dict["dependencies"],
+    looking each up in all_tools_as_dict.
+
+    Cycle-safe via a visited set, mirroring load_tool_dependencies at
+    tools_api.py:40-119.
+    """
+    if _visited is None:
+        _visited = set()
+
+    name = tool_dict.get("name")
+    if name is None or name in _visited:
+        return []
+    _visited.add(name)
+
+    result = set(tool_dict.get("mcp_dependencies") or [])
+    source = tool_dict.get("mcp_server")
+    if source:
+        result.add(source)
+
+    for dep_name in (tool_dict.get("dependencies") or []):
+        dep_tool = all_tools_as_dict.get(dep_name)
+        if not dep_tool:
+            continue
+        result.update(
+            compute_mcp_dependencies(dep_tool, all_tools_as_dict, _visited)
+        )
+    return sorted(result)
+
+
+def compute_dependency_hashes(
+    tool_dict: dict,
+    all_tools_as_dict: Dict[str, dict],
+    module_source_by_name: Dict[str, str],
+) -> Dict[str, Dict[str, str]]:
+    """
+    For every direct dep of tool_dict, return dep_name -> {params, module, combined}.
+
+    The three-component hash captures both the dep's params schema and its
+    module source at the time this tool was created/updated. The health pass
+    compares each component against the current hash to attribute drift to
+    schema vs code.
+    """
+    hashes: Dict[str, Dict[str, str]] = {}
+    for dep_name in (tool_dict.get("dependencies") or []):
+        dep = all_tools_as_dict.get(dep_name)
+        if not dep:
+            continue
+        dep_source = module_source_by_name.get(dep_name, "")
+        params_hash, module_hash, combined = hash_tool_interface(dep, dep_source)
+        hashes[dep_name] = {
+            "params": params_hash,
+            "module": module_hash,
+            "combined": combined,
+        }
+    return hashes
+
 
 class FileExecutor:
     def __init__(
@@ -226,7 +317,12 @@ class FileExecutor:
             logger.error(f"Error parsing manifest: {e}")
             raise HTTPException(status_code=400, detail=f"Error parsing manifest: {e}")
 
-        if not self.execute_python_locally:
+        # MCP-packaged tools are executed against a remote server; docker is
+        # only needed for local python packaging. Skipping the docker client
+        # init for MCP avoids spurious "docker daemon not running" errors on
+        # hosts that don't run docker but only use external MCPs.
+        is_mcp = (self.manifest or {}).get("packaging_format") == "mcp"
+        if not self.execute_python_locally and not is_mcp:
             try:
                 self.client = docker.from_env()
             except ImportError:
@@ -308,6 +404,52 @@ class FileExecutor:
         Executes a Python file using MCP server
         """
         import asyncio
+
+        # Fast path: tool was imported via the External MCPs feature — route
+        # through the pooled, long-lived session managed by ExternalMCPManager.
+        # Legacy single-tool MCP entries (no `mcp_server` field) fall through
+        # to the original transient-SSE path below, unchanged.
+        mcp_server_name = self.manifest.get("mcp_server")
+        if mcp_server_name:
+            try:
+                from skillberry_store.modules.external_mcp_manager import (
+                    get_current_manager,
+                )
+                manager = get_current_manager()
+            except Exception:
+                manager = None
+            if manager is not None:
+                # Remote tool name is everything after the "<server>__" prefix
+                # we applied at import time. Fall back to the manifest name.
+                full_name = self.manifest.get("name") or ""
+                prefix = f"{mcp_server_name}__"
+                remote_tool_name = (
+                    full_name[len(prefix):] if full_name.startswith(prefix) else full_name
+                )
+                try:
+                    text = await manager.call_tool(
+                        mcp_server_name,
+                        remote_tool_name,
+                        dict(parameters or {}),
+                        timeout=30.0,
+                    )
+                    logger.info(
+                        "[execute_python_file_in_mcp_server] pooled-session call "
+                        "to %s::%s succeeded", mcp_server_name, remote_tool_name
+                    )
+                    return {"return value": f"{text}"}
+                except Exception as e:
+                    logger.error(
+                        "[execute_python_file_in_mcp_server] pooled-session call "
+                        "to %s::%s failed: %s", mcp_server_name, remote_tool_name, e,
+                        exc_info=True,
+                    )
+                    return {
+                        "error": (
+                            f"External MCP '{mcp_server_name}' call failed for "
+                            f"tool '{remote_tool_name}': {e}"
+                        ),
+                    }
 
         # To experiment with the MCP server, see the instructions in the `docs/mcp-backend.md` file.
 

--- a/src/skillberry_store/modules/tool_health.py
+++ b/src/skillberry_store/modules/tool_health.py
@@ -1,0 +1,209 @@
+"""
+Universal tool-health pass.
+
+Scans every tool in the store and flips `state` between `approved` and
+`broken` based on whether its declared dependencies still match the hashes
+captured at create/update time.
+
+Broken-reason taxonomy:
+  - dep_missing:<dep>           the dep is gone from the store
+  - dep_schema_changed:<dep>    only the dep's params hash drifted
+  - dep_code_changed:<dep>      only the dep's module hash drifted
+  - dep_broken:<dep>            the dep is itself state=="broken"
+  - server_unavailable:<name>   set by the ExternalMCPManager for primitives
+                                of a server that failed to start; preserved
+                                here untouched.
+
+Runs to a fixpoint so transitive breakage propagates.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional, Tuple
+
+from skillberry_store.modules.file_handler import FileHandler
+from skillberry_store.modules.file_executor import hash_tool_interface
+
+logger = logging.getLogger(__name__)
+
+_MAX_ITERATIONS = 50
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _load_all(
+    tool_handler: FileHandler,
+    file_handler: FileHandler,
+) -> Tuple[Dict[str, Dict[str, Any]], Dict[str, str]]:
+    tools: Dict[str, Dict[str, Any]] = {}
+    modules: Dict[str, str] = {}
+    for fname in tool_handler.list_files():
+        if not fname.endswith(".json"):
+            continue
+        try:
+            content = tool_handler.read_file(fname, raw_content=True)
+            if not isinstance(content, str):
+                continue
+            d = json.loads(content)
+        except Exception as e:
+            logger.warning("health: skipping unreadable %s: %s", fname, e)
+            continue
+        name = d.get("name")
+        if not name:
+            continue
+        tools[name] = d
+        mod = d.get("module_name")
+        if mod:
+            try:
+                src = file_handler.read_file(mod, raw_content=True)
+                modules[name] = src if isinstance(src, str) else ""
+            except Exception:
+                modules[name] = ""
+        else:
+            modules[name] = ""
+    return tools, modules
+
+
+def _evaluate_reason(
+    tool: Dict[str, Any],
+    tools: Dict[str, Dict[str, Any]],
+    current_hashes: Dict[str, Tuple[str, str, str]],
+) -> Optional[str]:
+    """Return the broken_reason this tool should have right now, or None if healthy."""
+    deps = tool.get("dependencies") or []
+    stored = tool.get("dependency_hashes") or {}
+
+    for dep in deps:
+        if dep not in tools:
+            return f"dep_missing:{dep}"
+
+        dep_tool = tools[dep]
+        if dep_tool.get("state") == "broken":
+            return f"dep_broken:{dep}"
+
+        cur_params, cur_module, _ = current_hashes[dep]
+        stored_entry = stored.get(dep)
+        if stored_entry is None:
+            # No captured baseline — treat as a trust point (skip drift check).
+            continue
+        if isinstance(stored_entry, str):
+            # Back-compat with an older single-hash format. Skip attribution;
+            # rely on the combined comparison.
+            continue
+        s_params = stored_entry.get("params")
+        s_module = stored_entry.get("module")
+        if s_params is not None and s_params != cur_params:
+            return f"dep_schema_changed:{dep}"
+        if s_module is not None and s_module != cur_module:
+            return f"dep_code_changed:{dep}"
+
+    return None
+
+
+def check_all_tools_health(
+    tool_handler: FileHandler,
+    file_handler: FileHandler,
+) -> Dict[str, Any]:
+    """
+    Run the universal dep-drift pass to a fixpoint.
+
+    Returns a summary: {"broken": [...], "unbroken": [...], "iterations": N}.
+    Primitives flagged by the ExternalMCPManager as `server_unavailable:*`
+    are preserved untouched — the manager owns that lifecycle.
+    """
+    tools, modules = _load_all(tool_handler, file_handler)
+    if not tools:
+        return {"broken": [], "unbroken": [], "iterations": 0}
+
+    current_hashes: Dict[str, Tuple[str, str, str]] = {
+        name: hash_tool_interface(d, modules.get(name, ""))
+        for name, d in tools.items()
+    }
+
+    broken_out: list = []
+    unbroken_out: list = []
+    changed_any = True
+    iteration = 0
+
+    while changed_any and iteration < _MAX_ITERATIONS:
+        changed_any = False
+        iteration += 1
+
+        for name, d in tools.items():
+            current_state = d.get("state")
+            current_reason = d.get("broken_reason")
+
+            # Manager-owned state — do not touch.
+            if str(current_reason or "").startswith("server_unavailable:"):
+                continue
+
+            new_reason = _evaluate_reason(d, tools, current_hashes)
+
+            if new_reason is not None:
+                if current_state == "broken" and current_reason == new_reason:
+                    continue
+                d["state"] = "broken"
+                d["broken_reason"] = new_reason
+                d["modified_at"] = _now_iso()
+                tool_handler.write_file_content(
+                    f"{name}.json", json.dumps(d, indent=4)
+                )
+                broken_out.append({"name": name, "reason": new_reason})
+                changed_any = True
+            else:
+                if current_state == "broken":
+                    d["state"] = "approved"
+                    d["broken_reason"] = None
+                    d["modified_at"] = _now_iso()
+                    tool_handler.write_file_content(
+                        f"{name}.json", json.dumps(d, indent=4)
+                    )
+                    unbroken_out.append(name)
+                    changed_any = True
+
+    return {
+        "broken": broken_out,
+        "unbroken": unbroken_out,
+        "iterations": iteration,
+    }
+
+
+def find_dependents(tool_name: str, tool_handler: FileHandler) -> list:
+    """Tools that list `tool_name` in their `dependencies`."""
+    out: list = []
+    for fname in tool_handler.list_files():
+        if not fname.endswith(".json"):
+            continue
+        try:
+            d = json.loads(tool_handler.read_file(fname, raw_content=True))
+        except Exception:
+            continue
+        deps = d.get("dependencies") or []
+        if tool_name in deps:
+            out.append(d.get("name") or fname.removesuffix(".json"))
+    return out
+
+
+def list_broken_tools(tool_handler: FileHandler) -> list:
+    """All tools currently in `state="broken"` with their reason."""
+    out: list = []
+    for fname in tool_handler.list_files():
+        if not fname.endswith(".json"):
+            continue
+        try:
+            d = json.loads(tool_handler.read_file(fname, raw_content=True))
+        except Exception:
+            continue
+        if d.get("state") == "broken":
+            out.append({
+                "name": d.get("name"),
+                "broken_reason": d.get("broken_reason"),
+                "mcp_server": d.get("mcp_server"),
+                "mcp_dependencies": d.get("mcp_dependencies") or [],
+            })
+    return out

--- a/src/skillberry_store/modules/vmcp_server.py
+++ b/src/skillberry_store/modules/vmcp_server.py
@@ -442,14 +442,22 @@ class VirtualMcpServer:
             if tool_dict is None:
                 raise ValueError(f"No cached manifest for tool '{tool_name}'")
 
-            module_name = tool_dict.get("module_name")
-            if not module_name:
-                raise ValueError(f"Tool '{tool_name}' has no module_name in cached manifest")
+            # MCP-packaged primitives (from the External MCPs feature) have no
+            # module_name — their "code" is the remote MCP tool. Synthesize a
+            # stub so FileExecutor's MCP branch + pooled-session path handles
+            # them the same way /tools/{name}/execute does.
+            if tool_dict.get("packaging_format") == "mcp":
+                from skillberry_store.fast_api.server_utils import mcp_content_from_manifest
+                module_content = mcp_content_from_manifest(tool_dict)
+            else:
+                module_name = tool_dict.get("module_name")
+                if not module_name:
+                    raise ValueError(f"Tool '{tool_name}' has no module_name in cached manifest")
 
-            file_handler = FileHandler(get_files_directory_path())
-            module_content = file_handler.read_file(module_name, raw_content=True)
-            if not isinstance(module_content, str):
-                raise ValueError(f"Could not read module for tool '{tool_name}'")
+                file_handler = FileHandler(get_files_directory_path())
+                module_content = file_handler.read_file(module_name, raw_content=True)
+                if not isinstance(module_content, str):
+                    raise ValueError(f"Could not read module for tool '{tool_name}'")
 
             executor = FileExecutor(
                 name=tool_name,

--- a/src/skillberry_store/plugins/__init__.py
+++ b/src/skillberry_store/plugins/__init__.py
@@ -1,0 +1,74 @@
+"""Plugin registry.
+
+`INSTALLED` is the hand-maintained list of plugins shipped with the store.
+Enabling/disabling is controlled at runtime via `plugins/enabled.json` and
+the `/plugins/{id}/enable|disable` admin endpoints.
+
+Main code must never branch on a plugin id. Use `active_plugins()` or
+`installed_plugins()` and iterate.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from .base import (
+    Plugin,
+    UIManifest,
+    read_enabled,
+    write_enabled,
+    mount_plugin,
+    unmount_plugin,
+    ensure_plugin_directory,
+)
+from .runspace import RunspacePlugin
+
+
+INSTALLED: List[Plugin] = [RunspacePlugin()]
+
+
+def installed_plugins() -> List[Plugin]:
+    return list(INSTALLED)
+
+
+def get_plugin(plugin_id: str) -> Optional[Plugin]:
+    for p in INSTALLED:
+        if p.id == plugin_id:
+            return p
+    return None
+
+
+def active_plugins() -> List[Plugin]:
+    enabled = set(read_enabled())
+    return [p for p in INSTALLED if p.id in enabled]
+
+
+def is_enabled(plugin_id: str) -> bool:
+    return plugin_id in set(read_enabled())
+
+
+def set_enabled(plugin_id: str, enabled: bool) -> List[str]:
+    current = read_enabled()
+    if enabled and plugin_id not in current:
+        current.append(plugin_id)
+    elif not enabled and plugin_id in current:
+        current = [x for x in current if x != plugin_id]
+    write_enabled(current)
+    return current
+
+
+__all__ = [
+    "Plugin",
+    "UIManifest",
+    "INSTALLED",
+    "installed_plugins",
+    "get_plugin",
+    "active_plugins",
+    "is_enabled",
+    "set_enabled",
+    "mount_plugin",
+    "unmount_plugin",
+    "read_enabled",
+    "write_enabled",
+    "ensure_plugin_directory",
+]

--- a/src/skillberry_store/plugins/base.py
+++ b/src/skillberry_store/plugins/base.py
@@ -1,0 +1,139 @@
+"""Plugin protocol and activation-file management.
+
+Plugins are self-describing add-ons that contribute a FastAPI router and a
+UI manifest. The main codebase never references any individual plugin by
+name; it iterates the registry instead.
+
+Activation state lives in `$SBS_BASE_DIR/plugins/enabled.json`. Each plugin
+may also use `$SBS_BASE_DIR/plugins/<plugin_id>/` for its own settings.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Protocol
+
+from fastapi import APIRouter, FastAPI
+
+from skillberry_store.tools.configure import (
+    get_plugin_directory,
+    get_plugins_directory,
+)
+
+logger = logging.getLogger(__name__)
+
+_ENABLED_FILE_NAME = "enabled.json"
+
+
+@dataclass
+class UIManifest:
+    """Serialized description of a plugin's UI contributions.
+
+    Consumed by the browser via `GET /plugins`. All paths are relative to
+    the SPA root; component identifiers are strings resolved by the UI
+    registry.
+    """
+
+    routes: List[Dict[str, str]] = field(default_factory=list)
+    nav_items: List[Dict[str, str]] = field(default_factory=list)
+    slots: Dict[str, List[Dict[str, str]]] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "routes": self.routes,
+            "nav_items": self.nav_items,
+            "slots": self.slots,
+        }
+
+
+class Plugin(Protocol):
+    id: str
+    name: str
+    description: str
+    prefix: str
+    requires_restart: bool
+    router: APIRouter
+    ui_manifest: UIManifest
+
+    def on_enable(self) -> None: ...
+    def on_disable(self) -> None: ...
+
+
+def read_enabled() -> List[str]:
+    """Return the list of enabled plugin ids from enabled.json.
+
+    Missing or malformed files are treated as an empty list (opt-in default).
+    """
+    path = os.path.join(get_plugins_directory(), _ENABLED_FILE_NAME)
+    if not os.path.exists(path):
+        return []
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        enabled = data.get("enabled", [])
+        if isinstance(enabled, list):
+            return [str(x) for x in enabled]
+    except Exception as e:
+        logger.warning(f"Failed to read {path}: {e}")
+    return []
+
+
+def write_enabled(enabled: List[str]) -> None:
+    plugins_dir = get_plugins_directory()
+    os.makedirs(plugins_dir, exist_ok=True)
+    path = os.path.join(plugins_dir, _ENABLED_FILE_NAME)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump({"enabled": list(enabled)}, f, indent=2)
+
+
+def ensure_plugin_directory(plugin_id: str) -> str:
+    path = get_plugin_directory(plugin_id)
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
+def mount_plugin(app: FastAPI, plugin: Plugin) -> None:
+    """Include a plugin's router on the live app."""
+    app.include_router(plugin.router, prefix=plugin.prefix, tags=[plugin.name])
+    try:
+        plugin.on_enable()
+    except Exception as e:
+        logger.warning(f"Plugin '{plugin.id}' on_enable hook failed: {e}")
+    # Force OpenAPI schema regeneration so newly-mounted routes show up.
+    app.openapi_schema = None
+
+
+def unmount_plugin(app: FastAPI, plugin: Plugin) -> None:
+    """Remove a plugin's routes from the live app.
+
+    Filters `app.router.routes` in place, dropping any route whose path
+    begins with the plugin's prefix. If the prefix is empty, drops routes
+    whose tags include the plugin's name.
+    """
+    prefix = plugin.prefix or ""
+    removed = 0
+    keep = []
+    for route in list(app.router.routes):
+        path = getattr(route, "path", "")
+        tags = getattr(route, "tags", []) or []
+        matches = False
+        if prefix:
+            if path.startswith(prefix):
+                matches = True
+        else:
+            if plugin.name in tags:
+                matches = True
+        if matches:
+            removed += 1
+            continue
+        keep.append(route)
+    app.router.routes = keep
+    logger.info(f"Unmounted plugin '{plugin.id}' ({removed} routes removed)")
+    try:
+        plugin.on_disable()
+    except Exception as e:
+        logger.warning(f"Plugin '{plugin.id}' on_disable hook failed: {e}")
+    app.openapi_schema = None

--- a/src/skillberry_store/plugins/runspace/__init__.py
+++ b/src/skillberry_store/plugins/runspace/__init__.py
@@ -1,0 +1,68 @@
+"""Runspace plugin: agent-driven skill export + Store Agent chat.
+
+Talks to an external `runspace-srv` daemon (default http://localhost:6767)
+to run Claude Code agents. The Python server never calls runspace directly —
+it only builds request bodies that the browser submits to runspace-srv.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from skillberry_store.plugins.base import UIManifest
+
+from .router import build_router
+
+PLUGIN_ID = "runspace"
+
+
+class RunspacePlugin:
+    id: str = PLUGIN_ID
+    name: str = "Runspace"
+    description: str = (
+        "Agent-driven skill export and a Store Agent chat, powered by the "
+        "Runspace daemon (runspace-srv). The browser talks to runspace-srv; "
+        "the store only assembles request payloads."
+    )
+    prefix: str = ""
+    requires_restart: bool = False
+
+    def __init__(self) -> None:
+        self._router: APIRouter | None = None
+        self._app_settings_provider = None
+
+    def bind_app(self, app) -> None:
+        """Called by the server before mount so the plugin can read app state."""
+        self._app_settings_provider = lambda: getattr(app, "settings", None)
+
+    @property
+    def router(self) -> APIRouter:
+        if self._router is None:
+            provider = self._app_settings_provider or (lambda: None)
+            self._router = build_router(provider)
+        return self._router
+
+    @property
+    def ui_manifest(self) -> UIManifest:
+        return UIManifest(
+            routes=[
+                {"path": "/runspace", "component": "runspace.RunspacePage"},
+            ],
+            nav_items=[
+                {"id": "runspace", "label": "Runspace", "path": "/runspace"},
+            ],
+            slots={
+                "skill.detail.actions": [
+                    {"component": "runspace.ExportWithAgentAction"},
+                ],
+            },
+        )
+
+    def on_enable(self) -> None:
+        pass
+
+    def on_disable(self) -> None:
+        pass
+
+
+__all__ = ["RunspacePlugin", "PLUGIN_ID"]

--- a/src/skillberry_store/plugins/runspace/agentic_exporter.py
+++ b/src/skillberry_store/plugins/runspace/agentic_exporter.py
@@ -1,0 +1,220 @@
+"""Agentic exporter: builds a RunspaceAgent request body for AI-driven skill creation."""
+
+import logging
+import os
+import tempfile
+from typing import Any, Dict, List, Optional
+
+from skillberry_store.tools.anthropic.exporter import get_tool_extension
+
+logger = logging.getLogger(__name__)
+
+
+def build_context_directory(
+    skill_dict: Dict[str, Any],
+    tools: List[Dict[str, Any]],
+    snippets: List[Dict[str, Any]],
+    tool_modules: Optional[Dict[str, str]],
+    base_dir: str,
+) -> str:
+    context_dir = os.path.join(base_dir, "context")
+    tools_dir = os.path.join(context_dir, "tools")
+    snippets_dir = os.path.join(context_dir, "snippets")
+    os.makedirs(tools_dir, exist_ok=True)
+    os.makedirs(snippets_dir, exist_ok=True)
+
+    skill_info = _build_skill_info(skill_dict, tools, snippets)
+    with open(os.path.join(context_dir, "skill_info.md"), "w", encoding="utf-8") as f:
+        f.write(skill_info)
+
+    for tool in tools:
+        tool_name = tool["name"]
+        ext = get_tool_extension(tool)
+        content = ""
+        if tool_modules and tool_name in tool_modules:
+            content = tool_modules[tool_name]
+        else:
+            lang = tool.get("programming_language", "python")
+            comment = "#" if lang.lower() in ("python", "py", "bash", "sh", "shell") else "//"
+            content = f"{comment} Source code not available for tool: {tool_name}\n"
+            logger.warning(f"No module content for tool '{tool_name}'")
+
+        with open(os.path.join(tools_dir, f"{tool_name}{ext}"), "w", encoding="utf-8") as f:
+            f.write(content)
+
+    for snippet in snippets:
+        snippet_name = snippet["name"]
+        content = snippet.get("content", "")
+        content_type = snippet.get("content_type", "text/plain")
+        ext = ".md" if "markdown" in content_type else ".txt"
+        with open(os.path.join(snippets_dir, f"{snippet_name}{ext}"), "w", encoding="utf-8") as f:
+            f.write(content)
+
+    return context_dir
+
+
+def _build_skill_info(
+    skill_dict: Dict[str, Any],
+    tools: List[Dict[str, Any]],
+    snippets: List[Dict[str, Any]],
+) -> str:
+    lines = []
+    lines.append(f"# Skill: {skill_dict['name']}\n")
+    lines.append(f"**Description:** {skill_dict.get('description', 'No description')}\n")
+    lines.append(f"**Version:** {skill_dict.get('version', 'unknown')}\n")
+
+    tags = skill_dict.get("tags") or []
+    if isinstance(tags, list) and tags:
+        lines.append(f"**Tags:** {', '.join(str(t) for t in tags)}\n")
+
+    if tools:
+        lines.append("\n## Tools\n")
+        for tool in tools:
+            lines.append(f"### {tool['name']}\n")
+            lines.append(f"- **Description:** {tool.get('description', 'No description')}")
+            lines.append(f"- **Language:** {tool.get('programming_language', 'unknown')}")
+
+            params = tool.get("params")
+            if isinstance(params, dict):
+                properties = params.get("properties", {})
+                required_params = params.get("required", [])
+                if properties:
+                    lines.append("- **Parameters:**")
+                    for p_name, p_schema in properties.items():
+                        if isinstance(p_schema, dict):
+                            p_type = p_schema.get("type", "any")
+                            p_desc = p_schema.get("description", "")
+                        else:
+                            p_type = "any"
+                            p_desc = ""
+                        p_required = "required" if p_name in required_params else "optional"
+                        lines.append(f"  - `{p_name}` ({p_type}, {p_required}): {p_desc}")
+
+            returns = tool.get("returns")
+            if isinstance(returns, dict):
+                r_type = returns.get("type", "any")
+                r_desc = returns.get("description", "")
+                lines.append(f"- **Returns:** {r_type} — {r_desc}")
+            elif isinstance(returns, str) and returns:
+                lines.append(f"- **Returns:** {returns}")
+
+            lines.append("")
+
+    if snippets:
+        lines.append("\n## Snippets\n")
+        for snippet in snippets:
+            lines.append(f"### {snippet['name']}\n")
+            lines.append(f"- **Description:** {snippet.get('description', 'No description')}")
+            lines.append(f"- **Content type:** {snippet.get('content_type', 'text/plain')}")
+            s_tags = snippet.get("tags") or []
+            if isinstance(s_tags, list) and s_tags:
+                lines.append(f"- **Tags:** {', '.join(str(t) for t in s_tags)}")
+            lines.append("")
+
+    return "\n".join(lines)
+
+
+def build_editable_directory(base_dir: str) -> str:
+    editable_dir = os.path.join(base_dir, "editable")
+    os.makedirs(editable_dir, exist_ok=True)
+    return editable_dir
+
+
+def build_default_env() -> Dict[str, str]:
+    ibm_base = os.environ.get("IBM_THIRD_PARTY_API_BASE", "")
+    ibm_key = os.environ.get("IBM_THIRD_PARTY_API_KEY", "")
+    return {
+        "ANTHROPIC_BASE_URL": ibm_base if ibm_base else "<insert-your-anthropic-base-url>",
+        "ANTHROPIC_AUTH_TOKEN": ibm_key if ibm_key else "<insert-your-auth-token>",
+        "ANTHROPIC_MODEL": "claude-opus-4-6",
+        "CLAUDE_CODE_SUBAGENT_MODEL": "claude-opus-4-6",
+        "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
+        "opusPlanEnabled": "true",
+    }
+
+
+def build_agent_prompt(skill_name: str) -> str:
+    return f"""\
+You are converting a skillberry-store skill into a high-quality Anthropic skill.
+
+The context/ directory contains the complete source material for a skill called "{skill_name}":
+- context/skill_info.md — Overview of the skill: its name, description, and a summary of every tool and snippet it contains (including parameter schemas).
+- context/tools/ — The actual source code (.py/.sh) for each tool in the skill.
+- context/snippets/ — The content of each snippet in the skill.
+
+Your task: Create a complete, production-quality Anthropic skill in the editable/ directory.
+
+## What to create
+
+1. **SKILL.md** with YAML frontmatter:
+   - `name`: Use "{skill_name}"
+   - `description`: A clear, actionable description of when and how to use this skill. Make it slightly "pushy" so it triggers reliably — describe not just what it does, but the user contexts where it should activate.
+   - Body: Usage instructions, workflow guidance, and explanations of what the skill provides.
+
+2. **scripts/** directory with standalone tool scripts:
+   - Convert each tool from context/tools/ into a standalone script with `argparse`.
+   - Each script must be runnable as: `python scripts/tool_name.py --arg1 value1 --arg2 value2`
+   - Preserve the core logic from the original source code but restructure for CLI use.
+   - Add proper `if __name__ == "__main__":` blocks.
+   - Include clear help text in the argparse description.
+   - For bash tools, keep them as .sh scripts with proper argument parsing.
+
+3. **references/** directory with documentation:
+   - Convert each snippet from context/snippets/ into a markdown reference document.
+   - Organize logically and add any cross-references between docs.
+
+## Guidelines
+
+- Read ALL files in context/ before starting. Understand the full picture first.
+- The SKILL.md body should explain how to use each script, with examples.
+- Keep scripts self-contained — each one should work independently.
+- Preserve the original tool's functionality faithfully.
+- Add error handling and input validation to scripts.
+- Use the /skill-creator skill for guidance on best practices for Anthropic skill structure.
+
+## Quality checklist
+
+Before finishing, verify:
+- [ ] SKILL.md has valid YAML frontmatter with name and description
+- [ ] Every tool has a corresponding script in scripts/
+- [ ] Every snippet has a corresponding reference in references/
+- [ ] Each script has argparse and can be invoked from the command line
+- [ ] SKILL.md body documents all scripts with usage examples
+"""
+
+
+def build_agent_request(
+    skill_dict: Dict[str, Any],
+    tools: List[Dict[str, Any]],
+    snippets: List[Dict[str, Any]],
+    tool_modules: Optional[Dict[str, str]] = None,
+) -> Dict[str, Any]:
+    skill_name = skill_dict["name"]
+
+    base_dir = tempfile.mkdtemp(prefix=f"sbs_agentic_export_{skill_name}_")
+    logger.info(f"Created agentic export workspace at: {base_dir}")
+
+    context_path = build_context_directory(
+        skill_dict, tools, snippets, tool_modules, base_dir
+    )
+    editable_path = build_editable_directory(base_dir)
+    prompt = build_agent_prompt(skill_name)
+    default_env = build_default_env()
+
+    return {
+        "name": f"agentic-export-{skill_name}",
+        "editable_dir": str(editable_path),
+        "context_dir": str(context_path),
+        "prompt": prompt,
+        "editable_description": "Empty directory — agent creates the Anthropic skill from scratch",
+        "context_description": (
+            f"Source code and metadata for the '{skill_name}' skill "
+            "— tool source files, snippet content, and a skill_info.md summary"
+        ),
+        "preinstalled_skills": ["skill-creator"],
+        "agent_type": "claude-code",
+        "mode": "local",
+        "output_zip": False,
+        "agent_settings": {"env": default_env},
+        "agent_max_turns": 50,
+    }

--- a/src/skillberry_store/plugins/runspace/router.py
+++ b/src/skillberry_store/plugins/runspace/router.py
@@ -1,0 +1,172 @@
+"""Runspace plugin routes.
+
+Hosts the three endpoints that previously lived in skills_api.py:
+
+- POST /skills/{name}/export-agent-request — build a RunspaceAgent request
+  for agentic export of a skill.
+- GET  /ai-settings                        — load plugin settings (runspace
+  URL, default env vars).
+- PUT  /ai-settings                        — persist plugin settings.
+- POST /agent/store-request                — build a RunspaceAgent request
+  for the Store Agent, preloaded with store MCP + merged env vars.
+
+Settings are stored at `$SBS_BASE_DIR/plugins/runspace/settings.json`, with
+a one-time migration from `$SBS_BASE_DIR/ai_features/settings.json` the
+first time the plugin loads.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+from typing import Annotated, Any, Dict
+
+from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile
+
+from skillberry_store.fast_api.skill_export_utils import get_skill_export_data
+from skillberry_store.tools.configure import (
+    get_ai_features_directory,
+    get_plugin_directory,
+)
+
+from .agentic_exporter import build_agent_request, build_default_env
+from .store_agent_builder import build_store_agent_request
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_ID = "runspace"
+_SETTINGS_FILENAME = "settings.json"
+
+
+def _settings_path() -> str:
+    return os.path.join(get_plugin_directory(PLUGIN_ID), _SETTINGS_FILENAME)
+
+
+def _legacy_settings_path() -> str:
+    return os.path.join(get_ai_features_directory(), "settings.json")
+
+
+def migrate_legacy_settings() -> None:
+    """One-time copy of the old ai_features/settings.json into the plugin dir.
+
+    Safe to call repeatedly; becomes a no-op once the new file exists.
+    """
+    new = _settings_path()
+    if os.path.exists(new):
+        return
+    old = _legacy_settings_path()
+    if not os.path.exists(old):
+        return
+    try:
+        os.makedirs(os.path.dirname(new), exist_ok=True)
+        shutil.copy2(old, new)
+        logger.info(f"Migrated runspace settings from {old} to {new}")
+    except Exception as e:
+        logger.warning(f"Failed to migrate runspace settings: {e}")
+
+
+def build_router(app_settings_provider) -> APIRouter:
+    """Return the runspace APIRouter.
+
+    `app_settings_provider` is a zero-arg callable that returns the SBS
+    settings object, used to resolve `agent_mcp_port` when building a
+    Store Agent request. This keeps the plugin loosely coupled to the app.
+    """
+    migrate_legacy_settings()
+
+    router = APIRouter()
+
+    @router.post("/skills/{name}/export-agent-request")
+    async def export_agent_request(name: str) -> Dict[str, Any]:
+        logger.info(f"Request to build agentic export for skill: {name}")
+        try:
+            skill_dict, tools, snippets, tool_modules, _mcp_servers = get_skill_export_data(name)
+            # The agentic exporter does not (yet) bundle MCP server configs
+            # into the runspace agent context; the value is unpacked for
+            # signature-compat with `get_skill_export_data` and discarded.
+            request_body = build_agent_request(
+                skill_dict=skill_dict,
+                tools=tools,
+                snippets=snippets,
+                tool_modules=tool_modules,
+            )
+            return request_body
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.error(f"Error building agentic export for skill '{name}': {e}")
+            raise HTTPException(
+                status_code=500, detail=f"Error building agentic export: {str(e)}"
+            )
+
+    @router.get("/ai-settings")
+    async def get_ai_settings() -> Dict[str, Any]:
+        path = _settings_path()
+        if os.path.exists(path):
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    return json.load(f)
+            except Exception as e:
+                logger.warning(f"Failed to read runspace settings file: {e}")
+        return {
+            "runspace_url": "http://localhost:6767",
+            "env_vars": [
+                {"key": k, "value": v}
+                for k, v in build_default_env().items()
+            ],
+        }
+
+    @router.put("/ai-settings")
+    async def save_ai_settings(request: Request) -> Dict[str, str]:
+        path = _settings_path()
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        data = await request.json()
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+        return {"message": "Settings saved"}
+
+    @router.post("/agent/store-request")
+    async def build_store_agent_request_endpoint(
+        prompt: Annotated[str, Form()],
+        context_files: list[UploadFile] = File(default=[]),
+    ) -> Dict[str, Any]:
+        if not prompt:
+            raise HTTPException(status_code=400, detail="'prompt' field is required")
+
+        settings = app_settings_provider()
+        agent_mcp_port = getattr(settings, "agent_mcp_port", 9999)
+        request_body = build_store_agent_request(prompt, agent_mcp_port=agent_mcp_port)
+
+        context_dir = request_body.get("context_dir", "")
+        for upload in context_files:
+            if upload.filename:
+                dest = os.path.join(context_dir, upload.filename)
+                os.makedirs(os.path.dirname(dest), exist_ok=True)
+                content = await upload.read()
+                with open(dest, "wb") as f:
+                    f.write(content)
+
+        path = _settings_path()
+        if os.path.exists(path):
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    ai_settings = json.load(f)
+                env_vars = ai_settings.get("env_vars", [])
+                env_dict: Dict[str, str] = {}
+                for ev in env_vars:
+                    k, v = ev.get("key", ""), ev.get("value", "")
+                    if k and v and not (v.startswith("<") and v.endswith(">")):
+                        env_dict[k] = v
+                if env_dict:
+                    request_body["agent_settings"]["env"].update(env_dict)
+                runspace_url = ai_settings.get("runspace_url")
+                if runspace_url:
+                    request_body["_runspace_url"] = runspace_url
+            except Exception as e:
+                logger.warning(f"Failed to merge runspace settings: {e}")
+
+        return request_body
+
+    return router

--- a/src/skillberry_store/plugins/runspace/store_agent_builder.py
+++ b/src/skillberry_store/plugins/runspace/store_agent_builder.py
@@ -1,0 +1,101 @@
+"""Store Agent builder: builds a RunspaceAgent request for the Store Agent.
+
+The Store Agent is an AI assistant that manages the Skillberry Store via MCP tools.
+It can create tools, skills, snippets, and VMCP servers on behalf of the user.
+"""
+
+import logging
+import os
+import tempfile
+from typing import Any, Dict
+
+from .agentic_exporter import build_default_env
+
+logger = logging.getLogger(__name__)
+
+STORE_AGENT_PROMPT = """\
+You are the Skillberry Store Assistant. You have access to the Skillberry Store \
+via MCP tools. Use the skillberry-store MCP tools to fulfill the user's request.
+
+## Available MCP Tools
+
+You have these tools from the "skillberry-store" MCP server:
+- list_tools — List all tools (name, description, state)
+- get_tool_metadata — Get full tool manifest
+- get_tool_code — Get tool Python source code
+- update_tool_code — Update tool source code
+- update_tool_metadata — Update description, tags, state, version
+- create_tool — Create a new tool from Python code
+- execute_tool — Execute a tool with parameters
+- search_tools — Semantic search over tool descriptions
+- list_skills — List all skills
+- get_skill — Get skill with resolved tools
+- create_skill — Create a new skill with tool names
+- add_tool_to_skill — Add a tool to a skill
+- remove_tool_from_skill — Remove a tool from a skill
+- create_vmcp_server — Create and start a VMCP server for a skill
+
+## User Request
+
+{user_request}
+
+## Context Files
+
+The user may have uploaded context files. If so, they are available in your \
+context directory. Read them to understand requirements, specs, or code samples \
+the user provided.
+
+## Guidelines
+
+1. Use the MCP tools to fulfill the request. Do NOT try to write files directly.
+2. When creating tools, write clean Python code with docstrings and proper error handling.
+3. When creating a VMCP server, include the `claude mcp add` command in your response \
+   so the user knows how to connect to it.
+4. If you create multiple tools, consider grouping them into a skill.
+5. Verify your work — after creating tools, try to list them to confirm they exist.
+"""
+
+
+def build_store_agent_request(
+    user_prompt: str,
+    agent_mcp_port: int = 9999,
+) -> Dict[str, Any]:
+    """Build a RunspaceAgent request for the Store Agent."""
+    base_dir = tempfile.mkdtemp(prefix="sbs_store_agent_")
+    editable_dir = os.path.join(base_dir, "editable")
+    context_dir = os.path.join(base_dir, "context")
+    os.makedirs(editable_dir, exist_ok=True)
+    os.makedirs(context_dir, exist_ok=True)
+
+    prompt = STORE_AGENT_PROMPT.format(user_request=user_prompt)
+    default_env = build_default_env()
+
+    return {
+        "name": "store-agent",
+        "editable_dir": editable_dir,
+        "context_dir": context_dir,
+        "prompt": prompt,
+        "editable_description": "Workspace for store agent operations",
+        "context_description": "Skillberry Store context",
+        "agent_type": "claude-code",
+        "mode": "local",
+        "output_zip": False,
+        "agent_settings": {"env": default_env},
+        "agent_max_turns": 50,
+        "mcp_servers": {
+            "skillberry-store": {
+                "type": "sse",
+                "url": f"http://localhost:{agent_mcp_port}/sse",
+            }
+        },
+        "extra_summary_sections": [
+            {
+                "title": "Answer to User",
+                "content": (
+                    "Directly answer the user's original question. "
+                    "Include any connection commands, URLs, or instructions "
+                    "they need to use what you created."
+                ),
+            }
+        ],
+    }

--- a/src/skillberry_store/schemas/manifest_schema.py
+++ b/src/skillberry_store/schemas/manifest_schema.py
@@ -14,6 +14,7 @@ class ManifestState(str, Enum):
     NEW = "new"
     CHECKED = "checked"
     APPROVED = "approved"
+    BROKEN = "broken"
 
 
 class ManifestSchema(BaseModel):

--- a/src/skillberry_store/schemas/name_validation.py
+++ b/src/skillberry_store/schemas/name_validation.py
@@ -1,0 +1,87 @@
+"""Shared name validation for store entities that are exposed as MCP servers
+or become positional-argument tokens (skills, VMCPs, external MCP servers).
+
+We enforce Anthropic's Agent Skills SKILL.md `name` format — the same slug
+shape the upstream `claude mcp add <name> …` CLI and URL segments expect:
+
+  ^[a-z0-9-]{1,64}$
+
+Lowercase letters, digits, and hyphens only; 1 to 64 characters. This rules
+out spaces, uppercase, underscores, dots, slashes, and every other punctuation
+that would either break a positional CLI arg or fail a URL-segment parse.
+
+Source: https://code.claude.com/docs/en/skills — Frontmatter reference
+("Lowercase letters, numbers, and hyphens only (max 64 characters).")
+
+Callers typically:
+
+    from skillberry_store.schemas.name_validation import validate_store_name
+    validate_store_name(name, kind="skill")   # raises HTTPException(400, …) on invalid
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict
+
+from fastapi import HTTPException
+
+# Anthropic Agent Skills naming spec.
+STORE_NAME_PATTERN = r"^[a-z0-9-]{1,64}$"
+STORE_NAME_RE = re.compile(STORE_NAME_PATTERN)
+
+
+def is_valid_store_name(name: str) -> bool:
+    return isinstance(name, str) and bool(STORE_NAME_RE.fullmatch(name))
+
+
+def format_hint(kind: str) -> str:
+    return (
+        f"{kind} names must match the Anthropic Agent Skills format: "
+        f"lowercase letters, digits, and hyphens (-) only; 1 to 64 characters. "
+        f"No spaces, underscores, uppercase, dots, or other punctuation. "
+        f"Examples: 'docs-research', 'context7', 'pdf-to-markdown'."
+    )
+
+
+def validate_store_name(name: Any, kind: str = "name") -> None:
+    """Validate a name used as an MCP/CLI identifier; raise HTTP 400 otherwise.
+
+    `kind` is a human label used in the error ("skill", "VMCP server",
+    "external MCP", "tool", ...).
+    """
+    if not isinstance(name, str) or not name:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "invalid_name",
+                "kind": kind,
+                "name": name,
+                "hint": format_hint(kind),
+            },
+        )
+    if not STORE_NAME_RE.fullmatch(name):
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "invalid_name",
+                "kind": kind,
+                "name": name,
+                "hint": format_hint(kind),
+                "pattern": STORE_NAME_PATTERN,
+            },
+        )
+
+
+def validate_store_name_message(name: Any, kind: str = "name") -> str | None:
+    """Non-raising variant. Returns None if valid, or a message string if not.
+
+    Convenient for curated MCP tools that return JSON error strings instead
+    of HTTP responses.
+    """
+    if not isinstance(name, str) or not name or not STORE_NAME_RE.fullmatch(name):
+        return (
+            f"Invalid {kind} name {name!r}. {format_hint(kind)} "
+            f"(pattern: {STORE_NAME_PATTERN})"
+        )
+    return None

--- a/src/skillberry_store/schemas/tool_schema.py
+++ b/src/skillberry_store/schemas/tool_schema.py
@@ -92,9 +92,12 @@ class ToolSchema(ManifestSchema):
         default_factory=list,
         description="External MCP server names this tool requires at runtime (union across dependencies for composites)."
     )
+    # Baseline for the health pass. Mainly for MCP: external servers can
+    # overwrite a primitive's params with no local commit, so we need a
+    # recorded snapshot to notice drift.
     dependency_hashes: Dict[str, Dict[str, str]] = Field(
         default_factory=dict,
-        description="Map of dep_name -> {params, module, combined} sha256 hashes captured at create/update time; used by the health pass to attribute drift to schema vs code."
+        description="Per-dep {params, module, combined} sha256 baseline captured at create/update; health pass diffs it to attribute drift to schema vs code (catches silent MCP schema changes)."
     )
     broken_reason: Optional[str] = Field(
         default=None,

--- a/src/skillberry_store/schemas/tool_schema.py
+++ b/src/skillberry_store/schemas/tool_schema.py
@@ -80,7 +80,36 @@ class ToolSchema(ManifestSchema):
         default=None,
         description="List of tool names that this tool depends on"
     )
-    
+    mcp_url: Optional[str] = Field(
+        default=None,
+        description="Legacy single-tool SSE URL for packaging_format='mcp' tools that point at an externally-hosted server (back-compat)."
+    )
+    mcp_server: Optional[str] = Field(
+        default=None,
+        description="Name of the external MCP server this tool was imported from; None for user-authored tools."
+    )
+    mcp_dependencies: List[str] = Field(
+        default_factory=list,
+        description="External MCP server names this tool requires at runtime (union across dependencies for composites)."
+    )
+    dependency_hashes: Dict[str, Dict[str, str]] = Field(
+        default_factory=dict,
+        description="Map of dep_name -> {params, module, combined} sha256 hashes captured at create/update time; used by the health pass to attribute drift to schema vs code."
+    )
+    broken_reason: Optional[str] = Field(
+        default=None,
+        description="Populated when state == broken; prefix-tagged: dep_missing / dep_schema_changed / dep_code_changed / dep_broken / server_unavailable."
+    )
+    bundled_with_mcps: Optional[bool] = Field(
+        default=None,
+        description=(
+            "Only meaningful for tools with mcp_server set or mcp_dependencies non-empty. "
+            "Default True when applicable. When False, the tool is skipped from bulk "
+            "'add all tools of MCP X' skill-builder operations; it can still be added "
+            "manually or via an include-all override."
+        ),
+    )
+
     def to_dict(self) -> Dict[str, Any]:
         """Convert the tool schema to a dictionary."""
         return self.model_dump(exclude_none=False)

--- a/src/skillberry_store/tests/test_external_mcp.py
+++ b/src/skillberry_store/tests/test_external_mcp.py
@@ -1,0 +1,447 @@
+"""Unit tests for the External MCPs feature.
+
+Covers:
+  - normalize_mcp_input (5 wire shapes)
+  - hash_tool_interface / compute_mcp_dependencies / compute_dependency_hashes
+  - tool_health: find_dependents, list_broken_tools, check_all_tools_health
+    (broken transitions across dep_missing, dep_schema_changed,
+    dep_code_changed, dep_broken; unbreak lifecycle; transitive propagation;
+    preservation of manager-owned server_unavailable state)
+  - ExternalMCPManager.find_dependents excludes self-owned primitives
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from typing import Any, Dict
+
+from skillberry_store.modules.external_mcp_manager import (
+    ExternalMCPManager,
+    _normalize_entry,
+    build_primitive_manifest,
+    normalize_mcp_input,
+    params_from_input_schema,
+    redact_entry,
+)
+from skillberry_store.modules.file_executor import (
+    compute_dependency_hashes,
+    compute_mcp_dependencies,
+    hash_tool_interface,
+)
+from skillberry_store.modules.file_handler import FileHandler
+from skillberry_store.modules.tool_health import (
+    check_all_tools_health,
+    find_dependents,
+    list_broken_tools,
+)
+
+
+# ---------------------------------------------------------------------------
+# normalize_mcp_input
+# ---------------------------------------------------------------------------
+
+
+class NormalizeMCPInputTests(unittest.TestCase):
+    def test_shape1_mcp_servers_dict(self):
+        r = normalize_mcp_input(
+            {
+                "mcpServers": {
+                    "pw": {
+                        "type": "stdio",
+                        "command": "cmd",
+                        "args": ["/c", "npx", "@playwright/mcp@latest"],
+                    },
+                    "st": {
+                        "type": "http",
+                        "url": "https://stitch.googleapis.com/mcp",
+                        "headers": {"X-K": "secret"},
+                    },
+                    "sks": {"type": "sse", "url": "http://localhost:9999/sse"},
+                }
+            }
+        )
+        self.assertEqual(len(r), 3)
+        by_name = {e["name"]: e for e in r}
+        self.assertEqual(by_name["pw"]["transport"], "stdio")
+        self.assertEqual(by_name["st"]["transport"], "http")
+        self.assertEqual(by_name["st"]["headers"]["X-K"], "secret")
+        self.assertEqual(by_name["sks"]["transport"], "sse")
+
+    def test_shape2_bare_dict(self):
+        r = normalize_mcp_input({"foo": {"command": "python", "args": ["-m", "x"]}})
+        self.assertEqual(r[0]["name"], "foo")
+        self.assertEqual(r[0]["transport"], "stdio")
+
+    def test_shape3_list(self):
+        r = normalize_mcp_input([{"name": "bar", "url": "http://x/sse"}])
+        self.assertEqual(r[0]["name"], "bar")
+        self.assertEqual(r[0]["transport"], "sse")
+
+    def test_shape4_single_entry(self):
+        r = normalize_mcp_input({"name": "solo", "type": "http", "url": "http://x/mcp"})
+        self.assertEqual(r[0]["name"], "solo")
+        self.assertEqual(r[0]["transport"], "http")
+
+    def test_shape5_source_url_recurses(self):
+        fetched = {"mcpServers": {"a": {"command": "echo"}}}
+        r = normalize_mcp_input(
+            {"source_url": "http://nowhere.example"}, fetch_url=lambda _u: fetched
+        )
+        self.assertEqual(r[0]["name"], "a")
+
+    def test_stdio_without_command_rejects(self):
+        with self.assertRaises(ValueError):
+            normalize_mcp_input({"xx": {"transport": "stdio"}})
+
+    def test_unknown_transport_rejects(self):
+        with self.assertRaises(ValueError):
+            _normalize_entry("x", {"transport": "weird", "url": "u"})
+
+
+# ---------------------------------------------------------------------------
+# Params conversion + manifest + redaction
+# ---------------------------------------------------------------------------
+
+
+class ParamsAndManifestTests(unittest.TestCase):
+    def test_params_from_input_schema_fills_optional(self):
+        p = params_from_input_schema(
+            {
+                "type": "object",
+                "properties": {"a": {"type": "string"}, "b": {"type": "number"}},
+                "required": ["a"],
+            }
+        )
+        self.assertEqual(p["required"], ["a"])
+        self.assertEqual(p["optional"], ["b"])
+
+    def test_params_from_none_gives_empty_object(self):
+        p = params_from_input_schema(None)
+        self.assertEqual(
+            p, {"type": "object", "properties": {}, "required": [], "optional": []}
+        )
+
+    def test_primitive_manifest_shape(self):
+        m = build_primitive_manifest(
+            "playwright__browser_click",
+            "playwright",
+            "Click a button",
+            {"type": "object", "properties": {}, "required": [], "optional": []},
+        )
+        self.assertEqual(m["packaging_format"], "mcp")
+        self.assertEqual(m["mcp_server"], "playwright")
+        # Primitives carry mcp_server (source); mcp_dependencies is for composites.
+        self.assertEqual(m["mcp_dependencies"], [])
+        self.assertIn("mcp:playwright", m["tags"])
+        self.assertIsNone(m["broken_reason"])
+
+    def test_compute_mcp_dependencies_primitive_returns_own_server(self):
+        """compute_mcp_dependencies must still surface a primitive's source MCP
+        even though primitives now carry empty mcp_dependencies — the source
+        comes from the `mcp_server` field."""
+        from skillberry_store.modules.file_executor import compute_mcp_dependencies
+        prim = build_primitive_manifest(
+            "pw__click", "playwright", "", {"type": "object", "properties": {}}
+        )
+        self.assertEqual(compute_mcp_dependencies(prim, {"pw__click": prim}), ["playwright"])
+
+    def test_redact_entry_masks_headers_and_env(self):
+        red = redact_entry(
+            {
+                "name": "x",
+                "headers": {"X-Api-Key": "verysecrettoken123"},
+                "env": {"TOKEN": "abcdefgh"},
+            }
+        )
+        self.assertNotIn("verysecrettoken123", red["headers"]["X-Api-Key"])
+        self.assertIn("•", red["headers"]["X-Api-Key"])
+        self.assertIn("•", red["env"]["TOKEN"])
+
+
+# ---------------------------------------------------------------------------
+# hash_tool_interface / compute_* helpers
+# ---------------------------------------------------------------------------
+
+
+class HashAndDepsTests(unittest.TestCase):
+    def test_hash_stable_and_sensitive(self):
+        d = {"params": {"type": "object", "properties": {"a": {"type": "str"}}}}
+        p1, m1, c1 = hash_tool_interface(d, "def f(): pass")
+        self.assertEqual(len(p1), 64)
+        p2, _, _ = hash_tool_interface(
+            {"params": {"type": "object", "properties": {"b": {"type": "int"}}}},
+            "def f(): pass",
+        )
+        self.assertNotEqual(p1, p2)
+        _, m2, _ = hash_tool_interface(d, "def f(): return 1")
+        self.assertNotEqual(m1, m2)
+
+    def test_compute_mcp_dependencies_recursive_and_cycle_safe(self):
+        tools = {
+            "A": {
+                "name": "A",
+                "mcp_server": "playwright",
+                "mcp_dependencies": ["playwright"],
+            },
+            "B": {"name": "B", "dependencies": ["A"], "mcp_dependencies": []},
+            "C": {"name": "C", "dependencies": ["B", "A"]},
+        }
+        self.assertEqual(compute_mcp_dependencies(tools["B"], tools), ["playwright"])
+        self.assertEqual(compute_mcp_dependencies(tools["C"], tools), ["playwright"])
+        # Cycle safety
+        cyc = {
+            "X": {"name": "X", "dependencies": ["Y"]},
+            "Y": {"name": "Y", "dependencies": ["X"], "mcp_dependencies": ["foo"]},
+        }
+        self.assertEqual(compute_mcp_dependencies(cyc["X"], cyc), ["foo"])
+
+    def test_compute_dependency_hashes_splits_components(self):
+        tools = {
+            "A": {
+                "name": "A",
+                "params": {"type": "object", "properties": {"x": {"type": "str"}}},
+            }
+        }
+        out = compute_dependency_hashes(
+            {"name": "B", "dependencies": ["A"]}, tools, {"A": "def A(x): return x"}
+        )
+        self.assertIn("A", out)
+        entry = out["A"]
+        self.assertIn("params", entry)
+        self.assertIn("module", entry)
+        self.assertIn("combined", entry)
+        # Changing A's code changes module hash but not params hash
+        out2 = compute_dependency_hashes(
+            {"name": "B", "dependencies": ["A"]}, tools, {"A": "def A(x): return 42"}
+        )
+        self.assertEqual(out2["A"]["params"], entry["params"])
+        self.assertNotEqual(out2["A"]["module"], entry["module"])
+
+
+# ---------------------------------------------------------------------------
+# tool_health
+# ---------------------------------------------------------------------------
+
+
+class ToolHealthTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.tools_dir = os.path.join(self.tmp, "tools")
+        self.files_dir = os.path.join(self.tmp, "files")
+        os.makedirs(self.tools_dir)
+        os.makedirs(self.files_dir)
+        self.th = FileHandler(self.tools_dir)
+        self.fh = FileHandler(self.files_dir)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _write_tool(self, d: Dict[str, Any]):
+        self.th.write_file_content(f"{d['name']}.json", json.dumps(d))
+
+    def _read_tool(self, name: str) -> Dict[str, Any]:
+        return json.loads(self.th.read_file(f"{name}.json", raw_content=True))
+
+    def _primitive(self, name: str, server: str = "s1") -> Dict[str, Any]:
+        return {
+            "name": name,
+            "packaging_format": "mcp",
+            "mcp_server": server,
+            "mcp_dependencies": [server],
+            "state": "approved",
+            "params": {
+                "type": "object",
+                "properties": {"x": {"type": "string"}},
+                "required": ["x"],
+                "optional": [],
+            },
+            "module_name": None,
+            "dependencies": None,
+            "dependency_hashes": {},
+            "broken_reason": None,
+        }
+
+    def test_find_dependents_and_list_broken(self):
+        A = self._primitive("A")
+        B = {
+            "name": "B",
+            "packaging_format": "code",
+            "dependencies": ["A"],
+            "mcp_dependencies": ["s1"],
+            "state": "approved",
+            "params": {"type": "object", "properties": {}, "required": [], "optional": []},
+            "module_name": "B.py",
+            "dependency_hashes": compute_dependency_hashes(
+                {"dependencies": ["A"]}, {"A": A}, {"A": ""}
+            ),
+            "broken_reason": None,
+        }
+        self._write_tool(A)
+        self._write_tool(B)
+        self.fh.write_file_content("B.py", "def B(): A(x='hi')")
+
+        self.assertEqual(find_dependents("A", self.th), ["B"])
+        self.assertEqual(list_broken_tools(self.th), [])
+
+    def test_check_all_tools_health_schema_change_breaks_and_unbreaks(self):
+        A = self._primitive("A")
+        B = {
+            "name": "B",
+            "packaging_format": "code",
+            "dependencies": ["A"],
+            "mcp_dependencies": ["s1"],
+            "state": "approved",
+            "params": {"type": "object", "properties": {}, "required": [], "optional": []},
+            "module_name": "B.py",
+            "dependency_hashes": compute_dependency_hashes(
+                {"dependencies": ["A"]}, {"A": A}, {"A": ""}
+            ),
+            "broken_reason": None,
+        }
+        self._write_tool(A)
+        self._write_tool(B)
+        self.fh.write_file_content("B.py", "def B(): A(x='hi')")
+
+        # Healthy initially
+        r = check_all_tools_health(self.th, self.fh)
+        self.assertEqual(r["broken"], [])
+
+        # Mutate A's params schema → B goes broken with dep_schema_changed
+        A2 = dict(A)
+        A2["params"] = {
+            "type": "object",
+            "properties": {"y": {"type": "int"}},
+            "required": ["y"],
+            "optional": [],
+        }
+        self._write_tool(A2)
+        r = check_all_tools_health(self.th, self.fh)
+        names = {b["name"]: b["reason"] for b in r["broken"]}
+        self.assertEqual(names.get("B"), "dep_schema_changed:A")
+
+        # Restore A → B unbreaks
+        self._write_tool(A)
+        r = check_all_tools_health(self.th, self.fh)
+        self.assertIn("B", r["unbroken"])
+        self.assertEqual(self._read_tool("B")["state"], "approved")
+
+    def test_check_all_tools_health_dep_missing(self):
+        A = self._primitive("A")
+        B = {
+            "name": "B",
+            "packaging_format": "code",
+            "dependencies": ["A"],
+            "mcp_dependencies": [],
+            "state": "approved",
+            "params": {"type": "object", "properties": {}, "required": [], "optional": []},
+            "module_name": None,
+            "dependency_hashes": compute_dependency_hashes(
+                {"dependencies": ["A"]}, {"A": A}, {"A": ""}
+            ),
+            "broken_reason": None,
+        }
+        self._write_tool(A)
+        self._write_tool(B)
+        self.th.delete_file("A.json")
+        r = check_all_tools_health(self.th, self.fh)
+        names = {b["name"]: b["reason"] for b in r["broken"]}
+        self.assertEqual(names.get("B"), "dep_missing:A")
+
+    def test_check_all_tools_health_preserves_server_unavailable(self):
+        A = self._primitive("A")
+        A["state"] = "broken"
+        A["broken_reason"] = "server_unavailable:s1"
+        B = {
+            "name": "B",
+            "packaging_format": "code",
+            "dependencies": ["A"],
+            "mcp_dependencies": ["s1"],
+            "state": "approved",
+            "params": {"type": "object", "properties": {}, "required": [], "optional": []},
+            "module_name": None,
+            "dependency_hashes": compute_dependency_hashes(
+                {"dependencies": ["A"]}, {"A": self._primitive("A")}, {"A": ""}
+            ),
+            "broken_reason": None,
+        }
+        self._write_tool(A)
+        self._write_tool(B)
+        r = check_all_tools_health(self.th, self.fh)
+
+        a_now = self._read_tool("A")
+        self.assertEqual(a_now["state"], "broken")
+        self.assertEqual(a_now["broken_reason"], "server_unavailable:s1")
+        # Transitive propagation → B also broken with dep_broken reason
+        b_now = self._read_tool("B")
+        self.assertEqual(b_now["state"], "broken")
+        self.assertEqual(b_now["broken_reason"], "dep_broken:A")
+
+
+# ---------------------------------------------------------------------------
+# ExternalMCPManager.find_dependents
+# ---------------------------------------------------------------------------
+
+
+class ManagerFindDependentsTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        for sub in ("tools", "files", "mcps"):
+            os.makedirs(os.path.join(self.tmp, sub))
+        self.th = FileHandler(os.path.join(self.tmp, "tools"))
+        self.fh = FileHandler(os.path.join(self.tmp, "files"))
+        self.ch = FileHandler(os.path.join(self.tmp, "mcps"))
+        self.mgr = ExternalMCPManager(
+            tool_handler=self.th, file_handler=self.fh, config_handler=self.ch
+        )
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_excludes_self_owned_primitives(self):
+        # Two primitives from server 'p'.
+        p1 = build_primitive_manifest(
+            "p__a", "p", "", params_from_input_schema(None)
+        )
+        p2 = build_primitive_manifest(
+            "p__b", "p", "", params_from_input_schema(None)
+        )
+        # A composite on p's primitives.
+        comp = {
+            "name": "wrapper",
+            "packaging_format": "code",
+            "mcp_server": None,
+            "mcp_dependencies": ["p"],
+            "dependencies": ["p__a"],
+            "state": "approved",
+        }
+        for d in (p1, p2, comp):
+            self.th.write_file_content(f"{d['name']}.json", json.dumps(d))
+
+        dependents = self.mgr.find_dependents("p")
+        # Primitives (p__a, p__b) are excluded — they're cascade-deleted, not
+        # "broken"-flagged — only the real composite shows up.
+        self.assertEqual(dependents, ["wrapper"])
+
+
+# ---------------------------------------------------------------------------
+# bundled_with_mcps default + primitive manifest
+# ---------------------------------------------------------------------------
+
+
+class BundledWithMcpsTests(unittest.TestCase):
+    def test_primitive_manifest_defaults_bundled_true(self):
+        m = build_primitive_manifest(
+            "ctx7__query-docs",
+            "context7",
+            "docs",
+            params_from_input_schema(None),
+        )
+        self.assertEqual(m["bundled_with_mcps"], True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/skillberry_store/tools/anthropic/exporter.py
+++ b/src/skillberry_store/tools/anthropic/exporter.py
@@ -4,8 +4,49 @@
 """Exporter for converting Skillberry skills to Anthropic skill format."""
 
 import io
+import json
+import re
 import zipfile
 from typing import Dict, List, Optional, Any
+
+
+def _redact_mcp_servers_for_export(
+    servers: List[Dict[str, Any]],
+) -> Dict[str, Dict[str, Any]]:
+    """Convert a list of normalized MCP server entries into an `mcpServers` dict
+    where every header value and every env value is replaced with a `${NAME}`
+    placeholder so secrets are never baked into a shareable skill bundle.
+    """
+    out: Dict[str, Dict[str, Any]] = {}
+    for entry in servers:
+        name = entry.get("name")
+        if not name:
+            continue
+        e: Dict[str, Any] = {"type": entry.get("transport") or "sse"}
+        if entry.get("command"):
+            e["command"] = entry["command"]
+        if entry.get("args"):
+            e["args"] = list(entry["args"])
+        if entry.get("url"):
+            e["url"] = entry["url"]
+        env = entry.get("env") or {}
+        if env:
+            e["env"] = {
+                k: "${" + _slugify_env_name(f"{name}_{k}") + "}"
+                for k in env.keys()
+            }
+        headers = entry.get("headers") or {}
+        if headers:
+            e["headers"] = {
+                k: "${" + _slugify_env_name(f"{name}_{k}") + "}"
+                for k in headers.keys()
+            }
+        out[name] = e
+    return out
+
+
+def _slugify_env_name(raw: str) -> str:
+    return re.sub(r"[^A-Z0-9_]", "_", raw.upper()).strip("_") or "SECRET"
 
 
 def extract_file_path_from_tags(tags: Optional[List[str]]) -> Optional[str]:
@@ -265,16 +306,20 @@ def export_skill_to_anthropic_format(
     skill: Dict[str, Any],
     tools: List[Dict[str, Any]],
     snippets: List[Dict[str, Any]],
-    tool_modules: Optional[Dict[str, str]] = None
+    tool_modules: Optional[Dict[str, str]] = None,
+    mcp_servers: Optional[List[Dict[str, Any]]] = None,
 ) -> bytes:
     """Export skill to Anthropic format as a ZIP file.
-    
+
     Args:
         skill: The skill dictionary
         tools: List of tool dictionaries
         snippets: List of snippet dictionaries
         tool_modules: Dictionary mapping tool names to module content
-        
+        mcp_servers: Optional list of external MCP server configs to bundle
+            alongside the skill. Secrets in `headers`/`env` are redacted to
+            `${ENV_VAR}` placeholders before bundling.
+
     Returns:
         ZIP file content as bytes
     """
@@ -324,7 +369,17 @@ def export_skill_to_anthropic_format(
             # Ensure content ends with a single newline (standard for text files)
             normalized_content = content if content.endswith('\n') else content + '\n'
             zip_file.writestr(f"{skill_name}/{file_path}", normalized_content)
-    
+
+        # Bundle external MCP server configs if requested, with secrets
+        # redacted to `${ENV_NAME}` placeholders. The importer side matches
+        # on this exact filename.
+        if mcp_servers:
+            redacted = _redact_mcp_servers_for_export(mcp_servers)
+            zip_file.writestr(
+                f"{skill_name}/mcp-servers.json",
+                json.dumps({"mcpServers": redacted}, indent=2) + "\n",
+            )
+
     # Get the ZIP content
     zip_buffer.seek(0)
     return zip_buffer.read()

--- a/src/skillberry_store/tools/anthropic/importer.py
+++ b/src/skillberry_store/tools/anthropic/importer.py
@@ -214,21 +214,42 @@ def read_from_folder(folder_path: str) -> List[Dict[str, str]]:
     return files
 
 
+def _extract_mcp_servers_payload(files: List[Dict[str, str]]) -> Optional[Dict[str, Any]]:
+    """Look for a sidecar `mcp-servers.json` in the bundle.
+
+    Accepts either the standard `{"mcpServers": {...}}` wrapper shape or a
+    bare name->entry dict. Returns the parsed JSON (any shape `normalize_mcp_input`
+    understands), or None if no file is present / parse fails.
+    """
+    for f in files:
+        name = (f.get('name') or '').lower()
+        if name == 'mcp-servers.json' or name == 'mcp_servers.json':
+            try:
+                import json as _json
+                return _json.loads(f['content'])
+            except Exception:
+                return None
+    return None
+
+
 def import_anthropic_skill(
     source_type: str,
     source_data: Any,
     snippet_mode: str = 'file'
-) -> Tuple[str, str, List[Any], List[Any], List[str]]:
+) -> Tuple[str, str, List[Any], List[Any], List[str], Optional[Dict[str, Any]]]:
     """Import Anthropic skill from various sources.
-    
+
     Args:
         source_type: 'url', 'zip', or 'folder'
         source_data: URL string, ZIP bytes, or list of file dicts
         snippet_mode: 'file' or 'paragraph'
-        
+
     Returns:
-        Tuple of (skill_name, skill_description, tools, snippets, ignored_files)
-        
+        Tuple of (skill_name, skill_description, tools, snippets, ignored_files,
+        mcp_servers_payload). `mcp_servers_payload` is the raw parsed content
+        of a bundled `mcp-servers.json` (or None if absent), suitable to hand
+        straight to `normalize_mcp_input`.
+
     Raises:
         Exception: If import fails
     """
@@ -305,4 +326,15 @@ def import_anthropic_skill(
         tools = code_parse_result['tools']
         ignored_files = code_parse_result['ignoredFiles']
     
-    return skill_name, skill_description, tools, snippets, ignored_files
+    # Step 4: Detect bundled external MCP servers (new-feature-aware imports
+    # carry a sidecar `mcp-servers.json`; legacy bundles simply return None).
+    mcp_servers_payload = _extract_mcp_servers_payload(files)
+
+    return (
+        skill_name,
+        skill_description,
+        tools,
+        snippets,
+        ignored_files,
+        mcp_servers_payload,
+    )

--- a/src/skillberry_store/tools/configure.py
+++ b/src/skillberry_store/tools/configure.py
@@ -187,6 +187,22 @@ def get_tools_directory():
     return default_path
 
 
+def get_external_mcps_directory():
+    """
+    Get the directory path for external MCP server configs.
+
+    One JSON file per server describes how the store should connect to a
+    user-imported MCP server (transport + command/url/headers/env).
+    """
+    env_path = os.getenv("SBS_EXTERNAL_MCPS_DIRECTORY")
+    if env_path:
+        logger.info(f"Using external MCPs directory from environment: {env_path}")
+        return env_path
+    default_path = _default_sbs_dir("external_mcps")
+    logger.info(f"Using default external MCPs directory: {default_path}")
+    return default_path
+
+
 def get_snippets_descriptions_directory():
     """
     Get the directory path for snippet descriptions.
@@ -239,6 +255,36 @@ def get_vmcp_descriptions_directory():
     default_path = _default_sbs_dir("vmcp_descriptions")
     logger.info(f"Using default vmcp descriptions directory: {default_path}")
     return default_path
+
+def get_ai_features_directory():
+    """
+    Get the directory path for AI features settings.
+
+    Retained for the runspace-plugin migration shim: on first boot, if the
+    old ai_features/settings.json exists and the new runspace plugin
+    settings file does not, it is copied over.
+    """
+    env_path = os.getenv("SBS_AI_FEATURES_DIRECTORY")
+    if env_path:
+        logger.info(f"Using AI features directory from environment: {env_path}")
+        return env_path
+    default_path = _default_sbs_dir("ai_features")
+    logger.info(f"Using default AI features directory: {default_path}")
+    return default_path
+
+
+def get_plugins_directory():
+    """Root directory for plugin state: $SBS_BASE_DIR/plugins/"""
+    env_path = os.getenv("SBS_PLUGINS_DIRECTORY")
+    if env_path:
+        return env_path
+    return _default_sbs_dir("plugins")
+
+
+def get_plugin_directory(plugin_id: str):
+    """Per-plugin data directory: $SBS_BASE_DIR/plugins/<plugin_id>/"""
+    return os.path.join(get_plugins_directory(), plugin_id)
+
 
 def is_auto_detect_dependencies_enabled():
     """

--- a/src/skillberry_store/ui/src/App.tsx
+++ b/src/skillberry_store/ui/src/App.tsx
@@ -1,6 +1,7 @@
 // Copyright 2025 IBM Corp.
 // Licensed under the Apache License, Version 2.0
 
+import { useEffect } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import { AppLayout } from './components/AppLayout';
 import { HomePage } from './pages/HomePage';
@@ -12,38 +13,72 @@ import { SnippetsPage } from './pages/SnippetsPage';
 import { SnippetDetailPage } from './pages/SnippetDetailPage';
 import { VMCPServersPage } from './pages/VMCPServersPage';
 import { VMCPServerDetailPage } from './pages/VMCPServerDetailPage';
+import { ExternalMCPsPage } from './pages/ExternalMCPsPage';
+import { ExternalMCPDetailPage } from './pages/ExternalMCPDetailPage';
 import { AdminPage } from './pages/AdminPage';
 import { ObservabilityPage } from './pages/ObservabilityPage';
+import { AgentConnectPage } from './pages/AgentConnectPage';
+import { PluginsPage } from './pages/PluginsPage';
+
 import { NotFoundPage } from './pages/NotFoundPage';
+import { pluginsApi } from '@/services/api';
+import { applyPluginsListFromBackend, useActiveManifests } from '@/plugins/registry';
 
 function App() {
+  const activeManifests = useActiveManifests();
+
+  useEffect(() => {
+    pluginsApi.list()
+      .then((items) => applyPluginsListFromBackend(items))
+      .catch(() => {
+        // If /plugins isn't available, no plugins render — safe default.
+      });
+  }, []);
+
   return (
     <AppLayout>
       <Routes>
         <Route path="/" element={<HomePage />} />
-        
+
         {/* Tools routes */}
         <Route path="/tools" element={<ToolsPage />} />
         <Route path="/tools/:name" element={<ToolDetailPage />} />
-        
+
         {/* Skills routes */}
         <Route path="/skills" element={<SkillsPage />} />
         <Route path="/skills/:name" element={<SkillDetailPage />} />
-        
+
         {/* Snippets routes */}
         <Route path="/snippets" element={<SnippetsPage />} />
         <Route path="/snippets/:name" element={<SnippetDetailPage />} />
-        
+
         {/* Virtual MCP Servers routes */}
         <Route path="/vmcp-servers" element={<VMCPServersPage />} />
         <Route path="/vmcp-servers/:name" element={<VMCPServerDetailPage />} />
-        
+
+        {/* External MCPs routes (imported MCP servers the store consumes) */}
+        <Route path="/external-mcps" element={<ExternalMCPsPage />} />
+        <Route path="/external-mcps/:name" element={<ExternalMCPDetailPage />} />
+
         {/* Admin route */}
         <Route path="/admin" element={<AdminPage />} />
-        
+
         {/* Observability route */}
         <Route path="/observability" element={<ObservabilityPage />} />
-        
+
+        {/* Agent Connect route */}
+        <Route path="/agent-connect" element={<AgentConnectPage />} />
+
+        {/* Plugins */}
+        <Route path="/plugins" element={<PluginsPage />} />
+
+        {/* Plugin-contributed routes */}
+        {activeManifests.flatMap((m) =>
+          m.routes.map((r) => (
+            <Route key={`${m.id}:${r.path}`} path={r.path} element={r.element} />
+          ))
+        )}
+
         {/* 404 */}
         <Route path="*" element={<NotFoundPage />} />
       </Routes>

--- a/src/skillberry_store/ui/src/components/AppLayout.tsx
+++ b/src/skillberry_store/ui/src/components/AppLayout.tsx
@@ -21,6 +21,7 @@ import {
   Divider,
 } from '@patternfly/react-core';
 import { BarsIcon } from '@patternfly/react-icons';
+import { useActiveManifests } from '@/plugins/registry';
 
 interface AppLayoutProps {
   children: React.ReactNode;
@@ -30,6 +31,8 @@ export function AppLayout({ children }: AppLayoutProps) {
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
   const navigate = useNavigate();
   const location = useLocation();
+  const activeManifests = useActiveManifests();
+  const pluginNavItems = activeManifests.flatMap((m) => m.navItems);
 
   const navItems = [
     { id: 'home', label: 'Home', path: '/' },
@@ -112,6 +115,17 @@ export function AppLayout({ children }: AppLayoutProps) {
               Virtual MCP Servers
             </NavItem>
 
+            {/* External MCPs (imported MCP servers whose tools this store consumes) */}
+            <NavItem
+              key="external-mcps"
+              itemId="external-mcps"
+              isActive={location.pathname === '/external-mcps' ||
+                       location.pathname.startsWith('/external-mcps')}
+              onClick={() => navigate('/external-mcps')}
+            >
+              External MCPs
+            </NavItem>
+
             <Divider style={{ margin: '0.5rem 0' }} />
 
             {/* Observability */}
@@ -122,6 +136,38 @@ export function AppLayout({ children }: AppLayoutProps) {
               onClick={() => navigate('/observability')}
             >
               Observability
+            </NavItem>
+
+            {/* Connect Your Agent */}
+            <NavItem
+              key="agent-connect"
+              itemId="agent-connect"
+              isActive={location.pathname === '/agent-connect'}
+              onClick={() => navigate('/agent-connect')}
+            >
+              Connect Your Agent
+            </NavItem>
+
+            {/* Plugin-contributed nav items */}
+            {pluginNavItems.map((item) => (
+              <NavItem
+                key={item.id}
+                itemId={item.id}
+                isActive={location.pathname === item.path}
+                onClick={() => navigate(item.path)}
+              >
+                {item.label}
+              </NavItem>
+            ))}
+
+            {/* Plugins */}
+            <NavItem
+              key="plugins"
+              itemId="plugins"
+              isActive={location.pathname === '/plugins'}
+              onClick={() => navigate('/plugins')}
+            >
+              Plugins
             </NavItem>
 
             {/* Admin */}

--- a/src/skillberry_store/ui/src/hooks/useMCPClient.ts
+++ b/src/skillberry_store/ui/src/hooks/useMCPClient.ts
@@ -40,7 +40,7 @@ interface MCPClientState {
   prompts: MCPPrompt[];
 }
 
-export function useMCPClient(serverPort: number | undefined, serverName: string) {
+export function useMCPClient(serverPort: number | undefined, serverName: string, sseUrl?: string) {
   const [state, setState] = useState<MCPClientState>({
     isConnected: false,
     isConnecting: false,
@@ -52,13 +52,13 @@ export function useMCPClient(serverPort: number | undefined, serverName: string)
   const [client, setClient] = useState<Client | null>(null);
 
   const connect = useCallback(async () => {
-    if (!serverPort) {
-      console.error('[MCP Client] No server port provided');
-      setState(prev => ({ ...prev, error: 'Server port not available' }));
+    if (!sseUrl && !serverPort) {
+      console.error('[MCP Client] No server port or URL provided');
+      setState(prev => ({ ...prev, error: 'Server port or URL not available' }));
       return;
     }
 
-    console.log(`[MCP Client] Starting connection to port ${serverPort}`);
+    console.log(`[MCP Client] Starting connection to ${sseUrl || `port ${serverPort}`}`);
     setState(prev => ({ ...prev, isConnecting: true, error: null }));
 
     try {
@@ -79,10 +79,10 @@ export function useMCPClient(serverPort: number | undefined, serverName: string)
       console.log('[MCP Client] MCP client created successfully');
 
       // Create SSE transport
-      const sseUrl = `http://localhost:${serverPort}/sse`;
-      console.log(`[MCP Client] Creating SSE transport to ${sseUrl}`);
+      const resolvedUrl = sseUrl || `http://localhost:${serverPort}/sse`;
+      console.log(`[MCP Client] Creating SSE transport to ${resolvedUrl}`);
       const transport = new SSEClientTransport(
-        new URL(sseUrl)
+        new URL(resolvedUrl)
       );
       console.log('[MCP Client] SSE transport created');
 
@@ -101,15 +101,21 @@ export function useMCPClient(serverPort: number | undefined, serverName: string)
         inputSchema: tool.inputSchema,
       }));
 
-      // List available prompts
-      console.log('[MCP Client] Listing prompts...');
-      const promptsResponse = await mcpClient.listPrompts();
-      console.log(`[MCP Client] Received ${promptsResponse.prompts.length} prompts:`, promptsResponse.prompts);
-      const prompts = promptsResponse.prompts.map((prompt: any) => ({
-        name: prompt.name,
-        description: prompt.description,
-        arguments: prompt.arguments,
-      }));
+      // List available prompts — optional capability, some servers (e.g. FastApiMCP)
+      // don't implement prompts/list and return -32601 Method not found.
+      let prompts: MCPPrompt[] = [];
+      try {
+        console.log('[MCP Client] Listing prompts...');
+        const promptsResponse = await mcpClient.listPrompts();
+        console.log(`[MCP Client] Received ${promptsResponse.prompts.length} prompts:`, promptsResponse.prompts);
+        prompts = promptsResponse.prompts.map((prompt: any) => ({
+          name: prompt.name,
+          description: prompt.description,
+          arguments: prompt.arguments,
+        }));
+      } catch (promptsError) {
+        console.log('[MCP Client] Server does not support prompts/list — skipping.', promptsError);
+      }
 
       setClient(mcpClient);
       setState({
@@ -135,7 +141,7 @@ export function useMCPClient(serverPort: number | undefined, serverName: string)
         prompts: [],
       });
     }
-  }, [serverPort]);
+  }, [serverPort, sseUrl]);
 
   const disconnect = useCallback(async () => {
     if (client) {
@@ -178,10 +184,10 @@ export function useMCPClient(serverPort: number | undefined, serverName: string)
     }
   }, [client, state.isConnected]);
 
-  // Auto-connect when component mounts
+  // Auto-connect when component mounts or sseUrl/serverPort changes
   useEffect(() => {
-    console.log(`[MCP Client] useEffect triggered - serverPort: ${serverPort}, serverName: ${serverName}`);
-    if (serverPort) {
+    console.log(`[MCP Client] useEffect triggered - serverPort: ${serverPort}, serverName: ${serverName}, sseUrl: ${sseUrl}`);
+    if (serverPort || sseUrl) {
       connect();
     }
 
@@ -192,7 +198,7 @@ export function useMCPClient(serverPort: number | undefined, serverName: string)
         client.close().catch(console.error);
       }
     };
-  }, [serverPort]);
+  }, [serverPort, sseUrl]);
 
   return {
     ...state,

--- a/src/skillberry_store/ui/src/pages/AgentConnectPage.tsx
+++ b/src/skillberry_store/ui/src/pages/AgentConnectPage.tsx
@@ -1,0 +1,475 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+
+import { useState, useEffect } from 'react';
+import {
+  PageSection,
+  Title,
+  Card,
+  CardBody,
+  CardTitle,
+  Alert,
+  Spinner,
+  CodeBlock,
+  CodeBlockCode,
+  ClipboardCopyButton,
+  ExpandableSection,
+  Label,
+  DescriptionList,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  DescriptionListDescription,
+  Button,
+  Text,
+  ToggleGroup,
+  ToggleGroupItem,
+} from '@patternfly/react-core';
+import { CheckCircleIcon, ExclamationCircleIcon, PluggedIcon, UnpluggedIcon } from '@patternfly/react-icons';
+import { adminApi } from '@/services/api';
+import type { ServerInfo } from '@/services/api';
+import { useMCPClient } from '@/hooks/useMCPClient';
+
+type McpScope = 'project' | 'user';
+type McpMode = 'curated' | 'full';
+
+export function AgentConnectPage() {
+  const [copiedField, setCopiedField] = useState<string | null>(null);
+  const [isManualConfigExpanded, setIsManualConfigExpanded] = useState(false);
+  const [isTestingConnection, setIsTestingConnection] = useState(false);
+  const [serverInfo, setServerInfo] = useState<ServerInfo | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [mcpScope, setMcpScope] = useState<McpScope>('project');
+  const [mcpMode, setMcpMode] = useState<McpMode>('curated');
+
+  useEffect(() => {
+    adminApi.getServerInfo()
+      .then((info) => setServerInfo(info))
+      .catch((err) => setLoadError(err.message))
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  const curatedMcpUrl = serverInfo?.agent_mcp_url || `http://localhost:${serverInfo?.agent_mcp_port || 9999}/sse`;
+  const fullMcpUrl = serverInfo?.control_mcp_url || `http://localhost:${serverInfo?.port || 8000}/control_sse`;
+
+  const isCurated = mcpMode === 'curated';
+  const mcpUrl = isCurated ? curatedMcpUrl : fullMcpUrl;
+  const mcpServerName = isCurated ? 'skillberry-store' : 'skillberry-store-full';
+
+  const mcpClient = useMCPClient(undefined, mcpServerName, isTestingConnection ? mcpUrl : undefined);
+
+  const handleCopy = (text: string, field: string) => {
+    navigator.clipboard.writeText(text);
+    setCopiedField(field);
+    setTimeout(() => setCopiedField(null), 2000);
+  };
+
+  const scopeFlag = mcpScope === 'project' ? 'project' : 'user';
+  const addCommand = `claude mcp add ${mcpServerName} -s ${scopeFlag} -t sse ${mcpUrl}`;
+  const removeCommand = `claude mcp remove ${mcpServerName} -s ${scopeFlag}`;
+
+  const settingsJson = JSON.stringify({
+    mcpServers: {
+      [mcpServerName]: {
+        url: mcpUrl,
+      },
+    },
+  }, null, 2);
+
+  if (isLoading) {
+    return (
+      <PageSection>
+        <div style={{ display: 'flex', justifyContent: 'center', padding: '4rem' }}>
+          <Spinner size="xl" />
+        </div>
+      </PageSection>
+    );
+  }
+
+  return (
+    <>
+      <PageSection>
+        <Title headingLevel="h1" size="2xl">
+          Connect Your Agent
+        </Title>
+        <Text style={{ marginTop: '0.5rem', color: '#6a6e73' }}>
+          Connect AI agents to the Skillberry Store via MCP.
+          Once connected, your agent can list, create, update, and manage tools, skills, snippets, and VMCP servers.
+        </Text>
+        <Text style={{ marginTop: '0.75rem', color: '#6a6e73' }}>
+          Two endpoints are available:
+        </Text>
+        <ul style={{ margin: '0.25rem 0 0 0', paddingLeft: '1.25rem', color: '#6a6e73', lineHeight: '1.7' }}>
+          <li>
+            <strong>Curated</strong> (default, port 9999) — a compact, hand-picked set of ~15 tools with
+            LLM-friendly names and docstrings. Smaller context footprint, fewer tokens spent on tool discovery.
+            Recommended for most agent workflows.
+          </li>
+          <li>
+            <strong>Full</strong> (port 8000) — every FastAPI route auto-exposed as an MCP tool.
+            More complete coverage (delete, snippets, admin, import/export, etc.) but larger context footprint
+            and HTTP-style tool names. Pick this when the curated set is missing an operation you need.
+          </li>
+        </ul>
+      </PageSection>
+
+      <PageSection>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+          {loadError && (
+            <Alert variant="warning" title="Could not fetch server info" isInline>
+              {loadError}. Using default values.
+            </Alert>
+          )}
+
+          {/* MCP Endpoint Info */}
+          <Card>
+            <CardTitle>MCP Endpoint</CardTitle>
+            <CardBody>
+              <div style={{ marginBottom: '1rem' }}>
+                <Text component="small" style={{ fontWeight: 600, marginBottom: '0.5rem', display: 'block' }}>
+                  Connection mode:
+                </Text>
+                <ToggleGroup aria-label="MCP mode selection">
+                  <ToggleGroupItem
+                    text="Curated (recommended)"
+                    buttonId="mode-curated"
+                    isSelected={mcpMode === 'curated'}
+                    onChange={() => setMcpMode('curated')}
+                  />
+                  <ToggleGroupItem
+                    text="Full (all FastAPI endpoints)"
+                    buttonId="mode-full"
+                    isSelected={mcpMode === 'full'}
+                    onChange={() => setMcpMode('full')}
+                  />
+                </ToggleGroup>
+                <Text component="small" style={{ marginTop: '0.5rem', display: 'block', color: '#6a6e73', fontSize: '0.8rem' }}>
+                  {isCurated
+                    ? 'A compact, hand-picked set of ~15 tools with LLM-friendly names and docstrings. Smaller context footprint — the agent spends fewer tokens figuring out what to call. Recommended for most agent workflows.'
+                    : 'Exposes every FastAPI route as an MCP tool (auto-generated). More complete coverage (delete, snippets, admin, import/export, etc.) but larger context footprint and HTTP-style tool names. Pick this when the curated set is missing an operation you need.'}
+                </Text>
+              </div>
+              <DescriptionList isHorizontal>
+                <DescriptionListGroup>
+                  <DescriptionListTerm>{isCurated ? 'Agent MCP URL' : 'Full MCP URL'}</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    <code style={{ fontSize: '0.95rem' }}>{mcpUrl}</code>
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+                {serverInfo && (
+                  <>
+                    {!isCurated && (
+                      <DescriptionListGroup>
+                        <DescriptionListTerm>API Docs</DescriptionListTerm>
+                        <DescriptionListDescription>
+                          <a href={serverInfo.api_docs} target="_blank" rel="noopener noreferrer">
+                            {serverInfo.api_docs}
+                          </a>
+                          <Text component="small" style={{ display: 'block', color: '#6a6e73', fontSize: '0.8rem', marginTop: '0.25rem' }}>
+                            The Full MCP exposes every route from this OpenAPI surface.
+                          </Text>
+                        </DescriptionListDescription>
+                      </DescriptionListGroup>
+                    )}
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Status</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {isCurated ? (
+                          <Label color={serverInfo.agent_mcp_url ? 'green' : 'orange'}>
+                            {serverInfo.agent_mcp_url ? 'Running' : 'Not yet started'}
+                          </Label>
+                        ) : (
+                          <Label color="green">Running</Label>
+                        )}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                  </>
+                )}
+              </DescriptionList>
+            </CardBody>
+          </Card>
+
+          {/* Claude Code CLI Commands */}
+          <Card>
+            <CardTitle>Claude Code CLI Commands</CardTitle>
+            <CardBody>
+              <Text style={{ marginBottom: '1rem' }}>
+                Run these commands in your terminal to connect or disconnect Claude Code:
+              </Text>
+
+              <div style={{ marginBottom: '1rem' }}>
+                <Text component="small" style={{ fontWeight: 600, marginBottom: '0.5rem', display: 'block' }}>
+                  Install scope:
+                </Text>
+                <ToggleGroup aria-label="MCP scope selection">
+                  <ToggleGroupItem
+                    text="This project only"
+                    buttonId="scope-project"
+                    isSelected={mcpScope === 'project'}
+                    onChange={() => setMcpScope('project')}
+                  />
+                  <ToggleGroupItem
+                    text="Global (all projects)"
+                    buttonId="scope-user"
+                    isSelected={mcpScope === 'user'}
+                    onChange={() => setMcpScope('user')}
+                  />
+                </ToggleGroup>
+                <Text component="small" style={{ marginTop: '0.5rem', display: 'block', color: '#6a6e73', fontSize: '0.8rem' }}>
+                  {mcpScope === 'project'
+                    ? 'Saves to .claude/settings.json in your project — only available when working in this repo.'
+                    : 'Saves to ~/.claude/settings.json — available across all your projects.'}
+                </Text>
+              </div>
+
+              <div style={{ marginBottom: '1.5rem' }}>
+                <Text component="small" style={{ fontWeight: 600, marginBottom: '0.5rem', display: 'block' }}>
+                  Add MCP server:
+                </Text>
+                <CodeBlock
+                  actions={
+                    <ClipboardCopyButton
+                      id="copy-add-cmd"
+                      textId="add-cmd"
+                      aria-label="Copy add command"
+                      onClick={() => handleCopy(addCommand, 'add')}
+                      variant="plain"
+                    >
+                      {copiedField === 'add' ? 'Copied!' : 'Copy'}
+                    </ClipboardCopyButton>
+                  }
+                >
+                  <CodeBlockCode id="add-cmd">{addCommand}</CodeBlockCode>
+                </CodeBlock>
+              </div>
+
+              <div style={{ marginBottom: '1.5rem' }}>
+                <Text component="small" style={{ fontWeight: 600, marginBottom: '0.5rem', display: 'block' }}>
+                  Remove MCP server:
+                </Text>
+                <CodeBlock
+                  actions={
+                    <ClipboardCopyButton
+                      id="copy-remove-cmd"
+                      textId="remove-cmd"
+                      aria-label="Copy remove command"
+                      onClick={() => handleCopy(removeCommand, 'remove')}
+                      variant="plain"
+                    >
+                      {copiedField === 'remove' ? 'Copied!' : 'Copy'}
+                    </ClipboardCopyButton>
+                  }
+                >
+                  <CodeBlockCode id="remove-cmd">{removeCommand}</CodeBlockCode>
+                </CodeBlock>
+              </div>
+
+              <ExpandableSection
+                toggleText={isManualConfigExpanded ? 'Hide JSON config' : 'Or add JSON config to your agent'}
+                isExpanded={isManualConfigExpanded}
+                onToggle={(_event, expanded) => setIsManualConfigExpanded(expanded)}
+              >
+                <Text style={{ marginBottom: '0.75rem' }}>
+                  Add the following MCP server configuration to your agent:
+                </Text>
+                <CodeBlock
+                  actions={
+                    <ClipboardCopyButton
+                      id="copy-json"
+                      textId="json-config"
+                      aria-label="Copy JSON config"
+                      onClick={() => handleCopy(settingsJson, 'json')}
+                      variant="plain"
+                    >
+                      {copiedField === 'json' ? 'Copied!' : 'Copy'}
+                    </ClipboardCopyButton>
+                  }
+                >
+                  <CodeBlockCode id="json-config">{settingsJson}</CodeBlockCode>
+                </CodeBlock>
+              </ExpandableSection>
+            </CardBody>
+          </Card>
+
+          {/* Connection Test */}
+          <Card>
+            <CardTitle>Connection Test</CardTitle>
+            <CardBody>
+              <div style={{ marginBottom: '1rem' }}>
+                <Text component="small" style={{ fontWeight: 600, marginBottom: '0.5rem', display: 'block' }}>
+                  Test against:
+                </Text>
+                <ToggleGroup aria-label="Connection test target">
+                  <ToggleGroupItem
+                    text="Curated MCP"
+                    buttonId="test-mode-curated"
+                    isSelected={mcpMode === 'curated'}
+                    onChange={() => {
+                      if (isTestingConnection) {
+                        mcpClient.disconnect();
+                        setIsTestingConnection(false);
+                      }
+                      setMcpMode('curated');
+                    }}
+                  />
+                  <ToggleGroupItem
+                    text="Full MCP (over FastAPI)"
+                    buttonId="test-mode-full"
+                    isSelected={mcpMode === 'full'}
+                    onChange={() => {
+                      if (isTestingConnection) {
+                        mcpClient.disconnect();
+                        setIsTestingConnection(false);
+                      }
+                      setMcpMode('full');
+                    }}
+                  />
+                </ToggleGroup>
+                <Text component="small" style={{ marginTop: '0.5rem', display: 'block', color: '#6a6e73', fontSize: '0.8rem' }}>
+                  Currently targeting: <code>{mcpUrl}</code>
+                </Text>
+              </div>
+
+              {!isTestingConnection ? (
+                <Button
+                  variant="secondary"
+                  icon={<PluggedIcon />}
+                  onClick={() => setIsTestingConnection(true)}
+                >
+                  Test Connection
+                </Button>
+              ) : (
+                <div>
+                  {mcpClient.isConnecting && (
+                    <Alert variant="info" title="Connecting..." isInline>
+                      <Spinner size="sm" /> Attempting to connect to {mcpUrl}
+                    </Alert>
+                  )}
+                  {mcpClient.isConnected && (
+                    <>
+                      <Alert
+                        variant="success"
+                        title="Connected"
+                        isInline
+                        customIcon={<CheckCircleIcon />}
+                      >
+                        Successfully connected to the MCP server. Found{' '}
+                        <strong>{mcpClient.tools.length}</strong> tool(s) and{' '}
+                        <strong>{mcpClient.prompts.length}</strong> prompt(s).
+                      </Alert>
+
+                      <ExpandableSection
+                        toggleText={`Available Operations (${mcpClient.tools.length} tools, ${mcpClient.prompts.length} prompts)`}
+                        style={{ marginTop: '1rem' }}
+                      >
+                        {mcpClient.tools.length > 0 && (
+                          <div style={{ marginBottom: '1rem' }}>
+                            <Text component="small" style={{ fontWeight: 600, marginBottom: '0.5rem', display: 'block' }}>
+                              Tools:
+                            </Text>
+                            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+                              {mcpClient.tools.map((tool) => (
+                                <ExpandableSection
+                                  key={tool.name}
+                                  toggleContent={
+                                    <span style={{ fontSize: '0.875rem' }}>
+                                      <strong>{tool.name}</strong>
+                                      {tool.description && (
+                                        <span style={{ color: '#6a6e73', marginLeft: '0.5rem' }}>— {tool.description}</span>
+                                      )}
+                                    </span>
+                                  }
+                                >
+                                  <CodeBlock style={{ marginTop: '0.5rem', marginBottom: '0.5rem' }}>
+                                    <CodeBlockCode>{JSON.stringify(tool.inputSchema, null, 2)}</CodeBlockCode>
+                                  </CodeBlock>
+                                </ExpandableSection>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+                        {mcpClient.prompts.length > 0 && (
+                          <div>
+                            <Text component="small" style={{ fontWeight: 600, marginBottom: '0.5rem', display: 'block' }}>
+                              Prompts:
+                            </Text>
+                            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+                              {mcpClient.prompts.map((prompt) => (
+                                <ExpandableSection
+                                  key={prompt.name}
+                                  toggleContent={
+                                    <span style={{ fontSize: '0.875rem' }}>
+                                      <strong>{prompt.name}</strong>
+                                      {prompt.description && (
+                                        <span style={{ color: '#6a6e73', marginLeft: '0.5rem' }}>— {prompt.description}</span>
+                                      )}
+                                    </span>
+                                  }
+                                >
+                                  {prompt.arguments && prompt.arguments.length > 0 ? (
+                                    <CodeBlock style={{ marginTop: '0.5rem', marginBottom: '0.5rem' }}>
+                                      <CodeBlockCode>{JSON.stringify(prompt.arguments, null, 2)}</CodeBlockCode>
+                                    </CodeBlock>
+                                  ) : (
+                                    <Text component="small" style={{ color: '#6a6e73', marginTop: '0.5rem', display: 'block' }}>
+                                      No arguments
+                                    </Text>
+                                  )}
+                                </ExpandableSection>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+                      </ExpandableSection>
+                    </>
+                  )}
+                  {mcpClient.error && (
+                    <Alert
+                      variant="danger"
+                      title="Connection failed"
+                      isInline
+                      customIcon={<ExclamationCircleIcon />}
+                    >
+                      {mcpClient.error}
+                      <div style={{ marginTop: '0.5rem', fontSize: '0.875rem' }}>
+                        Make sure the Skillberry Store server is running and the Agent MCP server is started.
+                      </div>
+                    </Alert>
+                  )}
+                  <div style={{ marginTop: '0.75rem' }}>
+                    <Button
+                      variant="link"
+                      icon={<UnpluggedIcon />}
+                      onClick={() => {
+                        mcpClient.disconnect();
+                        setIsTestingConnection(false);
+                      }}
+                    >
+                      Disconnect
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </CardBody>
+          </Card>
+
+          {/* Example Use Cases */}
+          <Card>
+            <CardTitle>Example Use Cases</CardTitle>
+            <CardBody>
+              <ul style={{ margin: 0, paddingLeft: '1.25rem', lineHeight: '2' }}>
+                <li>"List all tools and their descriptions"</li>
+                <li>"Read the code of the calculator tool and add input validation"</li>
+                <li>"Create a new tool that fetches weather data from an API"</li>
+                <li>"Search for tools related to data processing"</li>
+                <li>"Create a skill called 'data-analysis' and add relevant tools to it"</li>
+                <li>"Create a VMCP server for the data-analysis skill so I can use it in Claude Code"</li>
+                <li>"Look at the execution metrics for the calculator tool and optimize it"</li>
+              </ul>
+            </CardBody>
+          </Card>
+        </div>
+      </PageSection>
+    </>
+  );
+}

--- a/src/skillberry_store/ui/src/pages/ExternalMCPDetailPage.tsx
+++ b/src/skillberry_store/ui/src/pages/ExternalMCPDetailPage.tsx
@@ -1,0 +1,208 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import {
+  Alert,
+  Breadcrumb,
+  BreadcrumbItem,
+  Button,
+  ButtonVariant,
+  Card,
+  CardBody,
+  CardTitle,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  Label,
+  List,
+  ListItem,
+  PageSection,
+  Spinner,
+  Title,
+} from '@patternfly/react-core';
+import { externalMcpsApi } from '@/services/api';
+import type { ExternalMCPStatus } from '@/services/api';
+
+export function ExternalMCPDetailPage() {
+  const { name: rawName } = useParams<{ name: string }>();
+  const name = decodeURIComponent(rawName ?? '');
+  const navigate = useNavigate();
+
+  const [server, setServer] = useState<ExternalMCPStatus | null>(null);
+  const [dependents, setDependents] = useState<string[]>([]);
+  const [remoteTools, setRemoteTools] = useState<Array<{ name: string; description: string }> | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [restarting, setRestarting] = useState(false);
+
+  async function refresh() {
+    setLoading(true);
+    setError(null);
+    try {
+      const [s, deps] = await Promise.all([
+        externalMcpsApi.get(name),
+        externalMcpsApi.dependents(name).catch(() => ({ name, dependents: [] })),
+      ]);
+      setServer(s);
+      setDependents(deps.dependents || []);
+      if (s.status === 'running') {
+        try {
+          setRemoteTools(await externalMcpsApi.listRemoteTools(name));
+        } catch {
+          setRemoteTools(null);
+        }
+      } else {
+        setRemoteTools(null);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    if (name) refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [name]);
+
+  async function handleRestart() {
+    setRestarting(true);
+    try {
+      await externalMcpsApi.restart(name);
+      await refresh();
+    } catch (e) {
+      window.alert(`Restart failed: ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      setRestarting(false);
+    }
+  }
+
+  return (
+    <PageSection>
+      <Breadcrumb>
+        <BreadcrumbItem onClick={() => navigate('/external-mcps')} to="#">
+          External MCPs
+        </BreadcrumbItem>
+        <BreadcrumbItem isActive>{name}</BreadcrumbItem>
+      </Breadcrumb>
+
+      <Title headingLevel="h1" size="2xl" style={{ marginTop: '1rem' }}>
+        {name}
+      </Title>
+
+      {error && (
+        <Alert variant="danger" title="Failed to load" isInline>
+          {error}
+        </Alert>
+      )}
+
+      {loading || !server ? (
+        <Spinner aria-label="loading" />
+      ) : (
+        <>
+          <Card style={{ marginTop: '1rem' }}>
+            <CardTitle>Status</CardTitle>
+            <CardBody>
+              <DescriptionList isCompact>
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Status</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    <Label color={server.status === 'running' ? 'green' : server.status === 'error' ? 'red' : 'grey'}>
+                      {server.status}
+                    </Label>
+                    {server.last_error && (
+                      <div style={{ marginTop: '0.25rem', color: 'var(--pf-v5-global--danger-color--100)' }}>
+                        {server.last_error}
+                      </div>
+                    )}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Transport</DescriptionListTerm>
+                  <DescriptionListDescription>{server.transport}</DescriptionListDescription>
+                </DescriptionListGroup>
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Primitives imported</DescriptionListTerm>
+                  <DescriptionListDescription>{server.tool_count}</DescriptionListDescription>
+                </DescriptionListGroup>
+                {server.transport === 'stdio' && (
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Command</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      <code>{server.config.command} {(server.config.args || []).join(' ')}</code>
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                )}
+                {server.transport !== 'stdio' && (
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>URL</DescriptionListTerm>
+                    <DescriptionListDescription><code>{server.config.url}</code></DescriptionListDescription>
+                  </DescriptionListGroup>
+                )}
+              </DescriptionList>
+              <Button
+                variant={ButtonVariant.secondary}
+                onClick={handleRestart}
+                isDisabled={restarting}
+                style={{ marginTop: '1rem' }}
+              >
+                {restarting ? 'Restarting…' : 'Restart (reconcile)'}
+              </Button>
+            </CardBody>
+          </Card>
+
+          <Card style={{ marginTop: '1rem' }}>
+            <CardTitle>Remote tools</CardTitle>
+            <CardBody>
+              {remoteTools === null ? (
+                <span style={{ color: 'var(--pf-v5-global--Color--200)' }}>
+                  Server not running — introspection unavailable.
+                </span>
+              ) : remoteTools.length === 0 ? (
+                <span>No remote tools reported.</span>
+              ) : (
+                <List>
+                  {remoteTools.map((t) => (
+                    <ListItem key={t.name}>
+                      <Button
+                        variant="link"
+                        isInline
+                        onClick={() => navigate(`/tools/${encodeURIComponent(`${name}__${t.name}`)}`)}
+                      >
+                        <code>{name}__{t.name}</code>
+                      </Button>
+                      {t.description && <span> — {t.description}</span>}
+                    </ListItem>
+                  ))}
+                </List>
+              )}
+            </CardBody>
+          </Card>
+
+          <Card style={{ marginTop: '1rem' }}>
+            <CardTitle>Dependents (will break if this server is removed)</CardTitle>
+            <CardBody>
+              {dependents.length === 0 ? (
+                <span>None.</span>
+              ) : (
+                <List>
+                  {dependents.map((d) => (
+                    <ListItem key={d}>
+                      <Button variant="link" isInline onClick={() => navigate(`/tools/${encodeURIComponent(d)}`)}>
+                        {d}
+                      </Button>
+                    </ListItem>
+                  ))}
+                </List>
+              )}
+            </CardBody>
+          </Card>
+        </>
+      )}
+    </PageSection>
+  );
+}

--- a/src/skillberry_store/ui/src/pages/ExternalMCPsPage.tsx
+++ b/src/skillberry_store/ui/src/pages/ExternalMCPsPage.tsx
@@ -1,0 +1,293 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Alert,
+  Button,
+  ButtonVariant,
+  Card,
+  CardBody,
+  EmptyState,
+  EmptyStateBody,
+  Form,
+  FormGroup,
+  Label,
+  Modal,
+  ModalVariant,
+  PageSection,
+  Spinner,
+  TextArea,
+  Title,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
+} from '@patternfly/react-core';
+import {
+  Table,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+} from '@patternfly/react-table';
+import { externalMcpsApi } from '@/services/api';
+import type { ExternalMCPStatus } from '@/services/api';
+
+const SAMPLE_CONFIG = `{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
+    }
+  }
+}`;
+
+export function ExternalMCPsPage() {
+  const navigate = useNavigate();
+  const [servers, setServers] = useState<ExternalMCPStatus[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [listError, setListError] = useState<string | null>(null);
+
+  const [isAddOpen, setIsAddOpen] = useState(false);
+  const [configText, setConfigText] = useState(SAMPLE_CONFIG);
+  const [adding, setAdding] = useState(false);
+  const [addResult, setAddResult] = useState<string | null>(null);
+  const [addError, setAddError] = useState<string | null>(null);
+
+  const [removingName, setRemovingName] = useState<string | null>(null);
+  const [restartingName, setRestartingName] = useState<string | null>(null);
+
+  async function refresh() {
+    setLoading(true);
+    setListError(null);
+    try {
+      const list = await externalMcpsApi.list();
+      setServers(list);
+    } catch (e) {
+      setListError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  async function handleAdd() {
+    setAdding(true);
+    setAddError(null);
+    setAddResult(null);
+    try {
+      const parsed = JSON.parse(configText);
+      const res = await externalMcpsApi.create(parsed);
+      const lines = (res.results || []).map((r) => {
+        if (r.status === 'running') {
+          const n = r.reconcile?.added?.length ?? 0;
+          return `✅ ${r.name}: running (${n} primitives imported)`;
+        }
+        return `❌ ${r.name}: ${r.status}${r.error ? ' — ' + r.error : ''}`;
+      });
+      setAddResult(lines.join('\n'));
+      await refresh();
+    } catch (e) {
+      setAddError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setAdding(false);
+    }
+  }
+
+  async function handleRemove(name: string) {
+    if (!window.confirm(`Remove MCP server '${name}'? All its primitive tools will be deleted; composites that depend on it will be marked broken.`)) {
+      return;
+    }
+    setRemovingName(name);
+    try {
+      await externalMcpsApi.remove(name);
+      await refresh();
+    } catch (e) {
+      window.alert(`Remove failed: ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      setRemovingName(null);
+    }
+  }
+
+  async function handleRestart(name: string) {
+    setRestartingName(name);
+    try {
+      await externalMcpsApi.restart(name);
+      await refresh();
+    } catch (e) {
+      window.alert(`Restart failed: ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      setRestartingName(null);
+    }
+  }
+
+  const brokenBanner = useMemo(() => {
+    const errored = servers.filter((s) => s.status === 'error');
+    if (errored.length === 0) return null;
+    return (
+      <Alert variant="warning" title={`${errored.length} external MCP server(s) in error state`} isInline>
+        Composites depending on these servers are marked <code>state=broken</code>. Fix the config and restart.
+      </Alert>
+    );
+  }, [servers]);
+
+  return (
+    <PageSection>
+      <Title headingLevel="h1" size="2xl">External MCPs</Title>
+      <p style={{ marginTop: '0.5rem', marginBottom: '1rem', color: 'var(--pf-v5-global--Color--200)' }}>
+        MCP servers the store connects to and imports tools from. Paste any
+        standard <code>mcpServers</code> config (Claude Desktop style).
+      </p>
+
+      {brokenBanner}
+
+      <Toolbar>
+        <ToolbarContent>
+          <ToolbarItem>
+            <Button variant="primary" onClick={() => setIsAddOpen(true)}>
+              Add External MCP
+            </Button>
+          </ToolbarItem>
+          <ToolbarItem>
+            <Button variant="link" onClick={refresh} isDisabled={loading}>
+              Refresh
+            </Button>
+          </ToolbarItem>
+        </ToolbarContent>
+      </Toolbar>
+
+      {listError && (
+        <Alert variant="danger" title="Failed to load external MCPs" isInline>
+          {listError}
+        </Alert>
+      )}
+
+      <Card>
+        <CardBody>
+          {loading ? (
+            <Spinner aria-label="loading" />
+          ) : servers.length === 0 ? (
+            <EmptyState>
+              <Title headingLevel="h4" size="lg">No external MCP servers yet</Title>
+              <EmptyStateBody>
+                Click <strong>Add External MCP</strong> above to register one. Every
+                exposed tool will be imported as a primitive named{' '}
+                <code>&lt;server&gt;__&lt;tool&gt;</code>.
+              </EmptyStateBody>
+            </EmptyState>
+          ) : (
+            <Table aria-label="External MCP servers">
+              <Thead>
+                <Tr>
+                  <Th>Name</Th>
+                  <Th>Transport</Th>
+                  <Th>Status</Th>
+                  <Th>Primitives</Th>
+                  <Th>Actions</Th>
+                </Tr>
+              </Thead>
+              <Tbody>
+                {servers.map((s) => (
+                  <Tr key={s.name}>
+                    <Td>
+                      <Button
+                        variant="link"
+                        isInline
+                        onClick={() => navigate(`/external-mcps/${encodeURIComponent(s.name)}`)}
+                      >
+                        {s.name}
+                      </Button>
+                    </Td>
+                    <Td>{s.transport}</Td>
+                    <Td>
+                      <Label color={s.status === 'running' ? 'green' : s.status === 'error' ? 'red' : 'grey'}>
+                        {s.status}
+                      </Label>
+                      {s.last_error && (
+                        <div style={{ fontSize: '0.8em', color: 'var(--pf-v5-global--danger-color--100)' }}>
+                          {s.last_error}
+                        </div>
+                      )}
+                    </Td>
+                    <Td>{s.tool_count}</Td>
+                    <Td>
+                      <Button
+                        variant={ButtonVariant.secondary}
+                        size="sm"
+                        onClick={() => handleRestart(s.name)}
+                        isDisabled={restartingName === s.name}
+                        style={{ marginRight: '0.5rem' }}
+                      >
+                        {restartingName === s.name ? 'Restarting…' : 'Restart'}
+                      </Button>
+                      <Button
+                        variant={ButtonVariant.danger}
+                        size="sm"
+                        onClick={() => handleRemove(s.name)}
+                        isDisabled={removingName === s.name}
+                      >
+                        {removingName === s.name ? 'Removing…' : 'Remove'}
+                      </Button>
+                    </Td>
+                  </Tr>
+                ))}
+              </Tbody>
+            </Table>
+          )}
+        </CardBody>
+      </Card>
+
+      <Modal
+        variant={ModalVariant.large}
+        title="Add External MCP Server(s)"
+        isOpen={isAddOpen}
+        onClose={() => setIsAddOpen(false)}
+        actions={[
+          <Button key="add" variant="primary" onClick={handleAdd} isDisabled={adding}>
+            {adding ? 'Adding…' : 'Add'}
+          </Button>,
+          <Button key="close" variant="link" onClick={() => setIsAddOpen(false)}>
+            Close
+          </Button>,
+        ]}
+      >
+        <Form>
+          <FormGroup
+            label="Paste mcpServers JSON"
+            fieldId="mcp-config-json"
+          >
+            <TextArea
+              id="mcp-config-json"
+              value={configText}
+              onChange={(_e, v) => setConfigText(v)}
+              rows={14}
+              resizeOrientation="vertical"
+              aria-label="mcpServers JSON"
+              style={{ fontFamily: 'monospace' }}
+            />
+            <div style={{ marginTop: '0.25rem', fontSize: '0.85em', color: '#6a6e73' }}>
+              Accepts the Claude-Desktop-style <code>{'{ mcpServers: {...} }'}</code> wrapper, a
+              bare name→entry dict, a list form, a single entry, or{' '}
+              <code>{'{ source_url: "..." }'}</code> to fetch a config.
+            </div>
+          </FormGroup>
+          {addError && (
+            <Alert variant="danger" title="Add failed" isInline>
+              {addError}
+            </Alert>
+          )}
+          {addResult && (
+            <Alert variant="info" title="Result" isInline>
+              <pre style={{ margin: 0, whiteSpace: 'pre-wrap' }}>{addResult}</pre>
+            </Alert>
+          )}
+        </Form>
+      </Modal>
+    </PageSection>
+  );
+}

--- a/src/skillberry_store/ui/src/pages/PluginsPage.tsx
+++ b/src/skillberry_store/ui/src/pages/PluginsPage.tsx
@@ -1,0 +1,158 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  PageSection,
+  Title,
+  Card,
+  CardBody,
+  Switch,
+  Spinner,
+  Alert,
+  Button,
+} from '@patternfly/react-core';
+import {
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+} from '@patternfly/react-table';
+import { pluginsApi, type PluginInfo } from '@/services/api';
+import { applyPluginsListFromBackend } from '@/plugins/registry';
+
+export function PluginsPage() {
+  const navigate = useNavigate();
+  const [plugins, setPlugins] = useState<PluginInfo[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [restartPending, setRestartPending] = useState(false);
+
+  const refresh = async () => {
+    try {
+      const items = await pluginsApi.list();
+      setPlugins(items);
+      applyPluginsListFromBackend(items);
+    } catch (err: any) {
+      setError(err.message || 'Failed to load plugins');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const toggle = async (plugin: PluginInfo) => {
+    setPendingId(plugin.id);
+    setError(null);
+    try {
+      const resp = plugin.enabled
+        ? await pluginsApi.disable(plugin.id)
+        : await pluginsApi.enable(plugin.id);
+      if (resp.restart_required) {
+        setRestartPending(true);
+      }
+      await refresh();
+    } catch (err: any) {
+      setError(err.message || 'Failed to toggle plugin');
+    } finally {
+      setPendingId(null);
+    }
+  };
+
+  return (
+    <>
+      <PageSection>
+        <Title headingLevel="h1" size="2xl">Plugins</Title>
+        <div style={{ marginTop: '0.5rem', fontSize: '0.925rem', color: '#6a6e73' }}>
+          Optional add-ons that extend the Skillberry Store. Enabling or disabling a plugin
+          applies immediately unless the plugin declares that a restart is required.
+        </div>
+      </PageSection>
+
+      <PageSection>
+        {restartPending && (
+          <Alert
+            variant="warning"
+            title="Restart required"
+            isInline
+            style={{ marginBottom: '1rem' }}
+          >
+            One or more plugins require a store restart for the change to take effect.
+          </Alert>
+        )}
+        {error && (
+          <Alert variant="danger" title="Error" isInline style={{ marginBottom: '1rem' }}>
+            {error}
+          </Alert>
+        )}
+        <Card>
+          <CardBody>
+            {isLoading ? (
+              <div style={{ textAlign: 'center', padding: '2rem' }}>
+                <Spinner size="lg" />
+              </div>
+            ) : plugins.length === 0 ? (
+              <div style={{ textAlign: 'center', padding: '2rem', color: '#6a6e73' }}>
+                No plugins installed.
+              </div>
+            ) : (
+              <Table aria-label="Plugins" variant="compact">
+                <Thead>
+                  <Tr>
+                    <Th>Name</Th>
+                    <Th>Description</Th>
+                    <Th>Status</Th>
+                    <Th>Enabled</Th>
+                    <Th>Open</Th>
+                  </Tr>
+                </Thead>
+                <Tbody>
+                  {plugins.map((p) => {
+                    const primaryPath = p.ui_manifest?.nav_items?.[0]?.path;
+                    return (
+                      <Tr key={p.id}>
+                        <Td>
+                          <strong>{p.name}</strong>
+                          {p.requires_restart && (
+                            <div style={{ fontSize: '0.75rem', color: '#6a6e73' }}>
+                              Requires restart on toggle
+                            </div>
+                          )}
+                        </Td>
+                        <Td>{p.description}</Td>
+                        <Td>{p.enabled ? 'Enabled' : 'Disabled'}</Td>
+                        <Td>
+                          <Switch
+                            id={`plugin-toggle-${p.id}`}
+                            aria-label={`Toggle ${p.name}`}
+                            isChecked={p.enabled}
+                            isDisabled={pendingId === p.id}
+                            onChange={() => toggle(p)}
+                          />
+                        </Td>
+                        <Td>
+                          {p.enabled && primaryPath ? (
+                            <Button variant="link" isInline onClick={() => navigate(primaryPath)}>
+                              Open
+                            </Button>
+                          ) : null}
+                        </Td>
+                      </Tr>
+                    );
+                  })}
+                </Tbody>
+              </Table>
+            )}
+          </CardBody>
+        </Card>
+      </PageSection>
+    </>
+  );
+}

--- a/src/skillberry_store/ui/src/pages/SkillDetailPage.tsx
+++ b/src/skillberry_store/ui/src/pages/SkillDetailPage.tsx
@@ -42,7 +42,9 @@ import {
   TreeViewDataItem,
 } from '@patternfly/react-core';
 import { EditIcon, TrashIcon, FolderIcon, FileIcon, FileCodeIcon, ExportIcon } from '@patternfly/react-icons';
-import { skillsApi, toolsApi, snippetsApi } from '@/services/api';
+import { skillsApi, toolsApi, snippetsApi, externalMcpsApi, skillsExtrasApi } from '@/services/api';
+import type { BulkAddMode, BulkAddResult } from '@/services/api';
+import { PluginSlot } from '@/plugins/SlotRenderer';
 import type { Skill } from '@/types';
 
 export function SkillDetailPage() {
@@ -52,6 +54,13 @@ export function SkillDetailPage() {
 
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  // "Add tools from MCPs" bulk-add modal
+  const [isBulkMcpOpen, setIsBulkMcpOpen] = useState(false);
+  const [bulkSelectedMcps, setBulkSelectedMcps] = useState<string[]>([]);
+  const [bulkMode, setBulkMode] = useState<BulkAddMode>('bundled_related');
+  const [bulkResult, setBulkResult] = useState<BulkAddResult | null>(null);
+  const [bulkError, setBulkError] = useState<string | null>(null);
+  const [bulkSubmitting, setBulkSubmitting] = useState(false);
   const [activeTabKey, setActiveTabKey] = useState<string | number>(0);
   const [editedSkill, setEditedSkill] = useState({
     name: '',
@@ -93,6 +102,32 @@ export function SkillDetailPage() {
     queryKey: ['snippets'],
     queryFn: snippetsApi.list,
   });
+
+  // External MCP servers — lazy-load only when the bulk-add modal opens.
+  const { data: externalMcps } = useQuery({
+    queryKey: ['external-mcps'],
+    queryFn: externalMcpsApi.list,
+    enabled: isBulkMcpOpen,
+  });
+
+  async function handleBulkAddFromMcps() {
+    if (!name || bulkSelectedMcps.length === 0) return;
+    setBulkSubmitting(true);
+    setBulkError(null);
+    setBulkResult(null);
+    try {
+      const result = await skillsExtrasApi.bulkAddFromMcps(name, {
+        mcps: bulkSelectedMcps,
+        mode: bulkMode,
+      });
+      setBulkResult(result);
+      queryClient.invalidateQueries({ queryKey: ['skill', name] });
+    } catch (e) {
+      setBulkError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBulkSubmitting(false);
+    }
+  }
 
   // Fetch tool modules for all tools in the skill
   const { data: toolModules } = useQuery({
@@ -510,9 +545,20 @@ export function SkillDetailPage() {
             {skill.name}
           </Title>
           <div style={{ display: 'flex', gap: '0.5rem' }}>
-            <Button variant="primary" icon={<ExportIcon />} onClick={handleExportToAnthropic}>
-              Export to Anthropic
+            <Button
+              variant="secondary"
+              onClick={() => {
+                setBulkResult(null);
+                setBulkError(null);
+                setIsBulkMcpOpen(true);
+              }}
+            >
+              Add tools from MCPs
             </Button>
+            <Button variant="primary" icon={<ExportIcon />} onClick={handleExportToAnthropic}>
+              Export
+            </Button>
+            <PluginSlot name="skill.detail.actions" ctx={{ skill }} />
             <Button variant="secondary" icon={<EditIcon />} onClick={handleEditClick}>
               Edit
             </Button>
@@ -1080,6 +1126,127 @@ export function SkillDetailPage() {
         <Text>
           Are you sure you want to delete the skill "{skill?.name}"? This action cannot be undone.
         </Text>
+      </Modal>
+
+      {/* Bulk-add tools from MCPs modal */}
+      <Modal
+        variant={ModalVariant.medium}
+        title="Add tools to this skill from External MCPs"
+        isOpen={isBulkMcpOpen}
+        onClose={() => setIsBulkMcpOpen(false)}
+        actions={[
+          <Button
+            key="apply"
+            variant="primary"
+            onClick={handleBulkAddFromMcps}
+            isDisabled={bulkSubmitting || bulkSelectedMcps.length === 0}
+          >
+            {bulkSubmitting ? 'Adding…' : 'Add tools'}
+          </Button>,
+          <Button key="close" variant="link" onClick={() => setIsBulkMcpOpen(false)}>
+            Close
+          </Button>,
+        ]}
+      >
+        <Form>
+          <FormGroup
+            label="1. Pick one or more MCP servers"
+            fieldId="bulk-mcp-select"
+            isRequired
+          >
+            {externalMcps === undefined ? (
+              <Text component="small">Loading…</Text>
+            ) : externalMcps.length === 0 ? (
+              <Text component="small" style={{ color: '#c9190b' }}>
+                No external MCPs registered yet. Go to <a href="/external-mcps">External MCPs</a> first.
+              </Text>
+            ) : (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+                {externalMcps.map((s) => {
+                  const checked = bulkSelectedMcps.includes(s.name);
+                  return (
+                    <label key={s.name} style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={(e) => {
+                          setBulkSelectedMcps((cur) =>
+                            e.target.checked
+                              ? [...cur, s.name]
+                              : cur.filter((n) => n !== s.name),
+                          );
+                        }}
+                      />
+                      <span>
+                        <strong>{s.name}</strong>{' '}
+                        <small style={{ color: '#6a6e73' }}>
+                          ({s.transport}, {s.tool_count} primitives, {s.status})
+                        </small>
+                      </span>
+                    </label>
+                  );
+                })}
+              </div>
+            )}
+          </FormGroup>
+
+          <FormGroup label="2. What to add" fieldId="bulk-mode-select" isRequired>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+              {([
+                {
+                  v: 'primitives' as const,
+                  label: 'Only MCP primitives',
+                  help: 'Just the tools imported directly from the selected server(s).',
+                },
+                {
+                  v: 'related' as const,
+                  label: 'All related tools (primitives + composites)',
+                  help: 'Every composite whose mcp_dependencies intersects the selection, plus the primitives themselves.',
+                },
+                {
+                  v: 'bundled_related' as const,
+                  label: 'Bundled tools only (default)',
+                  help: 'Same as "related", but skips any tool whose bundled_with_mcps is False. If you want those included, pick "All related tools" instead.',
+                },
+              ]).map((opt) => (
+                <label key={opt.v} style={{ display: 'flex', alignItems: 'flex-start', gap: '0.5rem' }}>
+                  <input
+                    type="radio"
+                    name="bulkMode"
+                    value={opt.v}
+                    checked={bulkMode === opt.v}
+                    onChange={() => setBulkMode(opt.v)}
+                  />
+                  <span>
+                    <strong>{opt.label}</strong>
+                    <div style={{ fontSize: '0.85em', color: '#6a6e73' }}>{opt.help}</div>
+                  </span>
+                </label>
+              ))}
+            </div>
+          </FormGroup>
+
+          {bulkError && (
+            <Text component="small" style={{ color: '#c9190b' }}>{bulkError}</Text>
+          )}
+
+          {bulkResult && (
+            <div style={{ marginTop: '0.5rem', padding: '0.75rem', background: '#f0f8ff', borderRadius: 4 }}>
+              <div>✅ Added <strong>{bulkResult.added.length}</strong> tool(s): {bulkResult.added.map((t) => t.name).join(', ') || '—'}</div>
+              {bulkResult.skipped_duplicate.length > 0 && (
+                <div style={{ marginTop: '0.25rem' }}>⏭️ Skipped (already in skill): {bulkResult.skipped_duplicate.join(', ')}</div>
+              )}
+              {bulkResult.skipped_unbundled.length > 0 && (
+                <div style={{ marginTop: '0.25rem' }}>🚫 Skipped (unbundled): {bulkResult.skipped_unbundled.join(', ')}</div>
+              )}
+              {bulkResult.skipped_broken.length > 0 && (
+                <div style={{ marginTop: '0.25rem' }}>
+                  ⚠️ Skipped (broken): {bulkResult.skipped_broken.map((t) => `${t.name} (${t.reason})`).join(', ')}
+                </div>
+              )}
+            </div>
+          )}
+        </Form>
       </Modal>
     </>
   );

--- a/src/skillberry_store/ui/src/pages/SkillsPage.tsx
+++ b/src/skillberry_store/ui/src/pages/SkillsPage.tsx
@@ -38,7 +38,8 @@ import {
 } from '@patternfly/react-core';
 import { Table, Thead, Tr, Th, Tbody, Td, ThProps } from '@patternfly/react-table';
 import { PlusIcon, CodeIcon, SearchIcon, TrashIcon, ExportIcon, ImportIcon, UploadIcon } from '@patternfly/react-icons';
-import { skillsApi, toolsApi, snippetsApi } from '@/services/api';
+import { skillsApi, toolsApi, snippetsApi, externalMcpsApi, skillsExtrasApi } from '@/services/api';
+import type { BulkAddMode, BulkAddResult } from '@/services/api';
 import type { Skill } from '@/types';
 import { AnthropicSkillImporter } from '../components/AnthropicSkillImporter';
 
@@ -78,6 +79,11 @@ export function SkillsPage() {
   const [toolSearchTerm, setToolSearchTerm] = useState('');
   const [snippetSearchTerm, setSnippetSearchTerm] = useState('');
 
+  // Create-from-MCPs section state (used inside the Create Skill modal).
+  const [createMcpSelections, setCreateMcpSelections] = useState<string[]>([]);
+  const [createMcpMode, setCreateMcpMode] = useState<BulkAddMode>('bundled_related');
+  const [createBulkResult, setCreateBulkResult] = useState<BulkAddResult | null>(null);
+
   const { data: skills, isLoading, error } = useQuery({
     queryKey: ['skills'],
     queryFn: skillsApi.list,
@@ -100,6 +106,13 @@ export function SkillsPage() {
   const { data: allSnippets } = useQuery({
     queryKey: ['snippets'],
     queryFn: snippetsApi.list,
+  });
+
+  // Fetch registered external MCP servers — only when the create modal is open.
+  const { data: externalMcps } = useQuery({
+    queryKey: ['external-mcps'],
+    queryFn: externalMcpsApi.list,
+    enabled: isCreateModalOpen,
   });
 
   // Create skill mutation
@@ -177,8 +190,29 @@ export function SkillsPage() {
       });
       
       if (response.ok) {
+        // If the user picked MCPs in the "from External MCPs" section, chain
+        // the bulk-add call now that the skill exists.
+        let bulkSummary: BulkAddResult | null = null;
+        if (createMcpSelections.length > 0) {
+          try {
+            bulkSummary = await skillsExtrasApi.bulkAddFromMcps(newSkill.name, {
+              mcps: createMcpSelections,
+              mode: createMcpMode,
+            });
+          } catch (e) {
+            setCreateError(
+              'Skill created, but bulk-add from MCPs failed: ' +
+                (e instanceof Error ? e.message : String(e)),
+            );
+          }
+        }
+        setCreateBulkResult(bulkSummary);
         queryClient.invalidateQueries({ queryKey: ['skills'] });
-        setIsCreateModalOpen(false);
+        // Keep the modal open briefly if we have a bulk summary so the user
+        // can see what was added; close otherwise.
+        if (!bulkSummary) {
+          setIsCreateModalOpen(false);
+        }
         setNewSkill({
           name: '',
           version: '1.0.0',
@@ -187,6 +221,8 @@ export function SkillsPage() {
           toolNames: [],
           snippetNames: [],
         });
+        setCreateMcpSelections([]);
+        setCreateMcpMode('bundled_related');
       } else {
         const errorText = await response.text();
         setCreateError(`Failed to create skill: ${errorText}`);
@@ -638,6 +674,9 @@ export function SkillsPage() {
             toolNames: [],
             snippetNames: [],
           });
+          setCreateMcpSelections([]);
+          setCreateMcpMode('bundled_related');
+          setCreateBulkResult(null);
           setTagInput('');
           setToolSearchTerm('');
           setSnippetSearchTerm('');
@@ -747,6 +786,103 @@ export function SkillsPage() {
               </div>
             )}
           </FormGroup>
+          <FormGroup label="Tools from External MCPs (optional bulk-add)" fieldId="skill-from-mcps">
+            <Text component="small" style={{ display: 'block', marginBottom: '0.5rem', color: '#6a6e73' }}>
+              Pick one or more imported MCPs and a mode — on create, the matching tools will be added automatically.
+            </Text>
+            {externalMcps === undefined ? (
+              <Text component="small">Loading MCPs…</Text>
+            ) : externalMcps.length === 0 ? (
+              <Text component="small" style={{ color: '#6a6e73' }}>
+                No external MCPs registered yet. You can still create the skill and add tools manually below — or go to{' '}
+                <a href="/external-mcps">External MCPs</a> and import one first.
+              </Text>
+            ) : (
+              <>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', marginBottom: '0.5rem' }}>
+                  {externalMcps.map((s) => {
+                    const checked = createMcpSelections.includes(s.name);
+                    return (
+                      <label key={s.name} style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          onChange={(e) => {
+                            setCreateMcpSelections((cur) =>
+                              e.target.checked
+                                ? [...cur, s.name]
+                                : cur.filter((n) => n !== s.name),
+                            );
+                          }}
+                        />
+                        <span>
+                          <strong>{s.name}</strong>{' '}
+                          <small style={{ color: '#6a6e73' }}>
+                            ({s.transport}, {s.tool_count} primitives, {s.status})
+                          </small>
+                        </span>
+                      </label>
+                    );
+                  })}
+                </div>
+                {createMcpSelections.length > 0 && (
+                  <>
+                    <Text component="small" style={{ display: 'block', fontWeight: 600, marginTop: '0.5rem' }}>
+                      Which tools to add?
+                    </Text>
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+                      {([
+                        {
+                          v: 'primitives' as const,
+                          label: 'Only MCP primitives',
+                          help: 'Just the tools imported directly from the selected server(s).',
+                        },
+                        {
+                          v: 'related' as const,
+                          label: 'All related tools (primitives + composites)',
+                          help: 'Every composite whose mcp_dependencies intersects the selection, plus the primitives themselves. Ignores the bundled_with_mcps flag.',
+                        },
+                        {
+                          v: 'bundled_related' as const,
+                          label: 'Bundled related tools (default)',
+                          help: 'Same as "related", but skips any tool whose bundled_with_mcps is False. If you want those included, pick "All related tools" instead.',
+                        },
+                      ]).map((opt) => (
+                        <label key={opt.v} style={{ display: 'flex', alignItems: 'flex-start', gap: '0.5rem' }}>
+                          <input
+                            type="radio"
+                            name="createMcpMode"
+                            value={opt.v}
+                            checked={createMcpMode === opt.v}
+                            onChange={() => setCreateMcpMode(opt.v)}
+                          />
+                          <span>
+                            <strong>{opt.label}</strong>
+                            <div style={{ fontSize: '0.85em', color: '#6a6e73' }}>{opt.help}</div>
+                          </span>
+                        </label>
+                      ))}
+                    </div>
+                  </>
+                )}
+                {createBulkResult && (
+                  <div style={{ marginTop: '0.5rem', padding: '0.75rem', background: '#f0f8ff', borderRadius: 4 }}>
+                    <div>✅ Added <strong>{createBulkResult.added.length}</strong> tool(s) from MCPs</div>
+                    {createBulkResult.skipped_unbundled.length > 0 && (
+                      <div>🚫 Skipped (unbundled): {createBulkResult.skipped_unbundled.join(', ')}</div>
+                    )}
+                    {createBulkResult.skipped_broken.length > 0 && (
+                      <div>
+                        ⚠️ Skipped (broken):{' '}
+                        {createBulkResult.skipped_broken.map((t) => `${t.name} (${t.reason})`).join(', ')}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </>
+            )}
+          </FormGroup>
+
           <FormGroup label="Tools" fieldId="skill-tools">
             <Text component="small" style={{ display: 'block', marginBottom: '0.5rem', color: '#6a6e73' }}>
               Search and select tools to include in this skill

--- a/src/skillberry_store/ui/src/pages/SkillsPage.tsx
+++ b/src/skillberry_store/ui/src/pages/SkillsPage.tsx
@@ -38,9 +38,9 @@ import {
 } from '@patternfly/react-core';
 import { Table, Thead, Tr, Th, Tbody, Td, ThProps } from '@patternfly/react-table';
 import { PlusIcon, CodeIcon, SearchIcon, TrashIcon, ExportIcon, ImportIcon, UploadIcon } from '@patternfly/react-icons';
-import { skillsApi, toolsApi, snippetsApi, externalMcpsApi, skillsExtrasApi } from '@/services/api';
-import type { BulkAddMode, BulkAddResult } from '@/services/api';
-import type { Skill } from '@/types';
+import { skillsApi, toolsApi, snippetsApi, externalMcpsApi, isValidStoreName, STORE_NAME_HINT } from '@/services/api';
+import type { BulkAddMode } from '@/services/api';
+import type { Skill, Tool } from '@/types';
 import { AnthropicSkillImporter } from '../components/AnthropicSkillImporter';
 
 type SortableColumn = 'name' | 'description' | 'version';
@@ -79,10 +79,12 @@ export function SkillsPage() {
   const [toolSearchTerm, setToolSearchTerm] = useState('');
   const [snippetSearchTerm, setSnippetSearchTerm] = useState('');
 
-  // Create-from-MCPs section state (used inside the Create Skill modal).
+  // Create-from-MCPs section state — drives the inline "Add tools from MCPs…"
+  // shortcut inside the Tools FormGroup. Selected MCP tools get pushed into
+  // newSkill.toolNames; the panel itself stays transient.
+  const [isMcpPickerOpen, setIsMcpPickerOpen] = useState(false);
   const [createMcpSelections, setCreateMcpSelections] = useState<string[]>([]);
   const [createMcpMode, setCreateMcpMode] = useState<BulkAddMode>('bundled_related');
-  const [createBulkResult, setCreateBulkResult] = useState<BulkAddResult | null>(null);
 
   const { data: skills, isLoading, error } = useQuery({
     queryKey: ['skills'],
@@ -107,6 +109,34 @@ export function SkillsPage() {
     queryKey: ['snippets'],
     queryFn: snippetsApi.list,
   });
+
+  // Client-side preview of which tools would be added under the current MCP
+  // selection + mode. Shared by the preview chip list and the "Add matching
+  // tools to selection" button so WYSIWYG is guaranteed.
+  const mcpMatchPreview = useMemo(() => {
+    if (!allTools || createMcpSelections.length === 0) return [] as Tool[];
+    const mcpSet = new Set(createMcpSelections);
+    return allTools.filter((t) => {
+      const toolMcp = (t as any).mcp_server as string | null | undefined;
+      const toolDeps = new Set(((t as any).mcp_dependencies as string[] | undefined) || []);
+      const touches = (toolMcp && mcpSet.has(toolMcp)) || [...toolDeps].some((d) => mcpSet.has(d));
+      if (!touches) return false;
+      if (createMcpMode === 'primitives' && (!toolMcp || !mcpSet.has(toolMcp))) return false;
+      if (createMcpMode === 'bundled_related' && (t as any).bundled_with_mcps === false) return false;
+      if (t.state === 'broken') return false;
+      return true;
+    });
+  }, [allTools, createMcpSelections, createMcpMode]);
+
+  function handleAddMatchingToolsToSelection() {
+    const names = mcpMatchPreview.map((t) => t.name);
+    setNewSkill((cur) => ({
+      ...cur,
+      toolNames: Array.from(new Set([...cur.toolNames, ...names])),
+    }));
+    // Clear the picker's MCP selection; mode stays.
+    setCreateMcpSelections([]);
+  }
 
   // Fetch registered external MCP servers — only when the create modal is open.
   const { data: externalMcps } = useQuery({
@@ -157,6 +187,10 @@ export function SkillsPage() {
       setCreateError('Please fill in all required fields');
       return;
     }
+    if (!isValidStoreName(newSkill.name)) {
+      setCreateError(`Invalid skill name. ${STORE_NAME_HINT}`);
+      return;
+    }
     
     try {
       // Fetch tool and snippet UUIDs
@@ -190,29 +224,11 @@ export function SkillsPage() {
       });
       
       if (response.ok) {
-        // If the user picked MCPs in the "from External MCPs" section, chain
-        // the bulk-add call now that the skill exists.
-        let bulkSummary: BulkAddResult | null = null;
-        if (createMcpSelections.length > 0) {
-          try {
-            bulkSummary = await skillsExtrasApi.bulkAddFromMcps(newSkill.name, {
-              mcps: createMcpSelections,
-              mode: createMcpMode,
-            });
-          } catch (e) {
-            setCreateError(
-              'Skill created, but bulk-add from MCPs failed: ' +
-                (e instanceof Error ? e.message : String(e)),
-            );
-          }
-        }
-        setCreateBulkResult(bulkSummary);
+        // The "Add tools from MCPs…" shortcut (if used) already populated
+        // newSkill.toolNames, so nothing else to chain here — Create uses the
+        // explicit tool selection path.
         queryClient.invalidateQueries({ queryKey: ['skills'] });
-        // Keep the modal open briefly if we have a bulk summary so the user
-        // can see what was added; close otherwise.
-        if (!bulkSummary) {
-          setIsCreateModalOpen(false);
-        }
+        setIsCreateModalOpen(false);
         setNewSkill({
           name: '',
           version: '1.0.0',
@@ -223,6 +239,7 @@ export function SkillsPage() {
         });
         setCreateMcpSelections([]);
         setCreateMcpMode('bundled_related');
+        setIsMcpPickerOpen(false);
       } else {
         const errorText = await response.text();
         setCreateError(`Failed to create skill: ${errorText}`);
@@ -676,7 +693,7 @@ export function SkillsPage() {
           });
           setCreateMcpSelections([]);
           setCreateMcpMode('bundled_related');
-          setCreateBulkResult(null);
+          setIsMcpPickerOpen(false);
           setTagInput('');
           setToolSearchTerm('');
           setSnippetSearchTerm('');
@@ -726,8 +743,20 @@ export function SkillsPage() {
               type="text"
               id="skill-name"
               value={newSkill.name}
+              validated={newSkill.name === '' || isValidStoreName(newSkill.name) ? 'default' : 'error'}
               onChange={(_, value) => setNewSkill({ ...newSkill, name: value })}
             />
+            {newSkill.name !== '' && !isValidStoreName(newSkill.name) && (
+              <div
+                style={{
+                  marginTop: '0.25rem',
+                  fontSize: '0.85em',
+                  color: 'var(--pf-v5-global--danger-color--100)',
+                }}
+              >
+                Invalid name for Claude Code MCP. {STORE_NAME_HINT}
+              </div>
+            )}
           </FormGroup>
           <FormGroup label="Version" fieldId="skill-version">
             <TextInput
@@ -786,107 +815,136 @@ export function SkillsPage() {
               </div>
             )}
           </FormGroup>
-          <FormGroup label="Tools from External MCPs (optional bulk-add)" fieldId="skill-from-mcps">
-            <Text component="small" style={{ display: 'block', marginBottom: '0.5rem', color: '#6a6e73' }}>
-              Pick one or more imported MCPs and a mode — on create, the matching tools will be added automatically.
-            </Text>
-            {externalMcps === undefined ? (
-              <Text component="small">Loading MCPs…</Text>
-            ) : externalMcps.length === 0 ? (
-              <Text component="small" style={{ color: '#6a6e73' }}>
-                No external MCPs registered yet. You can still create the skill and add tools manually below — or go to{' '}
-                <a href="/external-mcps">External MCPs</a> and import one first.
-              </Text>
-            ) : (
-              <>
-                <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', marginBottom: '0.5rem' }}>
-                  {externalMcps.map((s) => {
-                    const checked = createMcpSelections.includes(s.name);
-                    return (
-                      <label key={s.name} style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-                        <input
-                          type="checkbox"
-                          checked={checked}
-                          onChange={(e) => {
-                            setCreateMcpSelections((cur) =>
-                              e.target.checked
-                                ? [...cur, s.name]
-                                : cur.filter((n) => n !== s.name),
-                            );
-                          }}
-                        />
-                        <span>
-                          <strong>{s.name}</strong>{' '}
-                          <small style={{ color: '#6a6e73' }}>
-                            ({s.transport}, {s.tool_count} primitives, {s.status})
-                          </small>
-                        </span>
-                      </label>
-                    );
-                  })}
-                </div>
-                {createMcpSelections.length > 0 && (
-                  <>
-                    <Text component="small" style={{ display: 'block', fontWeight: 600, marginTop: '0.5rem' }}>
-                      Which tools to add?
-                    </Text>
-                    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
-                      {([
-                        {
-                          v: 'primitives' as const,
-                          label: 'Only MCP primitives',
-                          help: 'Just the tools imported directly from the selected server(s).',
-                        },
-                        {
-                          v: 'related' as const,
-                          label: 'All related tools (primitives + composites)',
-                          help: 'Every composite whose mcp_dependencies intersects the selection, plus the primitives themselves. Ignores the bundled_with_mcps flag.',
-                        },
-                        {
-                          v: 'bundled_related' as const,
-                          label: 'Bundled related tools (default)',
-                          help: 'Same as "related", but skips any tool whose bundled_with_mcps is False. If you want those included, pick "All related tools" instead.',
-                        },
-                      ]).map((opt) => (
-                        <label key={opt.v} style={{ display: 'flex', alignItems: 'flex-start', gap: '0.5rem' }}>
-                          <input
-                            type="radio"
-                            name="createMcpMode"
-                            value={opt.v}
-                            checked={createMcpMode === opt.v}
-                            onChange={() => setCreateMcpMode(opt.v)}
-                          />
-                          <span>
-                            <strong>{opt.label}</strong>
-                            <div style={{ fontSize: '0.85em', color: '#6a6e73' }}>{opt.help}</div>
-                          </span>
-                        </label>
-                      ))}
-                    </div>
-                  </>
-                )}
-                {createBulkResult && (
-                  <div style={{ marginTop: '0.5rem', padding: '0.75rem', background: '#f0f8ff', borderRadius: 4 }}>
-                    <div>✅ Added <strong>{createBulkResult.added.length}</strong> tool(s) from MCPs</div>
-                    {createBulkResult.skipped_unbundled.length > 0 && (
-                      <div>🚫 Skipped (unbundled): {createBulkResult.skipped_unbundled.join(', ')}</div>
-                    )}
-                    {createBulkResult.skipped_broken.length > 0 && (
-                      <div>
-                        ⚠️ Skipped (broken):{' '}
-                        {createBulkResult.skipped_broken.map((t) => `${t.name} (${t.reason})`).join(', ')}
-                      </div>
-                    )}
-                  </div>
-                )}
-              </>
-            )}
-          </FormGroup>
-
           <FormGroup label="Tools" fieldId="skill-tools">
             <Text component="small" style={{ display: 'block', marginBottom: '0.5rem', color: '#6a6e73' }}>
               Search and select tools to include in this skill
             </Text>
+
+            {/* Shortcut: populate the Tools selection below from an MCP server's
+                tools, using one of the three filter modes. The matches land in
+                the Tools selection chip list; you can then tweak (add/remove)
+                anything before creating. */}
+            <div style={{ marginBottom: '0.75rem' }}>
+              <Button
+                variant="secondary"
+                onClick={() => setIsMcpPickerOpen((v) => !v)}
+              >
+                {isMcpPickerOpen ? 'Cancel — don’t add from MCPs' : 'Add tools from MCPs…'}
+              </Button>
+
+              {isMcpPickerOpen && (
+                <div
+                  style={{
+                    marginTop: '0.5rem',
+                    padding: '0.75rem',
+                    border: '1px solid #d2d2d2',
+                    borderRadius: 4,
+                    background: '#fafafa',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: '0.5rem',
+                  }}
+                >
+                  <strong>1. Pick one or more MCP servers</strong>
+                  {externalMcps === undefined ? (
+                    <Text component="small">Loading MCPs…</Text>
+                  ) : externalMcps.length === 0 ? (
+                    <Text component="small" style={{ color: '#6a6e73' }}>
+                      No external MCPs registered yet.{' '}
+                      <a href="/external-mcps">Go register one</a>, then come back.
+                    </Text>
+                  ) : (
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+                      {externalMcps.map((s) => (
+                        <label key={s.name} style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                          <input
+                            type="checkbox"
+                            checked={createMcpSelections.includes(s.name)}
+                            onChange={(e) => {
+                              setCreateMcpSelections((cur) =>
+                                e.target.checked
+                                  ? [...cur, s.name]
+                                  : cur.filter((n) => n !== s.name),
+                              );
+                            }}
+                          />
+                          <span>
+                            <strong>{s.name}</strong>{' '}
+                            <small style={{ color: '#6a6e73' }}>
+                              ({s.transport}, {s.tool_count} primitives, {s.status})
+                            </small>
+                          </span>
+                        </label>
+                      ))}
+                    </div>
+                  )}
+
+                  {externalMcps && externalMcps.length > 0 && createMcpSelections.length > 0 && (
+                    <>
+                      <strong style={{ marginTop: '0.5rem' }}>2. Which tools?</strong>
+                      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+                        {([
+                          {
+                            v: 'primitives' as const,
+                            label: 'Only MCP primitives',
+                            help: 'Just the tools imported directly from the selected server(s).',
+                          },
+                          {
+                            v: 'related' as const,
+                            label: 'All related tools (primitives + composites)',
+                            help: 'Every composite whose mcp_dependencies intersects the selection, plus the primitives themselves. Ignores the bundled_with_mcps flag.',
+                          },
+                          {
+                            v: 'bundled_related' as const,
+                            label: 'Bundled related tools (default)',
+                            help: 'Same as "related", but skips any tool whose bundled_with_mcps is False. For those, pick "All related tools" instead.',
+                          },
+                        ]).map((opt) => (
+                          <label key={opt.v} style={{ display: 'flex', alignItems: 'flex-start', gap: '0.5rem' }}>
+                            <input
+                              type="radio"
+                              name="createMcpMode"
+                              value={opt.v}
+                              checked={createMcpMode === opt.v}
+                              onChange={() => setCreateMcpMode(opt.v)}
+                            />
+                            <span>
+                              <strong>{opt.label}</strong>
+                              <div style={{ fontSize: '0.85em', color: '#6a6e73' }}>{opt.help}</div>
+                            </span>
+                          </label>
+                        ))}
+                      </div>
+
+                      <div
+                        style={{
+                          marginTop: '0.5rem',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'space-between',
+                          gap: '0.5rem',
+                        }}
+                      >
+                        <span style={{ color: '#6a6e73' }}>
+                          Will add <strong>{mcpMatchPreview.length}</strong>{' '}
+                          tool{mcpMatchPreview.length === 1 ? '' : 's'} to the selection below.
+                        </span>
+                        <Button
+                          variant="primary"
+                          onClick={() => {
+                            handleAddMatchingToolsToSelection();
+                            setIsMcpPickerOpen(false);
+                          }}
+                          isDisabled={mcpMatchPreview.length === 0}
+                        >
+                          Add to selection
+                        </Button>
+                      </div>
+                    </>
+                  )}
+                </div>
+              )}
+            </div>
             <Select
               id="skill-tools-select"
               isOpen={isToolSelectOpen}

--- a/src/skillberry_store/ui/src/pages/ToolDetailPage.tsx
+++ b/src/skillberry_store/ui/src/pages/ToolDetailPage.tsx
@@ -36,7 +36,7 @@ import {
   FormSelect,
   FormSelectOption,
 } from '@patternfly/react-core';
-import { PlayIcon, TrashIcon, EditIcon } from '@patternfly/react-icons';
+import { PlayIcon, TrashIcon, EditIcon, SaveIcon, TimesIcon } from '@patternfly/react-icons';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { toolsApi } from '@/services/api';
@@ -66,6 +66,8 @@ export function ToolDetailPage() {
   const [tagInput, setTagInput] = useState('');
   const [extraInput, setExtraInput] = useState('{}');
   const [editError, setEditError] = useState('');
+  const [isEditingCode, setIsEditingCode] = useState(false);
+  const [editedCode, setEditedCode] = useState('');
 
   // Fetch tool details
   const { data: tool, isLoading, error } = useQuery({
@@ -110,6 +112,16 @@ export function ToolDetailPage() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['tools'] });
       navigate('/tools');
+    },
+  });
+
+  // Update module mutation
+  const updateModuleMutation = useMutation({
+    mutationFn: (content: string) => toolsApi.updateModule(name!, content),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['tools', name, 'module'] });
+      queryClient.invalidateQueries({ queryKey: ['tools', name] });
+      setIsEditingCode(false);
     },
   });
 
@@ -272,11 +284,56 @@ export function ToolDetailPage() {
                       <DescriptionListDescription>
                         <Label color={
                           tool.state === 'approved' ? 'green' :
+                          tool.state === 'broken' ? 'red' :
                           tool.state === 'checked' ? 'blue' :
                           tool.state === 'new' ? 'cyan' : 'orange'
                         }>
                           {tool.state}
                         </Label>
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                  )}
+
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Health</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {(tool as any).state === 'broken' ? (
+                        <>
+                          <Label color="red">broken</Label>
+                          {(tool as any).broken_reason && (
+                            <span style={{ marginLeft: '0.5rem', color: 'var(--pf-v5-global--danger-color--100)' }}>
+                              {(tool as any).broken_reason}
+                            </span>
+                          )}
+                        </>
+                      ) : (
+                        <Label color="green">healthy</Label>
+                      )}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+
+                  {(tool as any).mcp_server && (
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Imported from MCP</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        <a href={`/external-mcps/${encodeURIComponent((tool as any).mcp_server)}`}>
+                          <Label color="purple">{(tool as any).mcp_server}</Label>
+                        </a>
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                  )}
+
+                  {(tool as any).mcp_dependencies && (tool as any).mcp_dependencies.length > 0 && (
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>External MCP dependencies</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+                          {(tool as any).mcp_dependencies.map((name: string) => (
+                            <a key={name} href={`/external-mcps/${encodeURIComponent(name)}`}>
+                              <Label color="purple">{name}</Label>
+                            </a>
+                          ))}
+                        </div>
                       </DescriptionListDescription>
                     </DescriptionListGroup>
                   )}
@@ -435,8 +492,53 @@ export function ToolDetailPage() {
           {tool.module_name ? (
             <Tab eventKey={1} title={<TabTitleText>Source Code</TabTitleText>}>
               <Card>
-                <CardTitle>Module Code ({tool.module_name})</CardTitle>
+                <CardTitle style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                  <span>Module Code ({tool.module_name})</span>
+                  {moduleCode && tool.packaging_format !== 'mcp' && (
+                    <div style={{ display: 'flex', gap: '0.5rem' }}>
+                      {isEditingCode ? (
+                        <>
+                          <Button
+                            variant="primary"
+                            icon={<SaveIcon />}
+                            size="sm"
+                            onClick={() => updateModuleMutation.mutate(editedCode)}
+                            isLoading={updateModuleMutation.isPending}
+                          >
+                            Save
+                          </Button>
+                          <Button
+                            variant="secondary"
+                            icon={<TimesIcon />}
+                            size="sm"
+                            onClick={() => setIsEditingCode(false)}
+                            isDisabled={updateModuleMutation.isPending}
+                          >
+                            Cancel
+                          </Button>
+                        </>
+                      ) : (
+                        <Button
+                          variant="secondary"
+                          icon={<EditIcon />}
+                          size="sm"
+                          onClick={() => {
+                            setEditedCode(moduleCode);
+                            setIsEditingCode(true);
+                          }}
+                        >
+                          Edit Code
+                        </Button>
+                      )}
+                    </div>
+                  )}
+                </CardTitle>
                 <CardBody>
+                  {updateModuleMutation.isError && (
+                    <Alert variant="danger" title="Error saving code" isInline style={{ marginBottom: '1rem' }}>
+                      {(updateModuleMutation.error as Error)?.message || 'Failed to save'}
+                    </Alert>
+                  )}
                   {isModuleLoading ? (
                     <div style={{ display: 'flex', justifyContent: 'center', padding: '2rem' }}>
                       <Spinner size="lg" />
@@ -446,27 +548,46 @@ export function ToolDetailPage() {
                       {(moduleError as Error).message}
                     </Alert>
                   ) : moduleCode ? (
-                    <div style={{
-                      maxHeight: '70vh',
-                      overflow: 'auto',
-                      border: '1px solid #3d3d3d',
-                      borderRadius: '6px'
-                    }}>
-                      <SyntaxHighlighter
-                        language="python"
-                        style={vscDarkPlus}
-                        showLineNumbers={true}
-                        wrapLines={false}
-                        customStyle={{
-                          margin: 0,
-                          fontSize: '15px',
+                    isEditingCode ? (
+                      <TextArea
+                        value={editedCode}
+                        onChange={(_, value) => setEditedCode(value)}
+                        aria-label="Edit source code"
+                        resizeOrientation="vertical"
+                        style={{
+                          fontFamily: 'monospace',
+                          fontSize: '14px',
                           lineHeight: '1.6',
-                          minHeight: '100%',
+                          minHeight: '60vh',
+                          backgroundColor: '#1e1e1e',
+                          color: '#d4d4d4',
+                          border: '1px solid #3d3d3d',
+                          borderRadius: '6px',
                         }}
-                      >
-                        {moduleCode}
-                      </SyntaxHighlighter>
-                    </div>
+                      />
+                    ) : (
+                      <div style={{
+                        maxHeight: '70vh',
+                        overflow: 'auto',
+                        border: '1px solid #3d3d3d',
+                        borderRadius: '6px'
+                      }}>
+                        <SyntaxHighlighter
+                          language="python"
+                          style={vscDarkPlus}
+                          showLineNumbers={true}
+                          wrapLines={false}
+                          customStyle={{
+                            margin: 0,
+                            fontSize: '15px',
+                            lineHeight: '1.6',
+                            minHeight: '100%',
+                          }}
+                        >
+                          {moduleCode}
+                        </SyntaxHighlighter>
+                      </div>
+                    )
                   ) : (
                     <Text>No module code available</Text>
                   )}

--- a/src/skillberry_store/ui/src/pages/ToolDetailPage.tsx
+++ b/src/skillberry_store/ui/src/pages/ToolDetailPage.tsx
@@ -56,7 +56,7 @@ export function ToolDetailPage() {
     name: '',
     description: '',
     version: '',
-    state: 'approved' as 'unknown' | 'any' | 'new' | 'checked' | 'approved',
+    state: 'approved' as 'unknown' | 'any' | 'new' | 'checked' | 'approved' | 'broken',
     tags: [] as string[],
     module_name: '',
     programming_language: 'python',
@@ -323,17 +323,23 @@ export function ToolDetailPage() {
                     </DescriptionListGroup>
                   )}
 
-                  {(tool as any).mcp_dependencies && (tool as any).mcp_dependencies.length > 0 && (
+                  {((tool as any).mcp_server || ((tool as any).mcp_dependencies && (tool as any).mcp_dependencies.length > 0)) && (
                     <DescriptionListGroup>
                       <DescriptionListTerm>External MCP dependencies</DescriptionListTerm>
                       <DescriptionListDescription>
-                        <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
-                          {(tool as any).mcp_dependencies.map((name: string) => (
-                            <a key={name} href={`/external-mcps/${encodeURIComponent(name)}`}>
-                              <Label color="purple">{name}</Label>
-                            </a>
-                          ))}
-                        </div>
+                        {(tool as any).mcp_dependencies && (tool as any).mcp_dependencies.length > 0 ? (
+                          <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+                            {(tool as any).mcp_dependencies.map((name: string) => (
+                              <a key={name} href={`/external-mcps/${encodeURIComponent(name)}`}>
+                                <Label color="purple">{name}</Label>
+                              </a>
+                            ))}
+                          </div>
+                        ) : (
+                          <span style={{ color: 'var(--pf-v5-global--Color--200)' }}>
+                            — none (this tool is itself an MCP primitive; dependencies are aggregated only for composites)
+                          </span>
+                        )}
                       </DescriptionListDescription>
                     </DescriptionListGroup>
                   )}

--- a/src/skillberry_store/ui/src/pages/ToolsPage.tsx
+++ b/src/skillberry_store/ui/src/pages/ToolsPage.tsx
@@ -49,8 +49,10 @@ export function ToolsPage() {
   const [similarityThreshold, setSimilarityThreshold] = useState(1);
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [createMode, setCreateMode] = useState<'upload' | 'write'>('upload');
   const [toolName, setToolName] = useState('');
   const [moduleFile, setModuleFile] = useState<File | null>(null);
+  const [codeContent, setCodeContent] = useState('');
   const [updateIfExists, setUpdateIfExists] = useState(false);
   const [createError, setCreateError] = useState('');
   const [selectedTools, setSelectedTools] = useState<string[]>([]);
@@ -81,8 +83,10 @@ export function ToolsPage() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['tools'] });
       setIsCreateModalOpen(false);
+      setCreateMode('upload');
       setToolName('');
       setModuleFile(null);
+      setCodeContent('');
       setUpdateIfExists(false);
       setCreateError('');
     },
@@ -104,16 +108,34 @@ export function ToolsPage() {
   });
 
   const handleCreateTool = () => {
-    if (!moduleFile) {
-      setCreateError('Please upload a Python file');
-      return;
+    let file: File;
+
+    if (createMode === 'upload') {
+      if (!moduleFile) {
+        setCreateError('Please upload a Python file');
+        return;
+      }
+      if (!moduleFile.name.endsWith('.py')) {
+        setCreateError('Only Python (.py) files are supported');
+        return;
+      }
+      file = moduleFile;
+    } else {
+      const code = codeContent.trim();
+      if (!code) {
+        setCreateError('Please write some Python code');
+        return;
+      }
+      if (!code.includes('def ')) {
+        setCreateError('Code must contain at least one function definition (def ...)');
+        return;
+      }
+      const fileName = toolName.trim() ? `${toolName.trim()}.py` : 'tool.py';
+      file = new File([code], fileName, { type: 'text/x-python' });
     }
-    if (!moduleFile.name.endsWith('.py')) {
-      setCreateError('Only Python (.py) files are supported');
-      return;
-    }
+
     createMutation.mutate({
-      file: moduleFile,
+      file,
       toolName: toolName.trim() || undefined,
       update: updateIfExists
     });
@@ -463,8 +485,10 @@ export function ToolsPage() {
         isOpen={isCreateModalOpen}
         onClose={() => {
           setIsCreateModalOpen(false);
+          setCreateMode('upload');
           setToolName('');
           setModuleFile(null);
+          setCodeContent('');
           setUpdateIfExists(false);
           setCreateError('');
         }}
@@ -482,8 +506,10 @@ export function ToolsPage() {
             variant="link"
             onClick={() => {
               setIsCreateModalOpen(false);
+              setCreateMode('upload');
               setToolName('');
               setModuleFile(null);
+              setCodeContent('');
               setUpdateIfExists(false);
               setCreateError('');
             }}
@@ -498,35 +524,94 @@ export function ToolsPage() {
           </Alert>
         )}
         <Alert variant="info" title="How it works" isInline style={{ marginBottom: '1rem' }}>
-          Upload a Python file with a function that has a properly formatted docstring.
-          The tool will automatically extract the function name, description, and parameters from the docstring.
+          {createMode === 'upload'
+            ? 'Upload a Python file with a function that has a properly formatted docstring. The tool will automatically extract the function name, description, and parameters from the docstring.'
+            : 'Write a Python function with a Google-style docstring. The tool name, description, and parameters will be extracted automatically from the docstring.'}
         </Alert>
         <Form>
-          <FormGroup
-            label="Python File"
-            isRequired
-            fieldId="tool-module"
-          >
-            <Text component="small" style={{ display: 'block', marginBottom: '0.5rem', color: '#6a6e73' }}>
-              Upload a .py file containing a function with a docstring
-            </Text>
-            <FileUpload
-              id="tool-module"
-              value={moduleFile || undefined}
-              filename={moduleFile?.name}
-              onFileInputChange={(_event: any, file: File) => setModuleFile(file)}
-              onClearClick={() => setModuleFile(null)}
-              hideDefaultPreview
-              browseButtonText="Upload Python File"
-              accept=".py"
-            />
+          <FormGroup label="Input Method" fieldId="create-mode">
+            <div style={{ display: 'flex', gap: '1rem', marginBottom: '0.5rem' }}>
+              <Button
+                variant={createMode === 'upload' ? 'primary' : 'secondary'}
+                onClick={() => setCreateMode('upload')}
+                size="sm"
+              >
+                Upload File
+              </Button>
+              <Button
+                variant={createMode === 'write' ? 'primary' : 'secondary'}
+                onClick={() => {
+                  setCreateMode('write');
+                  if (!codeContent) {
+                    setCodeContent(
+`def add(a: float, b: float) -> float:
+    """Returns the sum of a and b.
+
+    Args:
+        a (float): The first number.
+        b (float): The second number.
+
+    Returns:
+        float: The sum of a and b.
+    """
+    return a + b
+`
+                    );
+                  }
+                }}
+                size="sm"
+              >
+                Write Code
+              </Button>
+            </div>
           </FormGroup>
+
+          {createMode === 'upload' ? (
+            <FormGroup
+              label="Python File"
+              isRequired
+              fieldId="tool-module"
+            >
+              <Text component="small" style={{ display: 'block', marginBottom: '0.5rem', color: '#6a6e73' }}>
+                Upload a .py file containing a function with a docstring
+              </Text>
+              <FileUpload
+                id="tool-module"
+                value={moduleFile || undefined}
+                filename={moduleFile?.name}
+                onFileInputChange={(_event: any, file: File) => setModuleFile(file)}
+                onClearClick={() => setModuleFile(null)}
+                hideDefaultPreview
+                browseButtonText="Upload Python File"
+                accept=".py"
+              />
+            </FormGroup>
+          ) : (
+            <FormGroup
+              label="Python Code"
+              isRequired
+              fieldId="tool-code"
+            >
+              <Text component="small" style={{ display: 'block', marginBottom: '0.5rem', color: '#6a6e73' }}>
+                Write a function with type hints and a Google-style docstring (Args, Returns sections)
+              </Text>
+              <TextArea
+                id="tool-code"
+                value={codeContent}
+                onChange={(_event, value) => setCodeContent(value)}
+                rows={18}
+                style={{ fontFamily: 'monospace', fontSize: '0.85rem' }}
+                resizeOrientation="vertical"
+              />
+            </FormGroup>
+          )}
+
           <FormGroup
             label="Function Name"
             fieldId="tool-name"
           >
             <Text component="small" style={{ display: 'block', marginBottom: '0.5rem', color: '#6a6e73' }}>
-              Optional: Specify which function to use if the file contains multiple functions. If not provided, the first function will be used.
+              Optional: Specify which function to use if the code contains multiple functions. If not provided, the first function will be used.
             </Text>
             <TextInput
               type="text"

--- a/src/skillberry_store/ui/src/pages/VMCPServerDetailPage.tsx
+++ b/src/skillberry_store/ui/src/pages/VMCPServerDetailPage.tsx
@@ -39,6 +39,8 @@ import {
   ExpandableSection,
   CodeBlock,
   CodeBlockCode,
+  ClipboardCopy,
+  ClipboardCopyVariant,
 } from '@patternfly/react-core';
 import { EditIcon, TrashIcon, ConnectedIcon, DisconnectedIcon } from '@patternfly/react-icons';
 import { vmcpApi, skillsApi } from '@/services/api';
@@ -637,6 +639,48 @@ export function VMCPServerDetailPage() {
             )}
           </CardBody>
         </Card>
+
+        {/* Connect to Claude Code */}
+        {server.port && (
+          <Card style={{ marginTop: '1rem' }}>
+            <CardTitle>Connect to Claude Code</CardTitle>
+            <CardBody>
+              <Text style={{ marginBottom: '1rem' }}>
+                Use the following command to add this MCP server to Claude Code. This registers the server using SSE transport so Claude Code can discover and call its tools.
+              </Text>
+              <Text component="h4" style={{ marginBottom: '0.5rem', fontWeight: 'bold' }}>
+                Add to Claude Code:
+              </Text>
+              <ClipboardCopy
+                isReadOnly
+                hoverTip="Copy"
+                clickTip="Copied"
+                variant={ClipboardCopyVariant.expansion}
+                style={{ marginBottom: '1rem' }}
+              >
+                {`claude mcp add ${server.name} -s user -t sse http://localhost:${server.port}/sse`}
+              </ClipboardCopy>
+              <Text style={{ marginBottom: '0.5rem', marginTop: '1rem' }} component="small">
+                <strong>-s user</strong> saves to your user-level settings (available across all projects).
+                Use <strong>-s project</strong> to save to the current project only.
+              </Text>
+              <Text style={{ marginBottom: '1rem' }} component="small">
+                <strong>-t sse</strong> sets the transport to Server-Sent Events, which is the protocol this MCP server uses.
+              </Text>
+              <Text component="h4" style={{ marginBottom: '0.5rem', fontWeight: 'bold', marginTop: '1rem' }}>
+                Remove from Claude Code:
+              </Text>
+              <ClipboardCopy
+                isReadOnly
+                hoverTip="Copy"
+                clickTip="Copied"
+                style={{ marginBottom: '0.5rem' }}
+              >
+                {`claude mcp remove ${server.name} -s user`}
+              </ClipboardCopy>
+            </CardBody>
+          </Card>
+        )}
       </PageSection>
 
       {/* Edit Modal */}

--- a/src/skillberry_store/ui/src/plugins/SlotRenderer.tsx
+++ b/src/skillberry_store/ui/src/plugins/SlotRenderer.tsx
@@ -1,0 +1,33 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+
+import { Fragment } from 'react';
+import { useActiveManifests } from './registry';
+
+interface PluginSlotProps {
+  name: string;
+  ctx?: Record<string, unknown>;
+}
+
+/**
+ * Extension point rendered by main pages. Any active plugin that contributes
+ * to the slot name will render its component here, receiving `ctx` as props.
+ * If no plugin contributes, nothing renders.
+ */
+export function PluginSlot({ name, ctx }: PluginSlotProps) {
+  const activeManifests = useActiveManifests();
+  const contributions = activeManifests.flatMap((m) => m.slots[name] || []);
+  if (contributions.length === 0) return null;
+  return (
+    <>
+      {contributions.map((c) => {
+        const Comp = c.component as React.ComponentType<any>;
+        return (
+          <Fragment key={c.id}>
+            <Comp {...(ctx || {})} />
+          </Fragment>
+        );
+      })}
+    </>
+  );
+}

--- a/src/skillberry_store/ui/src/plugins/registry.ts
+++ b/src/skillberry_store/ui/src/plugins/registry.ts
@@ -1,0 +1,79 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+//
+// UI plugin registry. Main code never references a plugin by id — it reads
+// active plugins from here and iterates. The set of installed plugins is the
+// hand-maintained `manifests` list below; which ones are "active" is fetched
+// from the backend `/plugins` endpoint and stored in a small hook.
+
+import { useSyncExternalStore } from 'react';
+import type { PluginManifest, PluginListItem } from './types';
+import { runspaceManifest } from './runspace/manifest';
+
+export const manifests: PluginManifest[] = [runspaceManifest];
+
+type Listener = () => void;
+
+let activeIds: Set<string> = new Set();
+let loaded = false;
+const listeners = new Set<Listener>();
+
+function emit() {
+  for (const l of listeners) l();
+}
+
+export function getActiveManifests(): PluginManifest[] {
+  return manifests.filter((m) => activeIds.has(m.id));
+}
+
+export function getActiveIds(): Set<string> {
+  return new Set(activeIds);
+}
+
+export function isActive(id: string): boolean {
+  return activeIds.has(id);
+}
+
+export function setActiveIds(ids: Iterable<string>) {
+  activeIds = new Set(ids);
+  loaded = true;
+  emit();
+}
+
+export function isLoaded(): boolean {
+  return loaded;
+}
+
+function subscribe(listener: Listener) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+const ACTIVE_SNAPSHOT = { current: activeIds } as { current: Set<string> };
+function syncSnapshot() {
+  if (ACTIVE_SNAPSHOT.current !== activeIds) {
+    ACTIVE_SNAPSHOT.current = activeIds;
+  }
+  return ACTIVE_SNAPSHOT.current;
+}
+
+export function useActivePlugins(): Set<string> {
+  return useSyncExternalStore(
+    (listener) => subscribe(() => { syncSnapshot(); listener(); }),
+    syncSnapshot,
+    syncSnapshot,
+  );
+}
+
+export function useActiveManifests(): PluginManifest[] {
+  const ids = useActivePlugins();
+  return manifests.filter((m) => ids.has(m.id));
+}
+
+export function applyPluginsListFromBackend(items: PluginListItem[]) {
+  setActiveIds(items.filter((p) => p.enabled).map((p) => p.id));
+}
+
+export function getInstalledManifests(): PluginManifest[] {
+  return manifests;
+}

--- a/src/skillberry_store/ui/src/plugins/runspace/AgenticExportModal.tsx
+++ b/src/skillberry_store/ui/src/plugins/runspace/AgenticExportModal.tsx
@@ -1,0 +1,398 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+
+import { useState, useEffect, useCallback } from 'react';
+import {
+  Modal,
+  ModalVariant,
+  Button,
+  Form,
+  FormGroup,
+  TextInput,
+  TextArea,
+  Alert,
+  Spinner,
+  ClipboardCopy,
+  ClipboardCopyVariant,
+  DescriptionList,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  DescriptionListDescription,
+} from '@patternfly/react-core';
+import { DownloadIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import {
+  runspaceSettingsApi,
+  runspaceSkillApi,
+  envVarsToRecord,
+} from './api';
+
+interface AgenticExportModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  skillName: string;
+}
+
+interface SessionDetail {
+  session_id: string;
+  status: string;
+  total_tokens?: number;
+  total_cost_usd?: number | null;
+  duration_seconds?: number | null;
+  error?: string | null;
+  has_summary?: boolean;
+}
+
+export function AgenticExportModal({
+  isOpen,
+  onClose,
+  skillName,
+}: AgenticExportModalProps) {
+  const [runspaceUrl, setRunspaceUrl] = useState('http://localhost:6767');
+  const [requestBody, setRequestBody] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSending, setIsSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [sessionDetail, setSessionDetail] = useState<SessionDetail | null>(null);
+  const [summary, setSummary] = useState<string | null>(null);
+
+  const sessionStatus = sessionDetail?.status || null;
+
+  const resetState = useCallback(() => {
+    setRequestBody('');
+    setError(null);
+    setSessionId(null);
+    setSessionDetail(null);
+    setSummary(null);
+    setIsSending(false);
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen || !skillName) return;
+    resetState();
+    setIsLoading(true);
+
+    Promise.all([
+      runspaceSkillApi.exportAgentRequest(skillName),
+      runspaceSettingsApi.get(),
+    ])
+      .then(([data, settings]) => {
+        if (settings.runspace_url) {
+          setRunspaceUrl(settings.runspace_url);
+        }
+        if (data.agent_settings) {
+          data.agent_settings.env = envVarsToRecord(settings.env_vars || []);
+        }
+        setRequestBody(JSON.stringify(data, null, 2));
+      })
+      .catch((err) => {
+        setError(`Failed to build request: ${err.message}`);
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }, [isOpen, skillName, resetState]);
+
+  useEffect(() => {
+    if (!sessionId || !runspaceUrl) return;
+    if (sessionStatus === 'completed' || sessionStatus === 'failed') return;
+
+    const poll = async () => {
+      try {
+        const resp = await fetch(`${runspaceUrl}/sessions/${sessionId}`);
+        if (resp.ok) {
+          const data: SessionDetail = await resp.json();
+          setSessionDetail(data);
+        }
+      } catch {
+        // Network errors during polling are non-fatal
+      }
+    };
+
+    poll();
+    const interval = setInterval(poll, 5000);
+    return () => clearInterval(interval);
+  }, [sessionId, sessionStatus, runspaceUrl]);
+
+  useEffect(() => {
+    if (sessionStatus !== 'completed' || !sessionId || !runspaceUrl) return;
+    if (summary !== null) return;
+
+    fetch(`${runspaceUrl}/sessions/${sessionId}/summary`)
+      .then((resp) => {
+        if (resp.ok) return resp.text();
+        return null;
+      })
+      .then((text) => {
+        if (!text) return;
+        try {
+          const parsed = JSON.parse(text);
+          setSummary(parsed.content || text);
+        } catch {
+          setSummary(text);
+        }
+      })
+      .catch(() => {});
+  }, [sessionStatus, sessionId, runspaceUrl, summary]);
+
+  const handleSend = async () => {
+    setIsSending(true);
+    setError(null);
+
+    try {
+      const parsed = JSON.parse(requestBody);
+      const resp = await fetch(`${runspaceUrl}/run`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(parsed),
+      });
+
+      if (!resp.ok) {
+        const errText = await resp.text();
+        throw new Error(errText || `Server returned ${resp.status}`);
+      }
+
+      const data = await resp.json();
+      setSessionId(data.session_id);
+      setSessionDetail({ session_id: data.session_id, status: data.status || 'pending' });
+    } catch (err: any) {
+      if (err.name === 'TypeError' && err.message.includes('fetch')) {
+        setError(
+          `Could not reach Runspace at ${runspaceUrl}. ` +
+            'Make sure the server is running and CORS is enabled. ' +
+            'You can use "Copy as cURL" as a fallback.'
+        );
+      } else {
+        setError(`Failed to send: ${err.message}`);
+      }
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  const handleDownloadEditable = () => {
+    if (!sessionId || !runspaceUrl) return;
+    window.open(`${runspaceUrl}/sessions/${sessionId}/editable.zip`, '_blank');
+  };
+
+  const buildCurlCommand = () => {
+    const body = requestBody.replace(/'/g, "'\\''");
+    return `curl -X POST ${runspaceUrl}/run \\\n  -H "Content-Type: application/json" \\\n  -d '${body}'`;
+  };
+
+  const handleClose = () => {
+    if (!isSending) {
+      resetState();
+      onClose();
+    }
+  };
+
+  const getStatusVariant = () => {
+    switch (sessionStatus) {
+      case 'completed':
+        return 'success';
+      case 'failed':
+        return 'danger';
+      case 'running':
+        return 'info';
+      default:
+        return 'info';
+    }
+  };
+
+  const formatDuration = (seconds: number | null | undefined) => {
+    if (seconds == null) return '-';
+    if (seconds < 60) return `${seconds.toFixed(1)}s`;
+    const mins = Math.floor(seconds / 60);
+    const secs = (seconds % 60).toFixed(0);
+    return `${mins}m ${secs}s`;
+  };
+
+  return (
+    <Modal
+      variant={ModalVariant.large}
+      title="Export with Runspace Agent"
+      isOpen={isOpen}
+      onClose={handleClose}
+      actions={[
+        ...(sessionStatus === 'completed'
+          ? [
+              <Button
+                key="download"
+                variant="primary"
+                icon={<DownloadIcon />}
+                onClick={handleDownloadEditable}
+              >
+                Download Result
+              </Button>,
+            ]
+          : [
+              <Button
+                key="send"
+                variant="primary"
+                onClick={handleSend}
+                isDisabled={isLoading || isSending || !requestBody || !!sessionId}
+              >
+                {isSending ? (
+                  <>
+                    <Spinner size="md" /> Sending...
+                  </>
+                ) : (
+                  'Send to Agent'
+                )}
+              </Button>,
+            ]),
+        <Button key="close" variant="link" onClick={handleClose} isDisabled={isSending}>
+          {sessionId ? 'Close' : 'Cancel'}
+        </Button>,
+      ]}
+    >
+      <Form>
+        <FormGroup label="Runspace URL" isRequired fieldId="runspace-url">
+          <TextInput
+            type="text"
+            id="runspace-url"
+            value={runspaceUrl}
+            onChange={(_event, value) => setRunspaceUrl(value)}
+            isDisabled={!!sessionId}
+            placeholder="http://localhost:6767"
+          />
+          <div style={{ fontSize: '0.875rem', color: '#6a6e73', marginTop: '0.25rem' }}>
+            Start Runspace with: <code>runspace-srv</code>
+          </div>
+        </FormGroup>
+
+        {!sessionId && (
+          <>
+            <FormGroup label="Request Body" isRequired fieldId="request-body">
+              {isLoading ? (
+                <div style={{ textAlign: 'center', padding: '2rem' }}>
+                  <Spinner size="lg" />
+                  <div style={{ marginTop: '0.5rem' }}>Building request...</div>
+                </div>
+              ) : (
+                <TextArea
+                  id="request-body"
+                  value={requestBody}
+                  onChange={(_event, value) => setRequestBody(value)}
+                  rows={20}
+                  style={{ fontFamily: 'monospace', fontSize: '0.85rem' }}
+                  resizeOrientation="vertical"
+                />
+              )}
+              <div style={{ fontSize: '0.875rem', color: '#6a6e73', marginTop: '0.25rem' }}>
+                Defines the environment where the Claude Code agent will run.
+                Fill in any placeholder values (e.g. <code>ANTHROPIC_AUTH_TOKEN</code>) before sending.
+              </div>
+            </FormGroup>
+
+            {!isLoading && requestBody && (
+              <FormGroup label="Copy as cURL" fieldId="curl-copy">
+                <ClipboardCopy
+                  isReadOnly
+                  hoverTip="Copy"
+                  clickTip="Copied"
+                  variant={ClipboardCopyVariant.expansion}
+                  isExpanded={false}
+                >
+                  {buildCurlCommand()}
+                </ClipboardCopy>
+              </FormGroup>
+            )}
+          </>
+        )}
+
+        {error && (
+          <Alert variant="danger" title="Error" isInline style={{ marginTop: '1rem' }}>
+            {error}
+          </Alert>
+        )}
+
+        {sessionDetail && (
+          <Alert
+            variant={getStatusVariant()}
+            title={`Session: ${sessionStatus}`}
+            isInline
+            style={{ marginTop: '1rem' }}
+          >
+            <DescriptionList isCompact isHorizontal style={{ marginTop: '0.5rem' }}>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Session ID</DescriptionListTerm>
+                <DescriptionListDescription>
+                  <code style={{ fontSize: '0.85rem' }}>{sessionDetail.session_id}</code>
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              {sessionDetail.duration_seconds != null && (
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Duration</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    {formatDuration(sessionDetail.duration_seconds)}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+              )}
+              {sessionDetail.total_tokens != null && sessionDetail.total_tokens > 0 && (
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Tokens</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    {sessionDetail.total_tokens.toLocaleString()}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+              )}
+              {sessionDetail.total_cost_usd != null && (
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Cost</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    ${sessionDetail.total_cost_usd.toFixed(4)}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+              )}
+              {sessionDetail.error && (
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Error</DescriptionListTerm>
+                  <DescriptionListDescription style={{ color: '#c9190b' }}>
+                    {sessionDetail.error}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+              )}
+            </DescriptionList>
+
+            {sessionStatus !== 'completed' && sessionStatus !== 'failed' && (
+              <div style={{ marginTop: '0.75rem' }}>
+                <Spinner size="sm" /> Polling for status...
+              </div>
+            )}
+
+            <div style={{ marginTop: '0.75rem' }}>
+              <a
+                href={`${runspaceUrl}/ui/sessions/${sessionId}`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <ExternalLinkAltIcon /> Open in Runspace UI
+              </a>
+            </div>
+          </Alert>
+        )}
+
+        {summary && (
+          <FormGroup label="Agent Summary" fieldId="agent-summary" style={{ marginTop: '1rem' }}>
+            <div className="markdown-body" style={{
+              padding: '1rem',
+              background: '#f5f5f5',
+              borderRadius: '6px',
+              border: '1px solid #d2d2d2',
+              maxHeight: '400px',
+              overflow: 'auto',
+              fontSize: '0.9rem',
+              lineHeight: '1.6',
+            }}>
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{summary}</ReactMarkdown>
+            </div>
+          </FormGroup>
+        )}
+      </Form>
+    </Modal>
+  );
+}

--- a/src/skillberry_store/ui/src/plugins/runspace/ExportWithAgentAction.tsx
+++ b/src/skillberry_store/ui/src/plugins/runspace/ExportWithAgentAction.tsx
@@ -1,0 +1,38 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+
+import { useState } from 'react';
+import { Button } from '@patternfly/react-core';
+import { AutomationIcon } from '@patternfly/react-icons';
+import { AgenticExportModal } from './AgenticExportModal';
+
+interface Ctx {
+  skill?: { name?: string };
+}
+
+/**
+ * Slot contribution for `skill.detail.actions`. Renders the "Export with Runspace Agent"
+ * button on the skill detail page and owns the modal's open/close state.
+ */
+export function ExportWithAgentAction({ skill }: Ctx) {
+  const [isOpen, setIsOpen] = useState(false);
+  const skillName = skill?.name || '';
+
+  return (
+    <>
+      <Button
+        variant="secondary"
+        icon={<AutomationIcon />}
+        onClick={() => setIsOpen(true)}
+        isDisabled={!skillName}
+      >
+        Export with Runspace Agent
+      </Button>
+      <AgenticExportModal
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        skillName={skillName}
+      />
+    </>
+  );
+}

--- a/src/skillberry_store/ui/src/plugins/runspace/RunspacePage.tsx
+++ b/src/skillberry_store/ui/src/plugins/runspace/RunspacePage.tsx
@@ -1,0 +1,614 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  PageSection,
+  Card,
+  CardBody,
+  Title,
+  Form,
+  FormGroup,
+  TextInput,
+  TextArea,
+  Button,
+  Alert,
+  Divider,
+  Spinner,
+  Tabs,
+  Tab,
+  TabTitleText,
+  DescriptionList,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  DescriptionListDescription,
+  ExpandableSection,
+  Label,
+  Text,
+} from '@patternfly/react-core';
+import {
+  TrashIcon,
+  PlusCircleIcon,
+  ExternalLinkAltIcon,
+  AutomationIcon,
+  FolderOpenIcon,
+  EyeIcon,
+  EyeSlashIcon,
+} from '@patternfly/react-icons';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import {
+  runspaceSettingsApi,
+  runspaceAgentApi,
+  DEFAULT_RUNSPACE_URL,
+  type AiSettingsEnvVar,
+} from './api';
+
+const VALUE_PLACEHOLDERS: Record<string, string> = {
+  ANTHROPIC_AUTH_TOKEN: 'your-auth-token',
+  ANTHROPIC_BASE_URL: 'https://your-anthropic-base-url',
+};
+
+interface SessionDetail {
+  session_id: string;
+  status: string;
+  total_tokens?: number;
+  total_cost_usd?: number | null;
+  duration_seconds?: number | null;
+  error?: string | null;
+  has_summary?: boolean;
+}
+
+export function RunspacePage() {
+  const navigate = useNavigate();
+  const [activeTabKey, setActiveTabKey] = useState(0);
+
+  const [runspaceUrl, setRunspaceUrl] = useState(DEFAULT_RUNSPACE_URL);
+  const [envVars, setEnvVars] = useState<AiSettingsEnvVar[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [savedMessage, setSavedMessage] = useState(false);
+  const [settingsError, setSettingsError] = useState<string | null>(null);
+  const saveTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const debounceTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isLoaded = useRef(false);
+
+  const [isEnvVarsExpanded, setIsEnvVarsExpanded] = useState(false);
+  const [visibleValues, setVisibleValues] = useState<Set<number>>(new Set());
+
+  const stored = useRef(() => {
+    try {
+      const raw = sessionStorage.getItem('storeAgentSession');
+      return raw ? JSON.parse(raw) : null;
+    } catch { return null; }
+  }).current();
+
+  const [agentPrompt, setAgentPrompt] = useState(stored?.prompt || '');
+  const [contextFiles, setContextFiles] = useState<File[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [isSendingAgent, setIsSendingAgent] = useState(false);
+  const [agentError, setAgentError] = useState<string | null>(null);
+  const [agentSessionId, setAgentSessionId] = useState<string | null>(stored?.sessionId || null);
+  const [agentSessionDetail, setAgentSessionDetail] = useState<SessionDetail | null>(stored?.detail || null);
+  const [agentSummary, setAgentSummary] = useState<string | null>(stored?.summary || null);
+
+  const agentSessionStatus = agentSessionDetail?.status || null;
+
+  useEffect(() => {
+    const data: Record<string, any> = {};
+    if (agentSessionId) data.sessionId = agentSessionId;
+    if (agentSessionDetail) data.detail = agentSessionDetail;
+    if (agentSummary) data.summary = agentSummary;
+    if (agentPrompt && agentSessionId) data.prompt = agentPrompt;
+    if (Object.keys(data).length > 0) {
+      sessionStorage.setItem('storeAgentSession', JSON.stringify(data));
+    } else {
+      sessionStorage.removeItem('storeAgentSession');
+    }
+  }, [agentSessionId, agentSessionDetail, agentSummary, agentPrompt]);
+
+  useEffect(() => {
+    runspaceSettingsApi
+      .get()
+      .then((data) => {
+        setRunspaceUrl(data.runspace_url || DEFAULT_RUNSPACE_URL);
+        setEnvVars(
+          (data.env_vars || []).map((v) => ({
+            key: v.key,
+            value: v.value.startsWith('<') && v.value.endsWith('>') ? '' : v.value,
+          }))
+        );
+        isLoaded.current = true;
+      })
+      .catch((err) => {
+        setSettingsError(`Failed to load settings: ${err.message}`);
+        isLoaded.current = true;
+      })
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  const saveToBackend = useCallback(
+    (url: string, vars: AiSettingsEnvVar[]) => {
+      if (debounceTimeout.current) clearTimeout(debounceTimeout.current);
+      debounceTimeout.current = setTimeout(() => {
+        runspaceSettingsApi
+          .save({ runspace_url: url, env_vars: vars })
+          .then(() => {
+            setSavedMessage(true);
+            if (saveTimeout.current) clearTimeout(saveTimeout.current);
+            saveTimeout.current = setTimeout(() => setSavedMessage(false), 2000);
+          })
+          .catch((err) => setSettingsError(`Failed to save: ${err.message}`));
+      }, 500);
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (!isLoaded.current) return;
+    saveToBackend(runspaceUrl, envVars);
+  }, [runspaceUrl, envVars, saveToBackend]);
+
+  const handleEnvKeyChange = (index: number, value: string) => {
+    setEnvVars((prev) => prev.map((v, i) => (i === index ? { ...v, key: value } : v)));
+  };
+
+  const handleEnvValueChange = (index: number, value: string) => {
+    setEnvVars((prev) => prev.map((v, i) => (i === index ? { ...v, value: value } : v)));
+  };
+
+  const handleAddVar = () => {
+    setEnvVars((prev) => [...prev, { key: '', value: '' }]);
+  };
+
+  const handleRemoveVar = (index: number) => {
+    setEnvVars((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const handleResetDefaults = () => {
+    setRunspaceUrl(DEFAULT_RUNSPACE_URL);
+    setIsLoading(true);
+    runspaceSettingsApi
+      .save({ runspace_url: DEFAULT_RUNSPACE_URL, env_vars: [] })
+      .then(() => runspaceSettingsApi.get())
+      .then((data) => {
+        setRunspaceUrl(data.runspace_url || DEFAULT_RUNSPACE_URL);
+        setEnvVars(
+          (data.env_vars || []).map((v) => ({
+            key: v.key,
+            value: v.value.startsWith('<') && v.value.endsWith('>') ? '' : v.value,
+          }))
+        );
+      })
+      .catch((err) => setSettingsError(`Failed to reset: ${err.message}`))
+      .finally(() => setIsLoading(false));
+  };
+
+  const handleRunAgent = async () => {
+    if (!agentPrompt.trim()) return;
+    setIsSendingAgent(true);
+    setAgentError(null);
+    setAgentSessionId(null);
+    setAgentSessionDetail(null);
+    setAgentSummary(null);
+
+    try {
+      const requestBody = await runspaceAgentApi.buildStoreRequest(agentPrompt, contextFiles.length > 0 ? contextFiles : undefined);
+      const agentRunspaceUrl = requestBody._runspace_url || runspaceUrl;
+      delete requestBody._runspace_url;
+
+      const resp = await fetch(`${agentRunspaceUrl}/run`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(requestBody),
+      });
+
+      if (!resp.ok) {
+        const errText = await resp.text();
+        throw new Error(errText || `Server returned ${resp.status}`);
+      }
+
+      const data = await resp.json();
+      setAgentSessionId(data.session_id);
+      setAgentSessionDetail({ session_id: data.session_id, status: data.status || 'pending' });
+    } catch (err: any) {
+      if (err.name === 'TypeError' && err.message.includes('fetch')) {
+        setAgentError(
+          `Could not reach Runspace at ${runspaceUrl}. ` +
+          'Make sure the server is running (runspace-srv).'
+        );
+      } else {
+        setAgentError(`Failed to run agent: ${err.message}`);
+      }
+    } finally {
+      setIsSendingAgent(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!agentSessionId || !runspaceUrl) return;
+    if (agentSessionStatus === 'completed' || agentSessionStatus === 'failed') return;
+
+    const agentRunspaceUrl = runspaceUrl;
+    const poll = async () => {
+      try {
+        const resp = await fetch(`${agentRunspaceUrl}/sessions/${agentSessionId}`);
+        if (resp.ok) {
+          const data: SessionDetail = await resp.json();
+          setAgentSessionDetail(data);
+        }
+      } catch {
+        // Non-fatal during polling
+      }
+    };
+
+    poll();
+    const interval = setInterval(poll, 5000);
+    return () => clearInterval(interval);
+  }, [agentSessionId, agentSessionStatus, runspaceUrl]);
+
+  useEffect(() => {
+    if (agentSessionStatus !== 'completed' || !agentSessionId || !runspaceUrl) return;
+    if (agentSummary !== null) return;
+
+    fetch(`${runspaceUrl}/sessions/${agentSessionId}/summary`)
+      .then((resp) => {
+        if (resp.ok) return resp.text();
+        return null;
+      })
+      .then((text) => {
+        if (!text) return;
+        try {
+          const parsed = JSON.parse(text);
+          setAgentSummary(parsed.content || text);
+        } catch {
+          setAgentSummary(text);
+        }
+      })
+      .catch(() => {});
+  }, [agentSessionStatus, agentSessionId, runspaceUrl, agentSummary]);
+
+  const formatDuration = (seconds: number | null | undefined) => {
+    if (seconds == null) return '-';
+    if (seconds < 60) return `${seconds.toFixed(1)}s`;
+    const mins = Math.floor(seconds / 60);
+    const secs = (seconds % 60).toFixed(0);
+    return `${mins}m ${secs}s`;
+  };
+
+  const getStatusVariant = () => {
+    switch (agentSessionStatus) {
+      case 'completed': return 'success' as const;
+      case 'failed': return 'danger' as const;
+      default: return 'info' as const;
+    }
+  };
+
+  const handleNewAgentSession = () => {
+    setAgentPrompt('');
+    setContextFiles([]);
+    setAgentSessionId(null);
+    setAgentSessionDetail(null);
+    setAgentSummary(null);
+    setAgentError(null);
+    sessionStorage.removeItem('storeAgentSession');
+  };
+
+  if (isLoading) {
+    return (
+      <PageSection style={{ textAlign: 'center', paddingTop: '4rem' }}>
+        <Spinner size="xl" />
+      </PageSection>
+    );
+  }
+
+  return (
+    <>
+      <PageSection>
+        <Title headingLevel="h1" size="2xl">
+          Runspace
+        </Title>
+        <div style={{ marginTop: '0.5rem', fontSize: '0.925rem', color: '#6a6e73' }}>
+          Build and export agents via the Runspace daemon (runspace-srv). Configure settings
+          or chat with the Runspace Store Agent to create tools, skills, and VMCP servers on your behalf.
+        </div>
+      </PageSection>
+
+      <PageSection>
+        <Tabs activeKey={activeTabKey} onSelect={(_, tabIndex) => setActiveTabKey(tabIndex as number)}>
+          <Tab eventKey={0} title={<TabTitleText>Settings</TabTitleText>}>
+            <Card style={{ marginTop: '1rem' }}>
+              <CardBody>
+                {savedMessage && (
+                  <Alert variant="success" title="Settings saved" isInline isPlain style={{ marginBottom: '1rem' }} />
+                )}
+                {settingsError && (
+                  <Alert variant="danger" title={settingsError} isInline style={{ marginBottom: '1rem' }} />
+                )}
+
+                <Title headingLevel="h2" size="lg" style={{ marginBottom: '0.5rem' }}>
+                  Runspace Configuration
+                </Title>
+                <Alert variant="info" title="Runspace Agent Server" isInline isPlain style={{ marginBottom: '1rem' }}>
+                  The Runspace URL is the address of your Runspace server. You need to run{' '}
+                  <code>runspace-srv</code> from the runspace project so your agent is up and running.
+                </Alert>
+                <Form>
+                  <FormGroup label="Runspace URL" fieldId="runspace-url">
+                    <TextInput
+                      type="text"
+                      id="runspace-url"
+                      value={runspaceUrl}
+                      onChange={(_event, value) => setRunspaceUrl(value)}
+                      placeholder={DEFAULT_RUNSPACE_URL}
+                    />
+                  </FormGroup>
+                </Form>
+
+                <Divider style={{ margin: '1.5rem 0' }} />
+
+                <ExpandableSection
+                  toggleText={`Agent Environment Variables (${envVars.length})`}
+                  isExpanded={isEnvVarsExpanded}
+                  onToggle={(_event, expanded) => setIsEnvVarsExpanded(expanded)}
+                >
+                  <Alert variant="info" title="Environment for Claude Code Agent" isInline isPlain style={{ marginBottom: '1rem' }}>
+                    These environment variables are passed to the Claude Code agent running in the Runspace.
+                  </Alert>
+
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+                    <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'center' }}>
+                      <div style={{ flex: 1, fontWeight: 600, fontSize: '0.875rem' }}>Variable Name</div>
+                      <div style={{ flex: 1, fontWeight: 600, fontSize: '0.875rem' }}>Value</div>
+                      <div style={{ width: '72px' }} />
+                    </div>
+                    {envVars.map((envVar, index) => (
+                      <div key={index} style={{ display: 'flex', gap: '0.75rem', alignItems: 'center' }}>
+                        <TextInput
+                          type="text"
+                          aria-label={`Variable name ${index}`}
+                          value={envVar.key}
+                          onChange={(_event, value) => handleEnvKeyChange(index, value)}
+                          placeholder="VARIABLE_NAME"
+                          style={{ flex: 1 }}
+                        />
+                        <TextInput
+                          type={visibleValues.has(index) ? 'text' : 'password'}
+                          aria-label={`Variable value ${index}`}
+                          value={envVar.value}
+                          onChange={(_event, value) => handleEnvValueChange(index, value)}
+                          placeholder={VALUE_PLACEHOLDERS[envVar.key] || 'value'}
+                          style={{ flex: 1 }}
+                        />
+                        <Button
+                          variant="plain"
+                          aria-label={visibleValues.has(index) ? `Hide value ${envVar.key || index}` : `Show value ${envVar.key || index}`}
+                          onClick={() => setVisibleValues((prev) => {
+                            const next = new Set(prev);
+                            if (next.has(index)) next.delete(index); else next.add(index);
+                            return next;
+                          })}
+                        >
+                          {visibleValues.has(index) ? <EyeSlashIcon /> : <EyeIcon />}
+                        </Button>
+                        <Button variant="plain" aria-label={`Remove variable ${envVar.key || index}`} onClick={() => handleRemoveVar(index)}>
+                          <TrashIcon />
+                        </Button>
+                      </div>
+                    ))}
+                  </div>
+                  <div style={{ display: 'flex', gap: '1rem', marginTop: '1rem' }}>
+                    <Button variant="secondary" icon={<PlusCircleIcon />} onClick={handleAddVar}>
+                      Add Variable
+                    </Button>
+                    <Button variant="tertiary" onClick={handleResetDefaults}>
+                      Reset to Defaults
+                    </Button>
+                  </div>
+                </ExpandableSection>
+              </CardBody>
+            </Card>
+          </Tab>
+
+          <Tab eventKey={1} title={<TabTitleText>Runspace Store Agent</TabTitleText>}>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem', marginTop: '1rem' }}>
+              <Alert variant="info" title="Runspace Store Agent" isInline isPlain style={{ marginTop: '0.25rem' }}>
+                The Runspace Store Agent is a Claude Code agent that runs securely in a Docker container via Runspace,
+                already connected to the Store MCP. It can create tools, skills, snippets, and VMCP servers on your behalf.
+                To connect your own agent directly, see the <Button variant="link" isInline onClick={() => navigate('/agent-connect')}>Connect Your Agent</Button> page.
+              </Alert>
+
+              <div>
+                <Text component="small" style={{ fontWeight: 600, marginBottom: '0.5rem', display: 'block', color: '#6a6e73' }}>
+                  Try an example:
+                </Text>
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
+                  {[
+                    'Create an MCP for math operations with add, subtract, multiply, and divide tools',
+                    'Create a skill called "data-processing" with tools for CSV parsing, JSON validation, and text cleanup',
+                    'Remove tool "old-calculator" from skill "math-ops"',
+                    'List all tools and find any that are duplicates or overlap in functionality',
+                    'Optimize skill "web-scraper" based on the execution traces I added as context',
+                    'Read the code of tool "api-fetcher" and add proper error handling and retries',
+                    'Create a VMCP server for skill "dev-tools" so I can use it in Claude Code',
+                  ].map((example) => (
+                    <Label
+                      key={example}
+                      color="blue"
+                      style={{
+                        cursor: (agentSessionStatus === 'running' || agentSessionStatus === 'pending') ? 'default' : 'pointer',
+                        opacity: (agentSessionStatus === 'running' || agentSessionStatus === 'pending') ? 0.6 : 1,
+                      }}
+                      onClick={!(agentSessionStatus === 'running' || agentSessionStatus === 'pending') ? () => { handleNewAgentSession(); setAgentPrompt(example); } : undefined}
+                    >
+                      {example.length > 65 ? example.slice(0, 62) + '...' : example}
+                    </Label>
+                  ))}
+                </div>
+              </div>
+
+              <Card>
+                <CardBody>
+                  <Form>
+                    <FormGroup label="What would you like the agent to do?" fieldId="agent-prompt">
+                      <TextArea
+                        id="agent-prompt"
+                        value={agentPrompt}
+                        onChange={(_event, value) => setAgentPrompt(value)}
+                        placeholder="e.g., Create me an MCP for math operations with add, subtract, multiply, and divide tools"
+                        rows={4}
+                        isDisabled={!!agentSessionId && agentSessionStatus !== 'completed' && agentSessionStatus !== 'failed'}
+                        resizeOrientation="vertical"
+                      />
+                    </FormGroup>
+
+                    <FormGroup label="Context Files (optional)" fieldId="context-files">
+                      <div style={{ fontSize: '0.85rem', color: '#6a6e73', marginBottom: '0.5rem' }}>
+                        Upload files to give the agent additional context (e.g., requirements, specs, code samples).
+                      </div>
+                      <input
+                        ref={fileInputRef}
+                        type="file"
+                        multiple
+                        style={{ display: 'none' }}
+                        onChange={(e) => {
+                          if (e.target.files) {
+                            setContextFiles((prev) => [...prev, ...Array.from(e.target.files!)]);
+                            e.target.value = '';
+                          }
+                        }}
+                        disabled={!!agentSessionId && agentSessionStatus !== 'completed' && agentSessionStatus !== 'failed'}
+                      />
+                      <Button
+                        variant="secondary"
+                        icon={<FolderOpenIcon />}
+                        onClick={() => fileInputRef.current?.click()}
+                        isDisabled={!!agentSessionId && agentSessionStatus !== 'completed' && agentSessionStatus !== 'failed'}
+                        size="sm"
+                      >
+                        Add Files
+                      </Button>
+                      {contextFiles.length > 0 && (
+                        <div style={{ marginTop: '0.5rem', display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
+                          {contextFiles.map((file, idx) => (
+                            <Label
+                              key={`${file.name}-${idx}`}
+                              color="blue"
+                              onClose={(!agentSessionId || agentSessionStatus === 'completed' || agentSessionStatus === 'failed') ? () => setContextFiles((prev) => prev.filter((_, i) => i !== idx)) : undefined}
+                            >
+                              {file.name} ({(file.size / 1024).toFixed(1)} KB)
+                            </Label>
+                          ))}
+                        </div>
+                      )}
+                    </FormGroup>
+                  </Form>
+
+                  <div style={{ display: 'flex', gap: '0.75rem', marginTop: '1rem' }}>
+                    {!agentSessionId || agentSessionStatus === 'completed' || agentSessionStatus === 'failed' ? (
+                      <Button
+                        variant="primary"
+                        icon={<AutomationIcon />}
+                        onClick={handleRunAgent}
+                        isLoading={isSendingAgent}
+                        isDisabled={!agentPrompt.trim() || isSendingAgent}
+                      >
+                        {isSendingAgent ? 'Sending...' : 'Run Agent'}
+                      </Button>
+                    ) : (
+                      <Button
+                        variant="secondary"
+                        onClick={handleNewAgentSession}
+                        isDisabled={agentSessionStatus !== 'completed' && agentSessionStatus !== 'failed'}
+                      >
+                        New Session
+                      </Button>
+                    )}
+                  </div>
+                </CardBody>
+              </Card>
+
+              {agentError && (
+                <Alert variant="danger" title="Error" isInline>
+                  {agentError}
+                </Alert>
+              )}
+
+              {agentSessionDetail && (
+                <Alert variant={getStatusVariant()} title={`Session: ${agentSessionStatus}`} isInline>
+                  <DescriptionList isCompact isHorizontal style={{ marginTop: '0.5rem' }}>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Session ID</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        <code style={{ fontSize: '0.85rem' }}>{agentSessionDetail.session_id}</code>
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    {agentSessionDetail.duration_seconds != null && (
+                      <DescriptionListGroup>
+                        <DescriptionListTerm>Duration</DescriptionListTerm>
+                        <DescriptionListDescription>{formatDuration(agentSessionDetail.duration_seconds)}</DescriptionListDescription>
+                      </DescriptionListGroup>
+                    )}
+                    {agentSessionDetail.total_tokens != null && agentSessionDetail.total_tokens > 0 && (
+                      <DescriptionListGroup>
+                        <DescriptionListTerm>Tokens</DescriptionListTerm>
+                        <DescriptionListDescription>{agentSessionDetail.total_tokens.toLocaleString()}</DescriptionListDescription>
+                      </DescriptionListGroup>
+                    )}
+                    {agentSessionDetail.total_cost_usd != null && (
+                      <DescriptionListGroup>
+                        <DescriptionListTerm>Cost</DescriptionListTerm>
+                        <DescriptionListDescription>${agentSessionDetail.total_cost_usd.toFixed(4)}</DescriptionListDescription>
+                      </DescriptionListGroup>
+                    )}
+                    {agentSessionDetail.error && (
+                      <DescriptionListGroup>
+                        <DescriptionListTerm>Error</DescriptionListTerm>
+                        <DescriptionListDescription style={{ color: '#c9190b' }}>{agentSessionDetail.error}</DescriptionListDescription>
+                      </DescriptionListGroup>
+                    )}
+                  </DescriptionList>
+
+                  {agentSessionStatus !== 'completed' && agentSessionStatus !== 'failed' && (
+                    <div style={{ marginTop: '0.75rem' }}>
+                      <Spinner size="sm" /> Polling for status...
+                    </div>
+                  )}
+
+                  <div style={{ marginTop: '0.75rem' }}>
+                    <a
+                      href={`${runspaceUrl}/ui/sessions/${agentSessionId}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <ExternalLinkAltIcon /> Open in Runspace UI
+                    </a>
+                  </div>
+                </Alert>
+              )}
+
+              {agentSummary && (
+                <Card>
+                  <CardBody>
+                    <Title headingLevel="h3" size="md" style={{ marginBottom: '1rem' }}>
+                      Agent Summary
+                    </Title>
+                    <div className="markdown-body" style={{
+                      padding: '1rem',
+                      backgroundColor: '#f5f5f5',
+                      borderRadius: '6px',
+                      border: '1px solid #d2d2d2',
+                      lineHeight: '1.6',
+                    }}>
+                      <ReactMarkdown remarkPlugins={[remarkGfm]}>{agentSummary}</ReactMarkdown>
+                    </div>
+                  </CardBody>
+                </Card>
+              )}
+            </div>
+          </Tab>
+        </Tabs>
+      </PageSection>
+    </>
+  );
+}

--- a/src/skillberry_store/ui/src/plugins/runspace/api.ts
+++ b/src/skillberry_store/ui/src/plugins/runspace/api.ts
@@ -1,0 +1,81 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+//
+// Runspace plugin client API. The backend endpoints live under the runspace
+// plugin router; main services/api.ts has no knowledge of them.
+
+const API_BASE = '/api';
+
+export interface AiSettingsEnvVar {
+  key: string;
+  value: string;
+}
+
+export interface AiSettings {
+  runspace_url: string;
+  env_vars: AiSettingsEnvVar[];
+}
+
+async function handleResponse<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ detail: response.statusText }));
+    throw new Error(error.detail || 'An error occurred');
+  }
+  return response.json();
+}
+
+export const runspaceSettingsApi = {
+  get: async (): Promise<AiSettings> => {
+    const response = await fetch(`${API_BASE}/ai-settings`);
+    return handleResponse<AiSettings>(response);
+  },
+
+  save: async (settings: AiSettings): Promise<{ message: string }> => {
+    const response = await fetch(`${API_BASE}/ai-settings`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(settings),
+    });
+    return handleResponse<{ message: string }>(response);
+  },
+};
+
+export const runspaceAgentApi = {
+  buildStoreRequest: async (prompt: string, contextFiles?: File[]): Promise<Record<string, any>> => {
+    const formData = new FormData();
+    formData.append('prompt', prompt);
+    if (contextFiles) {
+      for (const file of contextFiles) {
+        formData.append('context_files', file);
+      }
+    }
+    const response = await fetch(`${API_BASE}/agent/store-request`, {
+      method: 'POST',
+      body: formData,
+    });
+    return handleResponse<Record<string, any>>(response);
+  },
+};
+
+export const runspaceSkillApi = {
+  exportAgentRequest: async (name: string): Promise<Record<string, any>> => {
+    const response = await fetch(`${API_BASE}/skills/${name}/export-agent-request`, {
+      method: 'POST',
+    });
+    return handleResponse<Record<string, any>>(response);
+  },
+};
+
+export const DEFAULT_RUNSPACE_URL = 'http://localhost:6767';
+
+export function envVarsToRecord(vars: AiSettingsEnvVar[]): Record<string, string> {
+  const record: Record<string, string> = {};
+  for (const v of vars) {
+    const key = v.key.trim();
+    const value = v.value.trim();
+    if (key && value) {
+      record[key] = value;
+    }
+  }
+  return record;
+}

--- a/src/skillberry_store/ui/src/plugins/runspace/manifest.tsx
+++ b/src/skillberry_store/ui/src/plugins/runspace/manifest.tsx
@@ -1,0 +1,24 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+
+import type { PluginManifest } from '../types';
+import { RunspacePage } from './RunspacePage';
+import { ExportWithAgentAction } from './ExportWithAgentAction';
+
+export const runspaceManifest: PluginManifest = {
+  id: 'runspace',
+  name: 'Runspace',
+  description:
+    'Agent-driven skill export and a Runspace Store Agent chat, powered by the Runspace daemon (runspace-srv).',
+  routes: [
+    { path: '/runspace', element: <RunspacePage /> },
+  ],
+  navItems: [
+    { id: 'runspace', label: 'Runspace', path: '/runspace' },
+  ],
+  slots: {
+    'skill.detail.actions': [
+      { id: 'runspace.export-with-agent', component: ExportWithAgentAction },
+    ],
+  },
+};

--- a/src/skillberry_store/ui/src/plugins/types.ts
+++ b/src/skillberry_store/ui/src/plugins/types.ts
@@ -1,0 +1,43 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+
+import type { ComponentType, ReactNode } from 'react';
+
+export interface PluginRoute {
+  path: string;
+  element: ReactNode;
+}
+
+export interface PluginNavItem {
+  id: string;
+  label: string;
+  path: string;
+  badge?: string;
+}
+
+export interface PluginSlotContribution {
+  id: string;
+  component: ComponentType<any>;
+}
+
+export interface PluginManifest {
+  id: string;
+  name: string;
+  description?: string;
+  routes: PluginRoute[];
+  navItems: PluginNavItem[];
+  slots: Record<string, PluginSlotContribution[]>;
+}
+
+export interface PluginListItem {
+  id: string;
+  name: string;
+  description: string;
+  enabled: boolean;
+  requires_restart: boolean;
+  ui_manifest: {
+    routes?: Array<{ path: string; component: string }>;
+    nav_items?: Array<{ id: string; label: string; path: string }>;
+    slots?: Record<string, Array<{ component: string }>>;
+  } | null;
+}

--- a/src/skillberry_store/ui/src/services/api.ts
+++ b/src/skillberry_store/ui/src/services/api.ts
@@ -79,6 +79,15 @@ export const toolsApi = {
     return handleResponse<{ message: string }>(response);
   },
 
+  updateModule: async (name: string, content: string): Promise<{ message: string }> => {
+    const response = await fetch(`${API_BASE}/tools/${name}/module`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content }),
+    });
+    return handleResponse<{ message: string }>(response);
+  },
+
   delete: async (name: string): Promise<{ message: string }> => {
     const response = await fetch(`${API_BASE}/tools/${name}`, {
       method: 'DELETE',
@@ -322,6 +331,195 @@ export const vmcpApi = {
     });
     const response = await fetch(`${API_BASE}/search/vmcp_servers?${params}`);
     return handleResponse<SearchResult[]>(response);
+  },
+};
+
+// External MCPs API — manage imported MCP servers the store consumes
+export type ExternalMCPTransport = 'stdio' | 'sse' | 'http';
+
+export interface ExternalMCPConfig {
+  name: string;
+  transport: ExternalMCPTransport;
+  command?: string | null;
+  args?: string[];
+  env?: Record<string, string>;
+  url?: string | null;
+  headers?: Record<string, string>;
+  enabled?: boolean;
+}
+
+export interface ExternalMCPStatus {
+  name: string;
+  transport: ExternalMCPTransport;
+  enabled: boolean;
+  status: 'running' | 'stopped' | 'error' | 'starting';
+  last_error: string | null;
+  tool_count: number;
+  config: ExternalMCPConfig & { created_at?: string; modified_at?: string };
+}
+
+export interface ExternalMCPStartResult {
+  name: string;
+  status: string;
+  error?: string;
+  reconcile?: { added: string[]; updated: string[]; removed: string[] };
+  health?: { broken: Array<{ name: string; reason: string }>; unbroken: string[]; iterations: number };
+}
+
+export const externalMcpsApi = {
+  list: async (): Promise<ExternalMCPStatus[]> => {
+    const response = await fetch(`${API_BASE}/external-mcps`);
+    return handleResponse<ExternalMCPStatus[]>(response);
+  },
+
+  get: async (name: string): Promise<ExternalMCPStatus> => {
+    const response = await fetch(`${API_BASE}/external-mcps/${encodeURIComponent(name)}`);
+    return handleResponse<ExternalMCPStatus>(response);
+  },
+
+  // Accepts any of the five input shapes — pass raw JSON straight through.
+  create: async (
+    config: unknown,
+  ): Promise<{ count: number; results: ExternalMCPStartResult[] }> => {
+    const response = await fetch(`${API_BASE}/external-mcps`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(config),
+    });
+    return handleResponse<{ count: number; results: ExternalMCPStartResult[] }>(response);
+  },
+
+  remove: async (name: string): Promise<{
+    name: string;
+    removed_primitives: string[];
+    health?: { broken: Array<{ name: string; reason: string }>; unbroken: string[] };
+  }> => {
+    const response = await fetch(`${API_BASE}/external-mcps/${encodeURIComponent(name)}`, {
+      method: 'DELETE',
+    });
+    return handleResponse(response);
+  },
+
+  restart: async (name: string): Promise<ExternalMCPStartResult> => {
+    const response = await fetch(`${API_BASE}/external-mcps/${encodeURIComponent(name)}/restart`, {
+      method: 'POST',
+    });
+    return handleResponse<ExternalMCPStartResult>(response);
+  },
+
+  listRemoteTools: async (
+    name: string,
+  ): Promise<Array<{ name: string; description: string; inputSchema: Record<string, unknown> }>> => {
+    const response = await fetch(
+      `${API_BASE}/external-mcps/${encodeURIComponent(name)}/remote-tools`,
+    );
+    return handleResponse(response);
+  },
+
+  dependents: async (name: string): Promise<{ name: string; dependents: string[] }> => {
+    const response = await fetch(
+      `${API_BASE}/external-mcps/${encodeURIComponent(name)}/dependents`,
+    );
+    return handleResponse(response);
+  },
+};
+
+// Per-tool: toggle bundled_with_mcps
+export const toolsExtrasApi = {
+  setBundledWithMcps: async (
+    name: string,
+    value: boolean,
+  ): Promise<{ name: string; bundled_with_mcps: boolean }> => {
+    const response = await fetch(
+      `${API_BASE}/tools/${encodeURIComponent(name)}/bundled-with-mcps?value=${value}`,
+      { method: 'PUT' },
+    );
+    return handleResponse(response);
+  },
+};
+
+// Bulk-add tools to a skill from their MCP association
+export type BulkAddMode = 'primitives' | 'related' | 'bundled_related';
+
+export interface BulkAddResult {
+  skill: string;
+  mode: BulkAddMode;
+  requested_mcps: string[];
+  added: Array<{ name: string; uuid: string }>;
+  skipped_duplicate: string[];
+  skipped_broken: Array<{ name: string; reason: string }>;
+  skipped_unbundled: string[];
+}
+
+export const skillsExtrasApi = {
+  bulkAddFromMcps: async (
+    skillName: string,
+    body: { mcps: string[]; mode: BulkAddMode },
+  ): Promise<BulkAddResult> => {
+    const response = await fetch(
+      `${API_BASE}/skills/${encodeURIComponent(skillName)}/bulk-add-tools-from-mcps`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      },
+    );
+    return handleResponse(response);
+  },
+};
+
+// Admin API
+export interface ServerInfo {
+  host: string;
+  port: number;
+  agent_mcp_port: number;
+  agent_mcp_url: string | null;
+  control_mcp_url: string;
+  api_docs: string;
+}
+
+export const adminApi = {
+  getServerInfo: async (): Promise<ServerInfo> => {
+    const response = await fetch(`${API_BASE}/admin/server-info`);
+    return handleResponse<ServerInfo>(response);
+  },
+};
+
+// Plugins API
+export interface PluginInfo {
+  id: string;
+  name: string;
+  description: string;
+  enabled: boolean;
+  requires_restart: boolean;
+  ui_manifest: {
+    routes?: Array<{ path: string; component: string }>;
+    nav_items?: Array<{ id: string; label: string; path: string }>;
+    slots?: Record<string, Array<{ component: string }>>;
+  } | null;
+}
+
+export interface PluginToggleResponse {
+  plugin_id: string;
+  enabled: boolean;
+  restart_required: boolean;
+}
+
+export const pluginsApi = {
+  list: async (): Promise<PluginInfo[]> => {
+    const response = await fetch(`${API_BASE}/plugins`);
+    const data = await handleResponse<{ plugins: PluginInfo[] }>(response);
+    return data.plugins;
+  },
+
+  enable: async (id: string): Promise<PluginToggleResponse> => {
+    const response = await fetch(`${API_BASE}/plugins/${id}/enable`, { method: 'POST' });
+    return handleResponse<PluginToggleResponse>(response);
+  },
+
+  disable: async (id: string): Promise<PluginToggleResponse> => {
+    const response = await fetch(`${API_BASE}/plugins/${id}/disable`, { method: 'POST' });
+    return handleResponse<PluginToggleResponse>(response);
   },
 };
 

--- a/src/skillberry_store/ui/src/services/api.ts
+++ b/src/skillberry_store/ui/src/services/api.ts
@@ -12,6 +12,15 @@ import type {
 
 const API_BASE = '/api';
 
+// Anthropic Agent Skills naming format — used for skill, VMCP, external MCP,
+// and tool names. Source: https://code.claude.com/docs/en/skills frontmatter.
+export const STORE_NAME_PATTERN = /^[a-z0-9-]{1,64}$/;
+export const STORE_NAME_HINT =
+  "Lowercase letters, digits, and hyphens (-) only; 1 to 64 characters. No spaces, underscores, or uppercase. Examples: 'docs-research', 'context7', 'pdf-to-markdown'.";
+export function isValidStoreName(name: string): boolean {
+  return STORE_NAME_PATTERN.test(name);
+}
+
 class ApiError extends Error {
   constructor(
     message: string,

--- a/src/skillberry_store/ui/src/styles/global.css
+++ b/src/skillberry_store/ui/src/styles/global.css
@@ -90,3 +90,61 @@ code {
   box-shadow: var(--pf-v5-global--BoxShadow--md);
   transition: box-shadow 0.2s ease-in-out;
 }
+
+/* Markdown body styles — override PatternFly resets for rendered markdown */
+.markdown-body h1 { font-size: 1.6em; font-weight: 600; margin: 1em 0 0.5em; }
+.markdown-body h2 { font-size: 1.35em; font-weight: 600; margin: 1em 0 0.5em; }
+.markdown-body h3 { font-size: 1.15em; font-weight: 600; margin: 0.8em 0 0.4em; }
+.markdown-body h4 { font-size: 1em; font-weight: 600; margin: 0.6em 0 0.3em; }
+.markdown-body p { margin: 0.5em 0; }
+.markdown-body ul, .markdown-body ol { padding-left: 1.5em; margin: 0.5em 0; }
+.markdown-body ul { list-style-type: disc; }
+.markdown-body ol { list-style-type: decimal; }
+.markdown-body li { margin: 0.25em 0; }
+.markdown-body li > ul, .markdown-body li > ol { margin: 0.15em 0; }
+.markdown-body blockquote {
+  margin: 0.5em 0;
+  padding: 0.25em 1em;
+  border-left: 4px solid var(--pf-v5-global--BorderColor--300, #d2d2d2);
+  color: var(--pf-v5-global--Color--200, #6a6e73);
+}
+.markdown-body code {
+  background-color: rgba(0, 0, 0, 0.06);
+  padding: 0.15em 0.35em;
+  border-radius: 3px;
+  font-size: 0.9em;
+}
+.markdown-body pre code {
+  background-color: transparent;
+  padding: 0;
+  border-radius: 0;
+  font-size: inherit;
+}
+.markdown-body table {
+  border-collapse: collapse;
+  margin: 0.5em 0;
+  width: 100%;
+}
+.markdown-body th, .markdown-body td {
+  border: 1px solid var(--pf-v5-global--BorderColor--100, #d2d2d2);
+  padding: 0.4em 0.8em;
+  text-align: left;
+}
+.markdown-body th {
+  background-color: rgba(0, 0, 0, 0.04);
+  font-weight: 600;
+}
+.markdown-body hr {
+  border: none;
+  border-top: 1px solid var(--pf-v5-global--BorderColor--100, #d2d2d2);
+  margin: 1em 0;
+}
+.markdown-body a {
+  color: var(--pf-v5-global--link--Color, #06c);
+  text-decoration: none;
+}
+.markdown-body a:hover {
+  text-decoration: underline;
+}
+.markdown-body strong { font-weight: 600; }
+.markdown-body img { max-width: 100%; }

--- a/src/skillberry_store/ui/src/types/index.ts
+++ b/src/skillberry_store/ui/src/types/index.ts
@@ -1,7 +1,7 @@
 // Copyright 2025 IBM Corp.
 // Licensed under the Apache License, Version 2.0
 
-export type ManifestState = 'unknown' | 'any' | 'new' | 'checked' | 'approved';
+export type ManifestState = 'unknown' | 'any' | 'new' | 'checked' | 'approved' | 'broken';
 
 export interface Tool {
   uuid: string;
@@ -28,6 +28,12 @@ export interface Tool {
   author?: string;
   created_at?: string;
   modified_at?: string;
+  // External MCPs feature
+  mcp_url?: string | null;
+  mcp_server?: string | null;
+  mcp_dependencies?: string[];
+  bundled_with_mcps?: boolean | null;
+  broken_reason?: string | null;
 }
 
 export interface Skill {


### PR DESCRIPTION
## Summary

PR walkthrough video in: https://drive.google.com/drive/folders/1CXwjkN4Q_LmWijSVbPMxfL3-KCiedmzg?usp=sharing

Adds four major pieces of functionality to the store:

1. **External MCPs** — import external MCP servers (stdio / SSE / streamable-HTTP) and use their tools as first-class store primitives. Verified with context7. To support certain mcps we should add option to run tools locally and not in container.
2. **Plugins framework + Runspace plugin** — extension system with an optional plugin for running Claude Code agents securely in Docker (agentic anthropic skill export to hierarchic directory using skill-creator skill, Store Agent chat automatically access store using the store mcp)
3. **Agent Connect tab** — UI to connect external agents to the store, exposing a curated (~20-tool) MCP alongside the existing full MCP
4. **Dependent-safe tool updates** — tools can now be safely updated/deleted when no other tool depends on them (call them); health check propagates drift across the store
5. **skill name compatibility with anthropic** — skill name validation to be consistent with anthropic and to prevent other issues

## 1. External MCPs (headline feature)

`ExternalMCPManager` owns one long-lived `ClientSession` per imported server across all three transports (`stdio`, `sse`, streamable-HTTP). On startup and on each registration it reconciles remote `list_tools()` into store primitives (`packaging_format="mcp"`, name-prefixed `<server>__<tool>`) and runs a boot-time drift sweep so dependents are marked broken when an upstream tool disappears or changes shape. Removing an external MCP preserves composites that depended on it (moved to `state=broken`, `broken_reason=dep_missing:...`) rather than deleting them.

`normalize_mcp_input` accepts five wire shapes: Claude-Desktop's `{"mcpServers": {...}}`, bare dicts, single entries, lists, and `{"source_url": "..."}` fetch. Secrets are stored plaintext and redacted on GET and on skill export.

Tool calls on external-MCP primitives go through the pooled session (fast path in `FileExecutor`, no Docker init).

Key files: `modules/external_mcp_manager.py`, `fast_api/external_mcps_api.py`, `tests/test_external_mcp.py`, `ui/src/pages/ExternalMCPsPage.tsx`, `ui/src/pages/ExternalMCPDetailPage.tsx`

## 2. Plugins framework + Runspace plugin

Protocol-based plugin system: each plugin registers a `UIManifest`, FastAPI routers, and startup/shutdown hooks. Activation lives in `$SBS_BASE_DIR/plugins/enabled.json`; admin endpoints `/plugins`, `/plugins/{id}/enable|disable` manage state. Main code iterates `active_plugins()` and never branches on a specific id.

Runspace is the only shipped plugin — optional, off by default. It talks to an external `runspace-srv` daemon to run Claude Code agents in Docker for:
- **Agentic skill export** — agent iterates and produces an Anthropic-skill bundle
- **Store Agent** — chat interface that uses the store MCP to perform operations

Endpoints previously in `skills_api.py` (`/skills/{name}/export-agent-request`, `/ai-settings`, `/agent/store-request`) were migrated to the plugin, with automatic migration of legacy `ai_features/settings.json`.

Key files: `plugins/base.py`, `plugins/__init__.py`, `plugins/runspace/*`, `ui/src/plugins/*`, `ui/src/plugins/runspace/*`

## 3. Agent Connect tab + curated Agent MCP

A second MCP server runs on its own port (`SBS_AGENT_MCP_PORT`, default 9999) with a hand-picked ~20-tool set (list/create/update/execute tools, skill + snippet + VMCP + external-MCP management, `bulk_add_tools_from_mcps`) — intentionally smaller than the auto-generated full MCP at `/control_sse` (renamed `full_mcp`) that mirrors ~40 FastAPI endpoints. The curated MCP is the better default for LLMs that can't handle the full surface area.

The Agent Connect UI shows both URLs, copy-ready `claude mcp add` commands (project/user scope toggle, curated/full toggle), and runs a live connection test.

Key files: `fast_api/agent_mcp_server.py` (new, 796 lines), `ui/src/pages/AgentConnectPage.tsx` (new, 475 lines), `fast_api/server.py` (wires `full_mcp` + `agent_mcp`), `main.py` (prints connect commands on startup)

## 4. Dependent-safe tool mutations

`tools_api.py` refuses destructive mutations (delete, interface-changing update, module swap) when another tool lists the target in its `dependencies`, returning HTTP 409 with a structured `tool_has_dependents` payload. Every mutation populates `mcp_dependencies` and `dependency_hashes` on the manifest and runs `check_all_tools_health` afterward so drift propagates across the store automatically.

New: `PUT /tools/{name}/module` (module-source updates), `PUT /tools/{name}/bundled-with-mcps` (bulk-add flag).

Health module introduces a broken-reason taxonomy: `dep_missing`, `dep_schema_changed`, `dep_code_changed`, `dep_broken`, `server_unavailable`. Broken tools surface with banners in Tool / Skill detail pages.

Key files: `fast_api/tools_api.py`, `modules/tool_health.py` (new), `schemas/tool_schema.py` (new fields + `ManifestState.BROKEN`)

## Other notable changes

- **Skill ↔ MCP bundling**: `POST /skills/{name}/bulk-add-tools-from-mcps` with three modes (`primitives`, `related`, `bundled_related`). Importer/exporter round-trip a sidecar `mcp-servers.json` inside the skill ZIP; env/header secrets are redacted to `${NAME}` placeholders on export and auto-registered on import.
- **VMCP external-MCP support**: `modules/vmcp_server.py` synthesizes MCP-primitive stubs so VMCP tool-execute routes external-MCP primitives through the pooled session.
- **Config plumbing** in `tools/configure.py`: `get_external_mcps_directory`, `get_plugins_directory`, `get_plugin_directory`, `get_ai_features_directory`. `SBSettings` gains `agent_mcp_port`.
- **UI additions**: bulk-add-from-MCPs section in Create Skill modal, broken-state banners, MCP-dependency views on Tool/Skill detail, MCP tags on tools list, dynamic plugin nav, slot-based action injection (e.g. "Export with Agent").
- **Global CSS**: ~60 lines added — worth a visual skim.
- **Fix in `check-multiarch.sh`**: removed a blank line before the shebang so the script is correctly recognized as bash on all kernels.
