### PR TITLE
Refactor: Replace `mcp_url` and `mcp_tool_name` with flexible `packaging_params`

### DIFF
--- a/client/python/skillberry_store_sdk/skillberry_store_sdk/api_client.py
+++ b/client/python/skillberry_store_sdk/skillberry_store_sdk/api_client.py
@@ -438,6 +438,18 @@ class ApiClient:
             return None
 
         if isinstance(klass, str):
+            # Handle Optional[] wrapper
+            # NOTE: This is a workaround for OpenAPI Generator limitation.
+            # The generator creates type strings like "Optional[Dict[str, object]]"
+            # but doesn't provide deserialization logic for the Optional[] wrapper.
+            # Without this, deserialization fails with AttributeError when trying
+            # to find a model class named "Optional[Dict[str, object]]".
+            if klass.startswith('Optional['):
+                m = re.match(r'Optional\[(.*)]', klass)
+                assert m is not None, "Malformed Optional type definition"
+                sub_kls = m.group(1)
+                return self.__deserialize(data, sub_kls)
+            
             if klass.startswith('List['):
                 m = re.match(r'List\[(.*)]', klass)
                 assert m is not None, "Malformed List type definition"

--- a/src/skillberry_store/fast_api/server_utils.py
+++ b/src/skillberry_store/fast_api/server_utils.py
@@ -152,7 +152,9 @@ async def get_mcp_tools(manifest_as_dict: dict) -> list:
             async with ClientSession(read, write) as session:
                 # Get MCP tool name from packaging_params, fall back to tool name
                 packaging_params = manifest_as_dict.get("packaging_params", {})
-                tool_name = packaging_params.get("mcp_tool_name") or manifest_as_dict.get("name", {})
+                tool_name = packaging_params.get(
+                    "mcp_tool_name"
+                ) or manifest_as_dict.get("name", {})
                 logger.info(
                     f"[get_mcp_tools] ClientSession created, tool_name: {tool_name}"
                 )

--- a/src/skillberry_store/fast_api/server_utils.py
+++ b/src/skillberry_store/fast_api/server_utils.py
@@ -69,8 +69,9 @@ def mcp_content_from_manifest(tool_dict: dict) -> str:
         f"{k}: {v.get('type', 'str')}" for k, v in properties.items()
     )
 
-    # Use mcp_tool_name if available (for MCP tools), otherwise use name
-    function_name = tool_dict.get("mcp_tool_name") or tool_dict["name"]
+    # Get MCP tool name from packaging_params, fall back to tool name
+    packaging_params = tool_dict.get("packaging_params", {})
+    function_name = packaging_params.get("mcp_tool_name") or tool_dict["name"]
 
     content_lines = [
         f"def {function_name}({param_list}):",
@@ -136,7 +137,9 @@ async def get_mcp_tools(manifest_as_dict: dict) -> list:
     import logging
 
     logger = logging.getLogger(__name__)
-    mcp_url = manifest_as_dict.get("mcp_url", {})
+    # Get MCP URL from packaging_params
+    packaging_params = manifest_as_dict.get("packaging_params", {})
+    mcp_url = packaging_params.get("mcp_url", {})
     logger.info(f"[get_mcp_tools] Starting - Connecting to MCP server at: {mcp_url}")
     logger.debug(f"[get_mcp_tools] Manifest dict: {manifest_as_dict}")
 
@@ -147,10 +150,9 @@ async def get_mcp_tools(manifest_as_dict: dict) -> list:
                 f"[get_mcp_tools] SSE client connected, creating ClientSession..."
             )
             async with ClientSession(read, write) as session:
-                # Use mcp_tool_name if available, otherwise fall back to name
-                tool_name = manifest_as_dict.get(
-                    "mcp_tool_name"
-                ) or manifest_as_dict.get("name", {})
+                # Get MCP tool name from packaging_params, fall back to tool name
+                packaging_params = manifest_as_dict.get("packaging_params", {})
+                tool_name = packaging_params.get("mcp_tool_name") or manifest_as_dict.get("name", {})
                 logger.info(
                     f"[get_mcp_tools] ClientSession created, tool_name: {tool_name}"
                 )

--- a/src/skillberry_store/modules/file_executor.py
+++ b/src/skillberry_store/modules/file_executor.py
@@ -375,7 +375,9 @@ class FileExecutor:
         try:
             # Get MCP tool name from packaging_params, fall back to tool name
             packaging_params = self.manifest.get("packaging_params", {})
