### PR TITLE
Prevent Duplicate Tool Exports in Anthropic Exporter

### DIFF
--- a/src/skillberry_store/tools/anthropic/exporter.py
+++ b/src/skillberry_store/tools/anthropic/exporter.py
@@ -172,15 +172,14 @@ def build_file_structure_from_tools(
             # Normalize the file path to remove skill name prefix
             normalized_path = normalize_file_path(file_path, skill_name)
             
-            # Get module content
-            content = ''
-            if tool_modules and tool['name'] in tool_modules:
-                content = tool_modules[tool['name']]
-            
-            # Group tools by file path
-            if normalized_path in files:
-                files[normalized_path] += '\n\n' + content
-            else:
+            # Only write each file once (first tool wins)
+            # This prevents duplicates since module_content already contains the complete file
+            if normalized_path not in files:
+                # Get module content
+                content = ''
+                if tool_modules and tool['name'] in tool_modules:
+                    content = tool_modules[tool['name']]
+                
                 files[normalized_path] = content
     
     return files


### PR DESCRIPTION
# Prevent Duplicate Tool Exports in Anthropic Exporter

## Problem

When exporting tools to Anthropic format, multiple tools from the same file caused duplicate content. The exporter was concatenating the complete file content for each tool instead of writing it once.

## Solution

Modified [`build_file_structure_from_tools()`](src/skillberry_store/tools/anthropic/exporter.py:172) to check if a file path has already been processed before adding content. Now each file is written only once (first tool wins).

## Changes

**File:** `src/skillberry_store/tools/anthropic/exporter.py` (lines 172-184)

```python
# Before: Concatenated content for each tool
if normalized_path in files:
    files[normalized_path] += '\n\n' + content
else:
    files[normalized_path] = content

# After: Only write each file once
if normalized_path not in files:
    content = tool_modules.get(tool['name'], '')
    files[normalized_path] = content
```

## Impact

- ✅ Eliminates duplicate tool definitions
- ✅ No breaking changes
- ✅ Improved performance (avoids redundant concatenation)
