### PR TITLE
fix: Configure Bob Shell to use npm package manager

### DIFF
--- a/.github/workflows/fix-issues-with-bob.yml
+++ b/.github/workflows/fix-issues-with-bob.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Install Bob Shell
         run: |
           echo "Installing Bob Shell..."
-          curl -fsSL https://bob.ibm.com/download/bobshell.sh | bash
+          curl -fsSL https://bob.ibm.com/download/bobshell.sh | bash -s -- --package-manager npm
 
           # Verify installation
           if command -v bob &> /dev/null; then


### PR DESCRIPTION
Closes #24

## Summary
This PR configures the Bob Shell installation in the GitHub workflow to explicitly use npm as the package manager, ensuring consistent behavior across all CI/CD environments.

## Changes
- Modified  to add  flag to the Bob Shell installation command
- Changed from: `curl -fsSL https://bob.ibm.com/download/bobshell.sh | bash`
- Changed to: `curl -fsSL https://bob.ibm.com/download/bobshell.sh | bash -s -- --package-manager npm`

## Motivation
Without explicitly specifying the package manager, Bob Shell may attempt to auto-detect the package manager, which can lead to:
- Inconsistent behavior across different environments
- Potential installation failures if the wrong package manager is detected
- Unpredictable CI/CD pipeline behavior

## Testing
- The change has been committed and pushed to the feature branch
- The workflow should be tested by triggering the GitHub Actions workflow to verify Bob Shell installs correctly with npm

## Design Decisions
- Used npm as the package manager since it's the standard Node.js package manager and is already available in the GitHub Actions environment
- Added the flag inline to the existing installation command to minimize changes

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>