-            function_name = packaging_params.get("mcp_tool_name") or self.manifest["name"]
+            function_name = (
+                packaging_params.get("mcp_tool_name") or self.manifest["name"]
+            )
 
             (
                 function_name,

--- a/src/skillberry_store/modules/file_executor.py
+++ b/src/skillberry_store/modules/file_executor.py
@@ -373,8 +373,9 @@ class FileExecutor:
         logger.info(f"Executing python code using a MCP server")
 
         try:
-            # Use mcp_tool_name if available, otherwise fall back to name
-            function_name = self.manifest.get("mcp_tool_name") or self.manifest["name"]
+            # Get MCP tool name from packaging_params, fall back to tool name
+            packaging_params = self.manifest.get("packaging_params", {})
+            function_name = packaging_params.get("mcp_tool_name") or self.manifest["name"]
 
             (
                 function_name,
@@ -421,7 +422,9 @@ class FileExecutor:
                         parameter_definition_type,
                     )
                     mcp_args_dict[parameter_definition_name] = converted_arg
-            mcp_server_url = self.manifest.get("mcp_url") or default_mcp_server_url
+            # Get MCP server URL from packaging_params
+            packaging_params = self.manifest.get("packaging_params", {})
+            mcp_server_url = packaging_params.get("mcp_url") or default_mcp_server_url
             logger.info(
                 f"[execute_python_file_in_mcp_server] Connecting to MCP server at: {mcp_server_url}"
             )

--- a/src/skillberry_store/schemas/tool_schema.py
+++ b/src/skillberry_store/schemas/tool_schema.py
@@ -1,7 +1,8 @@
 """Pydantic schema for tool objects."""
 
-from typing import Any, Dict, List, Optional
-from pydantic import BaseModel, Field, model_validator
+import json
+from typing import Any, Dict, List, Optional, Union
+from pydantic import BaseModel, Field, model_validator, field_validator
 from enum import Enum
 
 from .manifest_schema import ManifestSchema
@@ -69,9 +70,36 @@ class ToolSchema(ManifestSchema):
         description="Packaging format of the tool (e.g., 'code', 'mcp')"
     )
     packaging_params: Optional[Dict[str, Any]] = Field(
-        default=None, 
-        description="Parameters specific to the packaging format.For 'mcp' format, should contain 'mcp_url' and 'mcp_tool_name'."
+        default=None,
+        description="Parameters specific to the packaging format. For 'mcp' format, should contain 'mcp_url' and 'mcp_tool_name'. Can be provided as a JSON string or dict."
     )
+    
+    @field_validator('packaging_params', mode='before')
+    @classmethod
+    def parse_packaging_params(cls, v) -> Optional[Dict[str, Any]]:
+        """Parse packaging_params if it's a JSON string.
+        
+        This allows the field to accept both dict and JSON string formats,
+        which is necessary for FastAPI Query() parameters that can't handle
+        complex types directly.
+        
+        Args:
+            v: The value to validate (can be None, str, or dict)
+            
+        Returns:
+            Optional[Dict[str, Any]]: Parsed dictionary or None
+            
+        Raises:
+            ValueError: If string value is not valid JSON
+        """
+        if v is None:
+            return None
+        if isinstance(v, str):
+            try:
+                return json.loads(v)
+            except json.JSONDecodeError as e:
+                raise ValueError(f"packaging_params must be valid JSON string: {e}")
+        return v
     params: ToolParamsSchema = Field(
         default_factory=ToolParamsSchema,
         description="Parameters schema for the tool"

--- a/src/skillberry_store/schemas/tool_schema.py
+++ b/src/skillberry_store/schemas/tool_schema.py
@@ -1,7 +1,7 @@
 """Pydantic schema for tool objects."""
 
 from typing import Any, Dict, List, Optional
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from enum import Enum
 
 from .manifest_schema import ManifestSchema
@@ -66,15 +66,11 @@ class ToolSchema(ManifestSchema):
     )
     packaging_format: str = Field(
         default="code",
-        description="Packaging format of the tool"
+        description="Packaging format of the tool (e.g., 'code', 'mcp')"
     )
