### PR TITLE
fix: add GitHub token fallback to PR review workflow

### DIFF
--- a/.github/workflows/fix-pr-reviews-with-bob.yml
+++ b/.github/workflows/fix-pr-reviews-with-bob.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
-          token: ${{ secrets.ERANRA_GITHUB_TOKEN }}
+          token: ${{ secrets.ERANRA_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       
       - name: Setup Node.js


### PR DESCRIPTION
Closes #58

## Summary
This PR adds a fallback mechanism to the fix-pr-reviews-with-bob workflow to use the standard GITHUB_TOKEN when ERANRA_GITHUB_TOKEN is not available.

## Changes
- Modified the token parameter in the checkout action to use: `${{ secrets.ERANRA_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}`

## Design Decisions
- Used the || operator to provide a clean fallback mechanism
- Maintains backward compatibility by preferring ERANRA_GITHUB_TOKEN when available
- No changes to workflow logic or behavior, only authentication token selection

## Testing
- Verified the syntax is correct for GitHub Actions expressions
- The change follows GitHub Actions best practices for secret fallbacks
- No breaking changes to existing functionality

## Impact
This change ensures the workflow can run in different environments:
1. Environments with ERANRA_GITHUB_TOKEN configured (preferred path)
2. Environments with only GITHUB_TOKEN available (fallback path)

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>