### PR TITLE
Fix authentication error in PR review workflow when fetching from forks

### DIFF
--- a/.github/workflows/fix-pr-reviews-with-bob.yml
+++ b/.github/workflows/fix-pr-reviews-with-bob.yml
@@ -63,10 +63,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.base.ref }}
           fetch-depth: 0
           token: ${{ secrets.ERANRA_GITHUB_TOKEN }}
       
       - name: Fetch and checkout PR branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.ERANRA_GITHUB_TOKEN }}
         run: |
           # Add the fork as a remote if it's from a fork
           FORK_REPO="${{ github.event.pull_request.head.repo.full_name }}"
@@ -75,7 +78,7 @@ jobs:
           
           if [ "${FORK_REPO}" != "${BASE_REPO}" ]; then
             echo "PR is from fork: ${FORK_REPO}"
-            git remote add fork "https://github.com/${FORK_REPO}.git"
+            git remote add fork "https://x-access-token:${GITHUB_TOKEN}@github.com/${FORK_REPO}.git"
             git fetch fork "${PR_BRANCH}"
             git checkout -b "${PR_BRANCH}" "fork/${PR_BRANCH}"
           else


### PR DESCRIPTION
Closes #54

## Changes
This PR fixes the authentication error that occurs when the fix-pr-reviews-with-bob workflow tries to fetch PR branches from fork repositories.

### What was changed:
1. **Added authentication to fork remote fetch**: Added  environment variable and updated the fork remote URL to include authentication credentials using the  format
2. **Added base ref to initial checkout**: Added  to ensure the workflow checks out the exact base branch that the PR targets

### Why these changes were needed:
- The workflow was failing with 'Input required and not supplied: token' error when trying to fetch from fork repositories
- Without authentication, git cannot access private or fork repositories
- Checking out the correct base ref ensures Bob has the proper context for analyzing and addressing review comments

### Testing:
- Verified the workflow can now successfully fetch PR branches from fork repositories
- Confirmed the authentication token is properly passed through the git remote URL
- Validated that the base branch is correctly checked out before fetching the PR branch

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>