### PR TITLE
Refactor `/tools/add` to delegate to `/tools/`

### DIFF
--- a/src/skillberry_store/fast_api/tools_api.py
+++ b/src/skillberry_store/fast_api/tools_api.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from io import BytesIO
 from starlette.responses import PlainTextResponse
 import uuid
 from datetime import datetime, timezone
@@ -864,7 +865,7 @@ def register_tools_api(
 
             create_response = await create_tool(
                 tool=tool_schema,
-                module=UploadFile(filename=tool.filename, file=tool.file),
+                module=UploadFile(filename=tool.filename, file=BytesIO(tool_bytes)),
             )
 
             logger.info(f"Tool '{tool_schema.name}' added successfully")

--- a/src/skillberry_store/fast_api/tools_api.py
+++ b/src/skillberry_store/fast_api/tools_api.py
@@ -795,12 +795,9 @@ def register_tools_api(
             )
 
         try:
-            # Read the uploaded file content
             tool_bytes = await tool.read()
 
-            # Extract function name and docstring from the Python code
             try:
-                # extract_docstring returns (func_name, docstring_obj) tuple
                 func_name, docstring_obj = extract_docstring(tool_bytes, tool_name=tool_name)  # type: ignore
                 logger.info(f"Extracted function '{func_name}' from uploaded file")
             except Exception as e:
@@ -811,8 +808,6 @@ def register_tools_api(
                     "Ensure the function has a properly formatted docstring with parameters.",
                 )
 
-            # Build the tool schema from the docstring
-            # Extract description
             description = docstring_obj.short_description  # type: ignore
             if not description:
                 raise HTTPException(
@@ -820,7 +815,6 @@ def register_tools_api(
                     detail="Function docstring must include a description.",
                 )
 
-            # Extract parameters from docstring
             params_properties = {}
             required_params = []
 
@@ -831,7 +825,6 @@ def register_tools_api(
                 }
                 required_params.append(param.arg_name)
 
-            # Extract return information
             returns_schema = None
             if docstring_obj.returns:  # type: ignore
                 returns_schema = ToolReturnsSchema(
@@ -839,103 +832,44 @@ def register_tools_api(
                     description=docstring_obj.returns.description if docstring_obj.returns.description else None,  # type: ignore
                 )
 
-            # Check if tool already exists
-            existing_tools = tool_handler.list_files()
-            tool_filename = f"{func_name}.json"
-
-            if tool_filename in existing_tools:
-                if not update:
-                    raise HTTPException(
-                        status_code=409,
-                        detail=f"Tool '{func_name}' already exists. Set update=true to overwrite.",
-                    )
-                logger.info(f"Updating existing tool: {func_name}")
-
-                # Delete old description if updating
-                if tools_descriptions:
-                    try:
-                        tools_descriptions.delete_description(func_name)
-                    except Exception as e:
-                        logger.warning(f"Failed to delete old description: {e}")
-
-            # Generate UUID
-            tool_uuid = str(uuid.uuid4())
-            logger.info(f"Generated UUID for tool '{func_name}': {tool_uuid}")
-
-            # Save the module file
-            module_filename = tool.filename if tool.filename else f"{func_name}.py"
-            file_handler.write_file(tool_bytes, filename=module_filename)
-            logger.info(f"Saved module file: {module_filename}")
-
-            # Auto-detect dependencies if enabled
-            dependencies = None
-            if is_auto_detect_dependencies_enabled():
-                try:
-                    # Get list of available tools
-                    available_tools = [
-                        f.replace(".json", "") for f in tool_handler.list_files()
-                    ]
-                    # Detect dependencies from code
-                    detected_deps = detect_tool_dependencies(
-                        (
-                            tool_bytes.decode("utf-8")
-                            if isinstance(tool_bytes, bytes)
-                            else tool_bytes
-                        ),
-                        func_name,
-                        available_tools,
-                    )
-                    if detected_deps:
-                        dependencies = detected_deps
-                        logger.info(
-                            f"Auto-detected dependencies for '{func_name}': {detected_deps}"
-                        )
-                except Exception as e:
-                    logger.warning(f"Failed to auto-detect dependencies: {e}")
-
-            # Create the tool schema
-            params_schema = ToolParamsSchema(
-                type="object",
-                properties=params_properties,
-                required=required_params,
-                optional=[],
-            )
-
-            # Set timestamps
-            current_time = datetime.now(timezone.utc).isoformat()
-
             tool_schema = ToolSchema(
                 name=func_name,
+                uuid=None,
+                module_name=None,
                 description=description,
-                uuid=tool_uuid,
-                module_name=module_filename,
                 programming_language="python",
                 packaging_format="code",
                 version="0.0.1",
                 state=ManifestState.APPROVED,
-                params=params_schema,
+                params=ToolParamsSchema(
+                    type="object",
+                    properties=params_properties,
+                    required=required_params,
+                    optional=[],
+                ),
                 returns=returns_schema,
-                dependencies=dependencies,
-                created_at=current_time,
-                modified_at=current_time,
             )
 
-            # Save the manifest
-            tool_json = json.dumps(tool_schema.to_dict(), indent=4)
-            tool_handler.write_file_content(tool_filename, tool_json)
-            logger.info(f"Saved manifest: {tool_filename}")
+            if update:
+                tool_filename = f"{tool_schema.name}.json"
+                existing_tools = tool_handler.list_files()
+                if tool_filename in existing_tools:
+                    logger.info(f"Updating existing tool: {tool_schema.name}")
+                    if tools_descriptions and tool_schema.name:
+                        try:
+                            tools_descriptions.delete_description(tool_schema.name)
+                        except Exception as e:
+                            logger.warning(f"Failed to delete old description: {e}")
+                    tool_handler.delete_file(tool_filename)
 
-            # Write description for search capability
-            if tools_descriptions:
-                tools_descriptions.write_description(func_name, description)
-                logger.info(f"Tool description saved for: {func_name}")
+            create_response = await create_tool(
+                tool=tool_schema,
+                module=UploadFile(filename=tool.filename, file=tool.file),
+            )
 
-            logger.info(f"Tool '{func_name}' added successfully")
+            logger.info(f"Tool '{tool_schema.name}' added successfully")
             return {
-                "message": f"Tool '{func_name}' added successfully.",
-                "name": func_name,
-                "uuid": tool_uuid,
-                "module_name": module_filename,
+                **create_response,
                 "parameters": params_properties,
                 "description": description,
             }
@@ -945,6 +879,3 @@ def register_tools_api(
         except Exception as e:
             logger.error(f"Error adding tool: {e}")
             raise HTTPException(status_code=500, detail=f"Error adding tool: {str(e)}")
-            raise HTTPException(
-                status_code=500, detail=f"Error searching tools: {str(e)}"
-            )

--- a/src/skillberry_store/tests/e2e/integration/test_tools_integration.py
+++ b/src/skillberry_store/tests/e2e/integration/test_tools_integration.py
@@ -32,6 +32,9 @@ class TestToolsAPI:
         
         assert response is not None
         assert "message" in response or "name" in response
+        assert response.get("name") == "add_numbers"
+        assert response.get("module_name") == "test_add_numbers.py"
+        assert response.get("uuid") is not None
         
         # Store for later tests
         if "name" in response:
@@ -110,6 +113,9 @@ class TestToolsAPI:
         
         assert response is not None
         assert "message" in response or "name" in response
+        assert response.get("name") == "add_numbers"
+        assert response.get("module_name") == "test_add_numbers.py"
+        assert response.get("uuid") is not None
 
     def test_07_search_tools(self, tools_api):
         """Test searching tools."""

--- a/src/skillberry_store/tests/e2e/test_sdk_add_tool.py
+++ b/src/skillberry_store/tests/e2e/test_sdk_add_tool.py
@@ -87,12 +87,13 @@ async def test_sdk_add_tool(run_sbs, sdk_client):
         assert result is not None
         assert isinstance(result, dict)
         assert result.get("name") == "calculate_sum"
+        assert result.get("message") == "Tool 'calculate_sum' created successfully."
         assert "uuid" in result
         uuid_value = result.get("uuid")
         assert uuid_value is not None and len(uuid_value) == 36  # UUID4 format
         assert "module_name" in result
         module_name = result.get("module_name")
-        assert module_name is not None and module_name.endswith(".py")
+        assert module_name is not None and module_name == os.path.basename(temp_path)
         
         # Verify the tool was actually created by retrieving it
         tool = sdk_client.get_tool_tools_name_get(name="calculate_sum")

--- a/src/skillberry_store/tests/e2e/test_tools_api.py
+++ b/src/skillberry_store/tests/e2e/test_tools_api.py
@@ -205,6 +205,131 @@ async def test_create_duplicate_tool(run_sbs):
 
 
 @pytest.mark.asyncio
+async def test_add_tool_from_python_endpoint(run_sbs):
+    """Test creating a tool via POST /tools/add from a Python file."""
+    file_content = b'''def add_via_tools_add(x: int, y: int) -> int:
+    """Add two integers.
+    
+    Args:
+        x: First number
+        y: Second number
+        
+    Returns:
+        Sum of x and y
+    """
+    return x + y
+'''
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{BASE_URL}/tools/add",
+            params={"tool_name": "add_via_tools_add"},
+            files={"tool": ("add_via_tools_add.py", file_content, "text/x-python")},
+        )
+        assert response.status_code == 200, (
+            f"Expected 200, got {response.status_code}: {response.text}"
+        )
+        result = response.json()
+        assert result.get("name") == "add_via_tools_add"
+        assert result.get("message") == "Tool 'add_via_tools_add' created successfully."
+        assert result.get("module_name") == "add_via_tools_add.py"
+        assert result.get("uuid") is not None
+        assert result.get("description") == "Add two integers."
+        assert result.get("parameters") == {
+            "x": {"type": "string", "description": "First number"},
+            "y": {"type": "string", "description": "Second number"},
+        }
+
+        get_response = await client.get(f"{BASE_URL}/tools/add_via_tools_add")
+        assert get_response.status_code == 200
+        tool = get_response.json()
+        assert tool.get("module_name") == "add_via_tools_add.py"
+
+        delete_response = await client.delete(f"{BASE_URL}/tools/add_via_tools_add")
+        assert delete_response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_add_tool_from_python_endpoint_update(run_sbs):
+    """Test updating an existing tool via POST /tools/add with update=true."""
+    file_content = b'''def add_via_tools_add_update(x: int, y: int) -> int:
+    """Add two integers.
+    
+    Args:
+        x: First number
+        y: Second number
+        
+    Returns:
+        Sum of x and y
+    """
+    return x + y
+'''
+
+    updated_file_content = b'''def add_via_tools_add_update(x: int, y: int) -> int:
+    """Add two integers with updated description.
+    
+    Args:
+        x: First number
+        y: Second number
+        
+    Returns:
+        Sum of x and y
+    """
+    return x + y
+'''
+
+    async with httpx.AsyncClient() as client:
+        create_response = await client.post(
+            f"{BASE_URL}/tools/add",
+            params={"tool_name": "add_via_tools_add_update"},
+            files={
+                "tool": (
+                    "add_via_tools_add_update.py",
+                    file_content,
+                    "text/x-python",
+                )
+            },
+        )
+        assert create_response.status_code == 200, (
+            f"Expected 200, got {create_response.status_code}: {create_response.text}"
+        )
+        created = create_response.json()
+        first_uuid = created.get("uuid")
+        assert first_uuid is not None
+
+        update_response = await client.post(
+            f"{BASE_URL}/tools/add",
+            params={"tool_name": "add_via_tools_add_update", "update": "true"},
+            files={
+                "tool": (
+                    "add_via_tools_add_update.py",
+                    updated_file_content,
+                    "text/x-python",
+                )
+            },
+        )
+        assert update_response.status_code == 200, (
+            f"Expected 200, got {update_response.status_code}: {update_response.text}"
+        )
+        updated = update_response.json()
+        assert updated.get("name") == "add_via_tools_add_update"
+        assert updated.get("message") == "Tool 'add_via_tools_add_update' created successfully."
+        assert updated.get("module_name") == "add_via_tools_add_update.py"
+        assert updated.get("uuid") is not None
+        assert updated.get("uuid") != first_uuid
+        assert updated.get("description") == "Add two integers with updated description."
+
+        get_response = await client.get(f"{BASE_URL}/tools/add_via_tools_add_update")
+        assert get_response.status_code == 200
+        tool = get_response.json()
+        assert tool.get("description") == "Add two integers with updated description."
+        assert tool.get("module_name") == "add_via_tools_add_update.py"
+
+        delete_response = await client.delete(f"{BASE_URL}/tools/add_via_tools_add_update")
+        assert delete_response.status_code == 200
+
+
+@pytest.mark.asyncio
 async def test_list_tools(run_sbs):
     """Test listing all tools."""
     async with httpx.AsyncClient() as client:


### PR DESCRIPTION
# Refactor `/tools/add` to delegate to `/tools/`

## Summary
This change refactors [`POST /tools/add`](src/skillberry_store/fast_api/tools_api.py) so it parses the uploaded Python file into a [`ToolSchema`](src/skillberry_store/schemas/tool_schema.py) and then delegates persistence through [`create_tool()`](src/skillberry_store/fast_api/tools_api.py:202).

## Changes
- Inlined docstring parsing inside [`add_tool_from_python()`](src/skillberry_store/fast_api/tools_api.py:787)
- Reused [`create_tool()`](src/skillberry_store/fast_api/tools_api.py:202) for manifest/module persistence
- Preserved `/tools/add`-specific response fields:
  - parsed `parameters`
  - parsed `description`
- Fixed upload delegation by passing a fresh in-memory file to [`create_tool()`](src/skillberry_store/fast_api/tools_api.py:202), preventing empty saved modules after the initial read

## Tests
Updated coverage for `/tools/add` in:
- [`src/skillberry_store/tests/e2e/test_tools_api.py`](src/skillberry_store/tests/e2e/test_tools_api.py)
- [`src/skillberry_store/tests/e2e/test_sdk_add_tool.py`](src/skillberry_store/tests/e2e/test_sdk_add_tool.py)
- [`src/skillberry_store/tests/e2e/integration/test_tools_integration.py`](src/skillberry_store/tests/e2e/integration/test_tools_integration.py)

Validated:
- direct HTTP `/tools/add`
- SDK `/tools/add`
- MCP regression in [`test_execute_tool_with_mcp_packaging()`](src/skillberry_store/tests/e2e/test_mcp_tools.py:128)

## Notes
[`create_tool()`](src/skillberry_store/fast_api/tools_api.py:202) was intentionally left unchanged.