-    mcp_url: Optional[str] = Field(
-        default=None,
-        description="MCP server URL (required when packaging_format is 'mcp')"
-    )
-    mcp_tool_name: Optional[str] = Field(
-        default=None,
-        description="Actual tool name on the MCP server (required when packaging_format is 'mcp')"
+    packaging_params: Optional[Dict[str, Any]] = Field(
+        default=None, 
+        description="Parameters specific to the packaging format.For 'mcp' format, should contain 'mcp_url' and 'mcp_tool_name'."
     )
     params: ToolParamsSchema = Field(
         default_factory=ToolParamsSchema,
@@ -88,6 +84,36 @@ class ToolSchema(ManifestSchema):
         default=None,
         description="List of tool names that this tool depends on"
     )
+    
+    @model_validator(mode='after')
+    def validate_packaging_params(self) -> 'ToolSchema':
+        """Validate packaging_params based on packaging_format.
+        
+        For MCP packaging format, ensures that packaging_params contains
+        the required 'mcp_url' and 'mcp_tool_name' fields.
+        
+        Returns:
+            ToolSchema: The validated schema instance
+            
+        Raises:
+            ValueError: If packaging_params is missing or incomplete for MCP format
+        """
+        if self.packaging_format == "mcp":
+            if not self.packaging_params:
+                raise ValueError(
+                    "packaging_params is required when packaging_format is 'mcp'. "
+                    "It should contain 'mcp_url' and 'mcp_tool_name'."
+                )
+            
+            required_keys = {"mcp_url", "mcp_tool_name"}
+            missing_keys = required_keys - set(self.packaging_params.keys())
+            if missing_keys:
+                raise ValueError(
+                    f"MCP packaging requires these params in packaging_params: {missing_keys}. "
+                    f"Expected: {required_keys}"
+                )
+        
+        return self
     
     def to_dict(self) -> Dict[str, Any]:
         """Convert the tool schema to a dictionary."""

--- a/src/skillberry_store/tests/e2e/test_mcp_tools.py
+++ b/src/skillberry_store/tests/e2e/test_mcp_tools.py
@@ -301,15 +301,16 @@ def placeholder():
 """
         
         # Prepare the tool data with MCP packaging
+        # Note: packaging_params must be sent as JSON string for FastAPI Query() compatibility
         mcp_tool_data = {
             "name": mcp_tool_name,
             "description": "MCP wrapper tool for add_for_mcp_test",
             "programming_language": "python",
             "packaging_format": "mcp",
-            "packaging_params": {
+            "packaging_params": json.dumps({
                 "mcp_url": vmcp_url,
                 "mcp_tool_name": code_tool_name
-            },
+            }),
             "state": "approved"
         }
         

--- a/src/skillberry_store/tests/e2e/test_mcp_tools.py
+++ b/src/skillberry_store/tests/e2e/test_mcp_tools.py
@@ -159,8 +159,10 @@ async def test_execute_tool_with_mcp_packaging(run_sbs):
             "description": "MCP-based tool for testing",
             "programming_language": "python",
             "packaging_format": "mcp",
-            "mcp_url": vmcp_url,
-            "mcp_tool_name": code_tool_name,
+            "packaging_params": {
+                "mcp_url": vmcp_url,
+                "mcp_tool_name": code_tool_name
+            },
             "state": "approved"
         }
         
@@ -191,12 +193,13 @@ async def test_execute_tool_with_mcp_packaging(run_sbs):
         assert our_tool is not None, f"Tool '{tool_name}' not found in tools list"
         print(f"Tool found in list: {our_tool.get('name')}")
         print(f"  - packaging_format: {our_tool.get('packaging_format')}")
-        print(f"  - mcp_url: {our_tool.get('mcp_url')}")
+        packaging_params = our_tool.get('packaging_params', {})
+        print(f"  - mcp_url: {packaging_params.get('mcp_url')}")
         print(f"  - state: {our_tool.get('state')}")
         
         # Verify the tool properties match what we created
         assert our_tool.get("packaging_format") == "mcp", f"Expected packaging_format 'mcp', got '{our_tool.get('packaging_format')}'"
-        assert our_tool.get("mcp_url") == vmcp_url, f"Expected mcp_url '{vmcp_url}', got '{our_tool.get('mcp_url')}'"
+        assert packaging_params.get("mcp_url") == vmcp_url, f"Expected mcp_url '{vmcp_url}', got '{packaging_params.get('mcp_url')}'"
         print("✓ Tool verified in tools list with correct properties")
         
         # Step 5: Execute the MCP tool
@@ -303,8 +306,10 @@ def placeholder():
             "description": "MCP wrapper tool for add_for_mcp_test",
             "programming_language": "python",
             "packaging_format": "mcp",
-            "mcp_url": vmcp_url,
-            "mcp_tool_name": code_tool_name,
+            "packaging_params": {
+                "mcp_url": vmcp_url,
+                "mcp_tool_name": code_tool_name
+            },
             "state": "approved"
         }
         
@@ -323,7 +328,8 @@ def placeholder():
         tool_response = response.json()
         print(f"✓ Created MCP tool: {tool_response.get('name')}")
         print(f"  - packaging_format: mcp")
-        print(f"  - mcp_url: {vmcp_url}")
+        packaging_params = tool_response.get('packaging_params', {})
+        print(f"  - mcp_url: {packaging_params.get('mcp_url')}")
         
         # Step 3: Retrieve the tool and verify it has MCP packaging
         print("\n" + "="*60)
@@ -336,16 +342,17 @@ def placeholder():
         
         print(f"Tool name: {retrieved_tool.get('name')}")
         print(f"Packaging format: {retrieved_tool.get('packaging_format')}")
-        print(f"MCP URL: {retrieved_tool.get('mcp_url')}")
+        packaging_params = retrieved_tool.get('packaging_params', {})
+        print(f"MCP URL: {packaging_params.get('mcp_url')}")
         
         # Assert the tool has MCP packaging
         assert retrieved_tool.get("packaging_format") == "mcp", \
             f"Expected packaging_format 'mcp', got '{retrieved_tool.get('packaging_format')}'"
-        assert retrieved_tool.get("mcp_url") == vmcp_url, \
-            f"Expected mcp_url '{vmcp_url}', got '{retrieved_tool.get('mcp_url')}'"
+        assert packaging_params.get("mcp_url") == vmcp_url, \
+            f"Expected mcp_url '{vmcp_url}', got '{packaging_params.get('mcp_url')}'"
         
         print("✓ Tool verified with MCP packaging format")
-        print(f"✓ MCP URL correctly stored: {retrieved_tool.get('mcp_url')}")
+        print(f"✓ MCP URL correctly stored: {packaging_params.get('mcp_url')}")
         
         # Clean up
         print("\nCleaning up resources...")
@@ -506,8 +513,10 @@ async def test_get_tool_module_with_mcp_packaging(run_sbs):
             "description": "MCP-based tool for module testing",
             "programming_language": "python",
             "packaging_format": "mcp",
-            "mcp_url": vmcp_url,
-            "mcp_tool_name": code_tool_name,
+            "packaging_params": {
+                "mcp_url": vmcp_url,
+                "mcp_tool_name": code_tool_name
+            },
             "state": "approved"
         }
         
@@ -525,7 +534,7 @@ async def test_get_tool_module_with_mcp_packaging(run_sbs):
         print("Step 5: Retrieving module content...")
         print("="*60)
         print(f"Requesting module for tool: {tool_name}")
-        print(f"MCP URL in tool: {vmcp_url}")
+        print(f"MCP URL in tool packaging_params: {vmcp_url}")
         module_response = await client.get(f"{BASE_URL}/tools/{tool_name}/module")
         print(f"Module retrieval response status: {module_response.status_code}")
         print(f"Module retrieval response body: {module_response.text[:500]}")
@@ -565,8 +574,10 @@ async def test_mcp_tool_not_found(run_sbs):
             "description": "Non-existent MCP tool",
             "programming_language": "python",
             "packaging_format": "mcp",
-            "mcp_url": "http://localhost:9999/sse",  # Non-existent server
-            "mcp_tool_name": "nonexistent_tool",
+            "packaging_params": {
+                "mcp_url": "http://localhost:9999/sse",  # Non-existent server
+                "mcp_tool_name": "nonexistent_tool"
+            },
             "state": "approved"
         }
         

--- a/src/skillberry_store/tests/utils.py
+++ b/src/skillberry_store/tests/utils.py
@@ -63,7 +63,10 @@ async def add_tool_manifest(
         "programming_language": "python",
         "packaging_format": "mcp",
         "version": "0.0.1",
-        "mcp_url": mcp_url,
+        "packaging_params": {
+            "mcp_url": mcp_url,
+            "mcp_tool_name": name
+        },
         "name": name,
         "state": "approved",
     }


### PR DESCRIPTION
# Refactor: Replace `mcp_url` and `mcp_tool_name` with `packaging_params`

## Overview
This PR refactors the `ToolSchema` to replace the hardcoded `mcp_url` and `mcp_tool_name` fields with a flexible `packaging_params` dictionary. This design allows for extensibility to support additional packaging formats in the future while maintaining clean validation logic.

## Changes

### Core Schema Changes
- **`src/skillberry_store/schemas/tool_schema.py`**
  - Removed: `mcp_url` and `mcp_tool_name` fields
  - Added: `packaging_params: Optional[Dict[str, Any]]` field
  - Added: `@field_validator` to parse JSON strings (for FastAPI Query parameters)
  - Added: `@model_validator` to validate MCP-specific params when `packaging_format="mcp"`

### Code Updates
- **`src/skillberry_store/modules/file_executor.py`**
  - Updated to access MCP params from `packaging_params.get("mcp_url")` and `packaging_params.get("mcp_tool_name")`
  
- **`src/skillberry_store/fast_api/server_utils.py`**
  - Updated to access MCP params from `packaging_params` dictionary

### Test Updates
- **`src/skillberry_store/tests/e2e/test_mcp_tools.py`**
  - Updated all MCP tests to use new `packaging_params` structure
  - Tests using POST endpoint: Send `packaging_params` as `json.dumps({"mcp_url": ..., "mcp_tool_name": ...})`
  - Tests writing JSON files: Use dict format `{"mcp_url": ..., "mcp_tool_name": ...}`

### SDK Fix
- **`client/python/skillberry_store_sdk/skillberry_store_sdk/api_client.py`**
  - Added workaround for OpenAPI Generator limitation
  - Handles `Optional[]` wrapper in type deserialization
  - Fixes `AttributeError` when deserializing `Optional[Dict[str, Any]]` types

## Design Decisions

### 1. Clean Break Approach
- No backward compatibility or migration logic
- All changes deployed atomically in a single release
- Simplifies codebase and avoids technical debt

### 2. Extensible Design
- `packaging_params` as `Dict[str, Any]` allows future packaging formats
- Example: Could add `docker_params`, `lambda_params`, etc. without schema changes

### 3. Validation Strategy
- Pydantic `@model_validator` ensures MCP params are present when `packaging_format="mcp"`
- Validates both `mcp_url` and `mcp_tool_name` are provided
- Clear error messages for missing required params

### 4. FastAPI Query Parameter Handling
- Added `@field_validator` to parse JSON strings
- Necessary because FastAPI Query() can't handle complex Dict types directly
- Tests handle both query param (JSON string) and file (dict) scenarios

## Testing

### Test Results
✅ **All 4 MCP-specific tests passed** (`test_mcp_tools.py`)
- `test_execute_tool_with_mcp_packaging`
- `test_create_mcp_tool_via_post_endpoint`
- `test_get_tool_module_with_mcp_packaging`
- `test_mcp_tool_not_found`

✅ **All 21 integration tests passed** (`test_*_integration.py`)
- Skills API: 6 passed
- Snippets API: 7 passed
- Tools API: 8 passed

### Test Coverage
- MCP tool creation via POST endpoint
- MCP tool execution
- Tool listing with `packaging_params`
- Error handling for missing MCP params

## Migration Notes

### For API Users
**Before:**
```python
{
  "name": "my_tool",
  "packaging_format": "mcp",
  "mcp_url": "http://localhost:3000",
  "mcp_tool_name": "actual_tool_name"
}
```

**After:**
```python
{
  "name": "my_tool",
  "packaging_format": "mcp",
  "packaging_params": {
    "mcp_url": "http://localhost:3000",
    "mcp_tool_name": "actual_tool_name"
  }
}
```

### For SDK Users
The Python SDK now properly handles the `packaging_params` field with the included deserialization fix.

## Known Issues & Limitations

### SDK Regeneration
- Full SDK regeneration was **not** performed to avoid unwanted changes
- OpenAPI Generator would have changed build system from Poetry to setuptools
- Only the essential `api_client.py` workaround was applied
- Future SDK regeneration will require reapplying the Optional[] workaround

### OpenAPI Generator Limitation
The workaround in `api_client.py` addresses a known limitation where the generator doesn't handle `Optional[]` wrapper types in deserialization. This is documented in the code comments.

## Commits
1. `164a18a` - Core refactoring: Replace mcp_url/mcp_tool_name with packaging_params
2. `adf9c0e` - Fix: Handle packaging_params correctly for different test scenarios
3. `ea3626f` - Fix lint issues
4. `6ce4c14` - Fix SDK deserialization for Optional[Dict] types

## Checklist
- [x] Code changes implemented
- [x] Tests updated and passing
- [x] Validation logic added
- [x] SDK compatibility maintained
- [x] No breaking changes to non-MCP functionality
- [ ] Documentation updated (if needed)
- [ ] API examples updated (if needed)

## Related Issues
Addresses the need for a more flexible and extensible packaging parameter system for tools.