### PR TITLE
Add curated Agent MCP server + Connect Your Agent tab

### DIFF
--- a/src/skillberry_store/fast_api/admin_api.py
+++ b/src/skillberry_store/fast_api/admin_api.py
@@ -46,20 +46,20 @@ def register_admin_api(app: FastAPI, tags: str = "admin"):
 
         Used by the Connect Your Agent UI to render copy-ready
         `claude mcp add` commands and to know which SSE URL to test.
-        `agent_mcp_url` is None when the curated agent MCP failed to start.
+        `curated_mcp_url` is None when the curated agent MCP failed to start.
         """
         settings = app.settings
         host = settings.display_host
         port = settings.sbs_port
-        agent_mcp_port = getattr(settings, "agent_mcp_port", None)
-        agent_mcp_url = None
-        if agent_mcp_port is not None and getattr(app, "agent_mcp", None) is not None:
-            agent_mcp_url = f"http://{host}:{agent_mcp_port}/sse"
+        curated_mcp_port = getattr(settings, "curated_mcp_port", None)
+        curated_mcp_url = None
+        if curated_mcp_port is not None and getattr(app, "curated_mcp", None) is not None:
+            curated_mcp_url = f"http://{host}:{curated_mcp_port}/sse"
         return {
             "host": host,
             "port": port,
-            "agent_mcp_port": agent_mcp_port,
-            "agent_mcp_url": agent_mcp_url,
+            "curated_mcp_port": curated_mcp_port,
+            "curated_mcp_url": curated_mcp_url,
             "control_mcp_url": f"http://{host}:{port}/control_sse",
             "api_docs": f"http://{host}:{port}/docs",
         }

--- a/src/skillberry_store/fast_api/admin_api.py
+++ b/src/skillberry_store/fast_api/admin_api.py
@@ -40,6 +40,30 @@ def register_admin_api(app: FastAPI, tags: str = "admin"):
         app: The FastAPI application instance.
         tags: FastAPI tags for grouping the endpoints in documentation.
     """
+    @app.get("/admin/server-info", tags=[tags])
+    async def get_server_info():
+        """Return connection info for the backend and its MCP endpoints.
+
+        Used by the Connect Your Agent UI to render copy-ready
+        `claude mcp add` commands and to know which SSE URL to test.
+        `agent_mcp_url` is None when the curated agent MCP failed to start.
+        """
+        settings = app.settings
+        host = settings.display_host
+        port = settings.sbs_port
+        agent_mcp_port = getattr(settings, "agent_mcp_port", None)
+        agent_mcp_url = None
+        if agent_mcp_port is not None and getattr(app, "agent_mcp", None) is not None:
+            agent_mcp_url = f"http://{host}:{agent_mcp_port}/sse"
+        return {
+            "host": host,
+            "port": port,
+            "agent_mcp_port": agent_mcp_port,
+            "agent_mcp_url": agent_mcp_url,
+            "control_mcp_url": f"http://{host}:{port}/control_sse",
+            "api_docs": f"http://{host}:{port}/docs",
+        }
+
     @app.get("/admin/metrics", tags=[tags], response_class=PlainTextResponse)
     async def get_metrics():
         """Proxy endpoint to fetch Prometheus metrics.

--- a/src/skillberry_store/fast_api/agent_mcp_server.py
+++ b/src/skillberry_store/fast_api/agent_mcp_server.py
@@ -1,0 +1,262 @@
+"""Curated Agent MCP Server for Skillberry Store.
+
+Exposes a hand-picked set of LLM-friendly tools over SSE on its own port.
+Every tool here is a thin proxy to the local FastAPI backend (same process,
+different port) so validation, observability, and persistence stay in one
+place — the REST layer. The curation value is the smaller surface area and
+better names/docstrings, not reimplemented logic.
+"""
+
+import json
+import logging
+import threading
+from typing import Any, Dict, List, Optional
+
+import httpx
+import uvicorn
+from mcp.server.fastmcp import FastMCP
+from starlette.middleware.cors import CORSMiddleware
+
+logger = logging.getLogger(__name__)
+
+
+def create_agent_mcp_server(app, port: int = 9999):
+    """Build and start the curated Agent MCP server in a background thread.
+
+    Args:
+        app: The SBS FastAPI application. Used to read the backend port so
+            the proxy always hits the same process (even when SBS_PORT is
+            overridden).
+        port: TCP port for the curated SSE endpoint.
+
+    Returns:
+        The FastMCP instance (already serving).
+    """
+    mcp = FastMCP(name="skillberry-agent", port=port)
+
+    backend_port = app.settings.sbs_port
+    base_url = f"http://127.0.0.1:{backend_port}"
+    client_timeout = httpx.Timeout(60.0, connect=5.0)
+
+    def _request(method: str, path: str, **kwargs) -> str:
+        """Call the local FastAPI and return the response body as text.
+
+        Returns the raw JSON string on success and a JSON-encoded error
+        envelope on failure — agents parse MCP results as strings either
+        way, so the extra quoting isn't useful.
+        """
+        try:
+            with httpx.Client(base_url=base_url, timeout=client_timeout) as c:
+                r = c.request(method, path, **kwargs)
+            if r.status_code >= 400:
+                return json.dumps({
+                    "error": True,
+                    "status": r.status_code,
+                    "detail": r.json().get("detail") if r.headers.get("content-type", "").startswith("application/json") else r.text,
+                })
+            return r.text
+        except Exception as e:
+            return json.dumps({"error": True, "detail": str(e)})
+
+    def _resolve_tool_uuids(tool_names: List[str]) -> List[str]:
+        """Look up tool UUIDs by name via GET /tools/{name}."""
+        uuids: List[str] = []
+        with httpx.Client(base_url=base_url, timeout=client_timeout) as c:
+            for n in tool_names:
+                r = c.get(f"/tools/{n}")
+                if r.status_code == 200:
+                    uuids.append(r.json().get("uuid", ""))
+                else:
+                    raise ValueError(f"Tool '{n}' not found")
+        return uuids
+
+    def _resolve_skill_uuid(skill_name: str) -> str:
+        """Look up a skill UUID by name via GET /skills/{name}."""
+        with httpx.Client(base_url=base_url, timeout=client_timeout) as c:
+            r = c.get(f"/skills/{skill_name}")
+        if r.status_code != 200:
+            raise ValueError(f"Skill '{skill_name}' not found")
+        return r.json().get("uuid", "")
+
+    # ---- Tools ----
+
+    @mcp.tool()
+    def list_tools() -> str:
+        """List every tool in the store (name, description, state, tags)."""
+        return _request("GET", "/tools/")
+
+    @mcp.tool()
+    def get_tool(name: str) -> str:
+        """Get a tool's full metadata manifest by name."""
+        return _request("GET", f"/tools/{name}")
+
+    @mcp.tool()
+    def get_tool_code(name: str) -> str:
+        """Get a tool's Python source code."""
+        return _request("GET", f"/tools/{name}/module")
+
+    @mcp.tool()
+    def create_tool(code: str, filename: str, tool_name: Optional[str] = None) -> str:
+        """Create a new tool by uploading Python source with a docstring.
+
+        The store parses the function's docstring to extract description and
+        parameter schema, so the code must contain a function with a
+        well-formed docstring (Google, NumPy, or Sphinx style).
+
+        Args:
+            code: The full Python source (one or more functions).
+            filename: Name for the uploaded file, e.g. "my_tool.py".
+            tool_name: Optional specific function to register. Defaults to
+                the first function in the file.
+        """
+        params: Dict[str, Any] = {}
+        if tool_name:
+            params["tool_name"] = tool_name
+        return _request(
+            "POST",
+            "/tools/add",
+            params=params,
+            files={"tool": (filename, code.encode("utf-8"), "text/x-python")},
+        )
+
+    @mcp.tool()
+    def execute_tool(name: str, parameters: Optional[Dict[str, Any]] = None) -> str:
+        """Execute a tool by name with the given parameters.
+
+        Args:
+            name: The tool name.
+            parameters: Keyword arguments passed to the tool's function.
+        """
+        return _request("POST", f"/tools/{name}/execute", json=parameters or {})
+
+    @mcp.tool()
+    def search_tools(query: str, max_results: int = 5) -> str:
+        """Semantic search over tool descriptions.
+
+        Args:
+            query: The search query.
+            max_results: Maximum number of results.
+        """
+        return _request(
+            "GET",
+            "/search/tools",
+            params={"search_term": query, "max_number_of_results": max_results},
+        )
+
+    # ---- Skills ----
+
+    @mcp.tool()
+    def list_skills() -> str:
+        """List every skill in the store."""
+        return _request("GET", "/skills/")
+
+    @mcp.tool()
+    def get_skill(name: str) -> str:
+        """Get a skill's full manifest by name."""
+        return _request("GET", f"/skills/{name}")
+
+    @mcp.tool()
+    def create_skill(
+        name: str,
+        description: str,
+        tool_names: Optional[List[str]] = None,
+        tags: Optional[List[str]] = None,
+    ) -> str:
+        """Create a new skill. Resolves tool names to UUIDs automatically.
+
+        Args:
+            name: The skill name.
+            description: Human-readable description.
+            tool_names: Optional tool names to include — each is resolved to
+                the corresponding tool UUID before creation.
+            tags: Optional tags.
+        """
+        try:
+            tool_uuids = _resolve_tool_uuids(tool_names or [])
+        except ValueError as e:
+            return json.dumps({"error": True, "detail": str(e)})
+        params: List[tuple] = [
+            ("name", name),
+            ("description", description),
+            ("version", "1.0.0"),
+            ("state", "approved"),
+        ]
+        for u in tool_uuids:
+            params.append(("tool_uuids", u))
+        for t in tags or []:
+            params.append(("tags", t))
+        return _request("POST", "/skills/", params=params)
+
+    @mcp.tool()
+    def search_skills(query: str, max_results: int = 5) -> str:
+        """Semantic search over skill descriptions.
+
+        Args:
+            query: The search query.
+            max_results: Maximum number of results.
+        """
+        return _request(
+            "GET",
+            "/search/skills",
+            params={"search_term": query, "max_number_of_results": max_results},
+        )
+
+    # ---- Virtual MCP servers ----
+
+    @mcp.tool()
+    def list_vmcp_servers() -> str:
+        """List every Virtual MCP Server in the store."""
+        return _request("GET", "/vmcp_servers/")
+
+    @mcp.tool()
+    def create_vmcp_server(
+        name: str,
+        skill_name: str,
+        port: Optional[int] = None,
+    ) -> str:
+        """Create and start a Virtual MCP Server for a skill.
+
+        Args:
+            name: Name for the new VMCP server.
+            skill_name: Skill whose tools/snippets the VMCP will expose.
+                Resolved to skill_uuid automatically.
+            port: Optional TCP port; auto-assigned if omitted.
+        """
+        try:
+            skill_uuid = _resolve_skill_uuid(skill_name)
+        except ValueError as e:
+            return json.dumps({"error": True, "detail": str(e)})
+        params: List[tuple] = [
+            ("name", name),
+            ("description", f"VMCP server for skill '{skill_name}'"),
+            ("version", "1.0.0"),
+            ("state", "approved"),
+            ("skill_uuid", skill_uuid),
+        ]
+        if port is not None:
+            params.append(("port", port))
+        return _request("POST", "/vmcp_servers/", params=params)
+
+    @mcp.tool()
+    def delete_vmcp_server(name: str) -> str:
+        """Stop and delete a Virtual MCP Server by name."""
+        return _request("DELETE", f"/vmcp_servers/{name}")
+
+    # ---- Start the server ----
+
+    def _start():
+        logger.info(f"Starting Agent MCP server on port {port}")
+        sse_app = mcp.sse_app()
+        sse_app.add_middleware(
+            CORSMiddleware,
+            allow_origins=["*"],
+            allow_methods=["GET", "POST", "OPTIONS"],
+            allow_headers=["*"],
+            allow_credentials=True,
+            expose_headers=["*"],
+        )
+        uvicorn.run(sse_app, host="127.0.0.1", port=port, log_level="info")
+
+    threading.Thread(target=_start, daemon=True).start()
+    logger.info(f"Agent MCP server started on port {port}")
+    return mcp

--- a/src/skillberry_store/fast_api/curated_mcp_server.py
+++ b/src/skillberry_store/fast_api/curated_mcp_server.py
@@ -1,4 +1,4 @@
-"""Curated Agent MCP Server for Skillberry Store.
+"""Curated MCP Server for Skillberry Store.
 
 Exposes a hand-picked set of LLM-friendly tools over SSE on its own port.
 Every tool here is a thin proxy to the local FastAPI backend (same process,
@@ -20,8 +20,8 @@ from starlette.middleware.cors import CORSMiddleware
 logger = logging.getLogger(__name__)
 
 
-def create_agent_mcp_server(app, port: int = 9999):
-    """Build and start the curated Agent MCP server in a background thread.
+def create_curated_mcp_server(app, port: int = 9999):
+    """Build and start the curated MCP server in a background thread.
 
     Args:
         app: The SBS FastAPI application. Used to read the backend port so
@@ -32,7 +32,7 @@ def create_agent_mcp_server(app, port: int = 9999):
     Returns:
         The FastMCP instance (already serving).
     """
-    mcp = FastMCP(name="skillberry-agent", port=port)
+    mcp = FastMCP(name="skillberry-curated", port=port)
 
     backend_port = app.settings.sbs_port
     base_url = f"http://127.0.0.1:{backend_port}"
@@ -245,7 +245,7 @@ def create_agent_mcp_server(app, port: int = 9999):
     # ---- Start the server ----
 
     def _start():
-        logger.info(f"Starting Agent MCP server on port {port}")
+        logger.info(f"Starting Curated MCP server on port {port}")
         sse_app = mcp.sse_app()
         sse_app.add_middleware(
             CORSMiddleware,
@@ -258,5 +258,5 @@ def create_agent_mcp_server(app, port: int = 9999):
         uvicorn.run(sse_app, host="127.0.0.1", port=port, log_level="info")
 
     threading.Thread(target=_start, daemon=True).start()
-    logger.info(f"Agent MCP server started on port {port}")
+    logger.info(f"Curated MCP server started on port {port}")
     return mcp

--- a/src/skillberry_store/fast_api/server.py
+++ b/src/skillberry_store/fast_api/server.py
@@ -58,7 +58,7 @@ class SBSettings(BaseSettings):
     )
     observability: bool = Field(True, validation_alias="OBSERVABILITY")
     sbs_vdb: str = Field("faiss", env="SBS_VDB")
-    agent_mcp_port: int = Field(9999, validation_alias="SBS_AGENT_MCP_PORT")
+    curated_mcp_port: int = Field(9999, validation_alias="SBS_CURATED_MCP_PORT")
 
     @property
     def display_host(self) -> str:
@@ -103,21 +103,21 @@ class SBS(FastAPI):
         self.full_mcp = FastApiMCP(self)
         self.full_mcp.mount_sse(mount_path="/control_sse")
 
-        # Curated Agent MCP — hand-picked ~15-tool set on its own port, the
+        # Curated MCP — hand-picked ~15-tool set on its own port, the
         # default endpoint for AI agents (smaller context footprint, LLM-
-        # friendly names). Defined in agent_mcp_server.py; runs in a thread.
-        from skillberry_store.fast_api.agent_mcp_server import create_agent_mcp_server
+        # friendly names). Defined in curated_mcp_server.py; runs in a thread.
+        from skillberry_store.fast_api.curated_mcp_server import create_curated_mcp_server
         try:
-            self.agent_mcp = create_agent_mcp_server(
-                self, port=self.settings.agent_mcp_port
+            self.curated_mcp = create_curated_mcp_server(
+                self, port=self.settings.curated_mcp_port
             )
             logger.info(
-                f"Curated Agent MCP server started on port "
-                f"{self.settings.agent_mcp_port}"
+                f"Curated MCP server started on port "
+                f"{self.settings.curated_mcp_port}"
             )
         except Exception as e:
-            logger.warning(f"Failed to start curated Agent MCP server: {e}")
-            self.agent_mcp = None
+            logger.warning(f"Failed to start curated MCP server: {e}")
+            self.curated_mcp = None
 
     def configure_fastapi(self):
         """Configures CORS middleware and OpenAPI documentation settings."""

--- a/src/skillberry_store/fast_api/server.py
+++ b/src/skillberry_store/fast_api/server.py
@@ -58,6 +58,7 @@ class SBSettings(BaseSettings):
     )
     observability: bool = Field(True, validation_alias="OBSERVABILITY")
     sbs_vdb: str = Field("faiss", env="SBS_VDB")
+    agent_mcp_port: int = Field(9999, validation_alias="SBS_AGENT_MCP_PORT")
 
     @property
     def display_host(self) -> str:
@@ -96,9 +97,27 @@ class SBS(FastAPI):
         register_tools_api(self, tags="tools", tools_descriptions=self.state.tools_descriptions)
         register_admin_api(self, tags="admin")
 
-        # Mount MCP server
-        mcp_server = FastApiMCP(self)
-        mcp_server.mount_sse(mount_path="/control_sse")
+        # Full MCP — auto-generated from every FastAPI route, mirrors the
+        # complete HTTP surface. Broad but token-heavy; intended for
+        # control-plane/admin access.
+        self.full_mcp = FastApiMCP(self)
+        self.full_mcp.mount_sse(mount_path="/control_sse")
+
+        # Curated Agent MCP — hand-picked ~15-tool set on its own port, the
+        # default endpoint for AI agents (smaller context footprint, LLM-
+        # friendly names). Defined in agent_mcp_server.py; runs in a thread.
+        from skillberry_store.fast_api.agent_mcp_server import create_agent_mcp_server
+        try:
+            self.agent_mcp = create_agent_mcp_server(
+                self, port=self.settings.agent_mcp_port
+            )
+            logger.info(
+                f"Curated Agent MCP server started on port "
+                f"{self.settings.agent_mcp_port}"
+            )
+        except Exception as e:
+            logger.warning(f"Failed to start curated Agent MCP server: {e}")
+            self.agent_mcp = None
 
     def configure_fastapi(self):
         """Configures CORS middleware and OpenAPI documentation settings."""

--- a/src/skillberry_store/main.py
+++ b/src/skillberry_store/main.py
@@ -70,18 +70,18 @@ def main():
 
     host = server.settings.display_host
     port = server.settings.sbs_port
-    agent_mcp_port = server.settings.agent_mcp_port
-    agent_mcp_url = f"http://{host}:{agent_mcp_port}/sse"
+    curated_mcp_port = server.settings.curated_mcp_port
+    curated_mcp_url = f"http://{host}:{curated_mcp_port}/sse"
 
     print(f"\n{'='*60}")
     if ui_started:
         print(f"  Skillberry Store UI: http://{host}:{ui_manager.ui_port}")
     print(f"  Backend API: http://{host}:{port}/docs")
-    if getattr(server, "agent_mcp", None) is not None:
-        print(f"  Store MCP:   {agent_mcp_url}")
+    if getattr(server, "curated_mcp", None) is not None:
+        print(f"  Store MCP:   {curated_mcp_url}")
         print()
         print(f"  Connect Claude Code to the Store MCP:")
-        print(f"    claude mcp add skillberry-store -s user -t sse {agent_mcp_url}")
+        print(f"    claude mcp add skillberry-store -s user -t sse {curated_mcp_url}")
         print(f"  Remove:")
         print(f"    claude mcp remove skillberry-store -s user")
     print(f"{'='*60}\n")

--- a/src/skillberry_store/main.py
+++ b/src/skillberry_store/main.py
@@ -68,10 +68,22 @@ def main():
         if not ui_started:
             print("Warning: Failed to start UI server. Backend will run without UI.")
 
+    host = server.settings.display_host
+    port = server.settings.sbs_port
+    agent_mcp_port = server.settings.agent_mcp_port
+    agent_mcp_url = f"http://{host}:{agent_mcp_port}/sse"
+
     print(f"\n{'='*60}")
     if ui_started:
-        print(f"  Skillberry Store UI: http://{server.settings.display_host}:{ui_manager.ui_port}")
-    print(f"  Backend API: http://{server.settings.display_host}:{server.settings.sbs_port}/docs")
+        print(f"  Skillberry Store UI: http://{host}:{ui_manager.ui_port}")
+    print(f"  Backend API: http://{host}:{port}/docs")
+    if getattr(server, "agent_mcp", None) is not None:
+        print(f"  Store MCP:   {agent_mcp_url}")
+        print()
+        print(f"  Connect Claude Code to the Store MCP:")
+        print(f"    claude mcp add skillberry-store -s user -t sse {agent_mcp_url}")
+        print(f"  Remove:")
+        print(f"    claude mcp remove skillberry-store -s user")
     print(f"{'='*60}\n")
     sys.stdout.flush()
 

--- a/src/skillberry_store/ui/src/App.tsx
+++ b/src/skillberry_store/ui/src/App.tsx
@@ -14,6 +14,7 @@ import { VMCPServersPage } from './pages/VMCPServersPage';
 import { VMCPServerDetailPage } from './pages/VMCPServerDetailPage';
 import { AdminPage } from './pages/AdminPage';
 import { ObservabilityPage } from './pages/ObservabilityPage';
+import { AgentConnectPage } from './pages/AgentConnectPage';
 import { NotFoundPage } from './pages/NotFoundPage';
 
 function App() {
@@ -43,7 +44,10 @@ function App() {
         
         {/* Observability route */}
         <Route path="/observability" element={<ObservabilityPage />} />
-        
+
+        {/* Connect Your Agent route */}
+        <Route path="/agent-connect" element={<AgentConnectPage />} />
+
         {/* 404 */}
         <Route path="*" element={<NotFoundPage />} />
       </Routes>

--- a/src/skillberry_store/ui/src/components/AppLayout.tsx
+++ b/src/skillberry_store/ui/src/components/AppLayout.tsx
@@ -124,6 +124,16 @@ export function AppLayout({ children }: AppLayoutProps) {
               Observability
             </NavItem>
 
+            {/* Connect Your Agent */}
+            <NavItem
+              key="agent-connect"
+              itemId="agent-connect"
+              isActive={location.pathname === '/agent-connect'}
+              onClick={() => navigate('/agent-connect')}
+            >
+              Connect Your Agent
+            </NavItem>
+
             {/* Admin */}
             <NavItem
               key="admin"

--- a/src/skillberry_store/ui/src/hooks/useMCPClient.ts
+++ b/src/skillberry_store/ui/src/hooks/useMCPClient.ts
@@ -40,7 +40,7 @@ interface MCPClientState {
   prompts: MCPPrompt[];
 }
 
-export function useMCPClient(serverPort: number | undefined, serverName: string) {
+export function useMCPClient(serverPort: number | undefined, serverName: string, sseUrl?: string) {
   const [state, setState] = useState<MCPClientState>({
     isConnected: false,
     isConnecting: false,
@@ -52,13 +52,13 @@ export function useMCPClient(serverPort: number | undefined, serverName: string)
   const [client, setClient] = useState<Client | null>(null);
 
   const connect = useCallback(async () => {
-    if (!serverPort) {
-      console.error('[MCP Client] No server port provided');
-      setState(prev => ({ ...prev, error: 'Server port not available' }));
+    if (!sseUrl && !serverPort) {
+      console.error('[MCP Client] No server port or URL provided');
+      setState(prev => ({ ...prev, error: 'Server port or URL not available' }));
       return;
     }
 
-    console.log(`[MCP Client] Starting connection to port ${serverPort}`);
+    console.log(`[MCP Client] Starting connection to ${sseUrl || `port ${serverPort}`}`);
     setState(prev => ({ ...prev, isConnecting: true, error: null }));
 
     try {
@@ -79,10 +79,10 @@ export function useMCPClient(serverPort: number | undefined, serverName: string)
       console.log('[MCP Client] MCP client created successfully');
 
       // Create SSE transport
-      const sseUrl = `http://localhost:${serverPort}/sse`;
-      console.log(`[MCP Client] Creating SSE transport to ${sseUrl}`);
+      const resolvedUrl = sseUrl || `http://localhost:${serverPort}/sse`;
+      console.log(`[MCP Client] Creating SSE transport to ${resolvedUrl}`);
       const transport = new SSEClientTransport(
-        new URL(sseUrl)
+        new URL(resolvedUrl)
       );
       console.log('[MCP Client] SSE transport created');
 
@@ -101,15 +101,22 @@ export function useMCPClient(serverPort: number | undefined, serverName: string)
         inputSchema: tool.inputSchema,
       }));
 
-      // List available prompts
-      console.log('[MCP Client] Listing prompts...');
-      const promptsResponse = await mcpClient.listPrompts();
-      console.log(`[MCP Client] Received ${promptsResponse.prompts.length} prompts:`, promptsResponse.prompts);
-      const prompts = promptsResponse.prompts.map((prompt: any) => ({
-        name: prompt.name,
-        description: prompt.description,
-        arguments: prompt.arguments,
-      }));
+      // List available prompts — optional capability. FastApiMCP and the
+      // curated agent MCP don't implement prompts/list and return -32601
+      // (Method not found), which should not surface as a connection error.
+      let prompts: MCPPrompt[] = [];
+      try {
+        console.log('[MCP Client] Listing prompts...');
+        const promptsResponse = await mcpClient.listPrompts();
+        console.log(`[MCP Client] Received ${promptsResponse.prompts.length} prompts:`, promptsResponse.prompts);
+        prompts = promptsResponse.prompts.map((prompt: any) => ({
+          name: prompt.name,
+          description: prompt.description,
+          arguments: prompt.arguments,
+        }));
+      } catch (promptsError) {
+        console.log('[MCP Client] Server does not support prompts/list — skipping.', promptsError);
+      }
 
       setClient(mcpClient);
       setState({
@@ -135,7 +142,7 @@ export function useMCPClient(serverPort: number | undefined, serverName: string)
         prompts: [],
       });
     }
-  }, [serverPort]);
+  }, [serverPort, sseUrl]);
 
   const disconnect = useCallback(async () => {
     if (client) {
@@ -178,10 +185,10 @@ export function useMCPClient(serverPort: number | undefined, serverName: string)
     }
   }, [client, state.isConnected]);
 
-  // Auto-connect when component mounts
+  // Auto-connect when component mounts or serverPort/sseUrl changes
   useEffect(() => {
-    console.log(`[MCP Client] useEffect triggered - serverPort: ${serverPort}, serverName: ${serverName}`);
-    if (serverPort) {
+    console.log(`[MCP Client] useEffect triggered - serverPort: ${serverPort}, serverName: ${serverName}, sseUrl: ${sseUrl}`);
+    if (serverPort || sseUrl) {
       connect();
     }
 
@@ -192,7 +199,7 @@ export function useMCPClient(serverPort: number | undefined, serverName: string)
         client.close().catch(console.error);
       }
     };
-  }, [serverPort]);
+  }, [serverPort, sseUrl]);
 
   return {
     ...state,

--- a/src/skillberry_store/ui/src/pages/AgentConnectPage.tsx
+++ b/src/skillberry_store/ui/src/pages/AgentConnectPage.tsx
@@ -1,0 +1,475 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+
+import { useState, useEffect } from 'react';
+import {
+  PageSection,
+  Title,
+  Card,
+  CardBody,
+  CardTitle,
+  Alert,
+  Spinner,
+  CodeBlock,
+  CodeBlockCode,
+  ClipboardCopyButton,
+  ExpandableSection,
+  Label,
+  DescriptionList,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  DescriptionListDescription,
+  Button,
+  Text,
+  ToggleGroup,
+  ToggleGroupItem,
+} from '@patternfly/react-core';
+import { CheckCircleIcon, ExclamationCircleIcon, PluggedIcon, UnpluggedIcon } from '@patternfly/react-icons';
+import { adminApi } from '@/services/api';
+import type { ServerInfo } from '@/services/api';
+import { useMCPClient } from '@/hooks/useMCPClient';
+
+type McpScope = 'project' | 'user';
+type McpMode = 'curated' | 'full';
+
+export function AgentConnectPage() {
+  const [copiedField, setCopiedField] = useState<string | null>(null);
+  const [isManualConfigExpanded, setIsManualConfigExpanded] = useState(false);
+  const [isTestingConnection, setIsTestingConnection] = useState(false);
+  const [serverInfo, setServerInfo] = useState<ServerInfo | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [mcpScope, setMcpScope] = useState<McpScope>('project');
+  const [mcpMode, setMcpMode] = useState<McpMode>('curated');
+
+  useEffect(() => {
+    adminApi.getServerInfo()
+      .then((info) => setServerInfo(info))
+      .catch((err) => setLoadError(err.message))
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  const curatedMcpUrl = serverInfo?.agent_mcp_url || `http://localhost:${serverInfo?.agent_mcp_port || 9999}/sse`;
+  const fullMcpUrl = serverInfo?.control_mcp_url || `http://localhost:${serverInfo?.port || 8000}/control_sse`;
+
+  const isCurated = mcpMode === 'curated';
+  const mcpUrl = isCurated ? curatedMcpUrl : fullMcpUrl;
+  const mcpServerName = isCurated ? 'skillberry-store' : 'skillberry-store-full';
+
+  const mcpClient = useMCPClient(undefined, mcpServerName, isTestingConnection ? mcpUrl : undefined);
+
+  const handleCopy = (text: string, field: string) => {
+    navigator.clipboard.writeText(text);
+    setCopiedField(field);
+    setTimeout(() => setCopiedField(null), 2000);
+  };
+
+  const scopeFlag = mcpScope === 'project' ? 'project' : 'user';
+  const addCommand = `claude mcp add ${mcpServerName} -s ${scopeFlag} -t sse ${mcpUrl}`;
+  const removeCommand = `claude mcp remove ${mcpServerName} -s ${scopeFlag}`;
+
+  const settingsJson = JSON.stringify({
+    mcpServers: {
+      [mcpServerName]: {
+        url: mcpUrl,
+      },
+    },
+  }, null, 2);
+
+  if (isLoading) {
+    return (
+      <PageSection>
+        <div style={{ display: 'flex', justifyContent: 'center', padding: '4rem' }}>
+          <Spinner size="xl" />
+        </div>
+      </PageSection>
+    );
+  }
+
+  return (
+    <>
+      <PageSection>
+        <Title headingLevel="h1" size="2xl">
+          Connect Your Agent
+        </Title>
+        <Text style={{ marginTop: '0.5rem', color: '#6a6e73' }}>
+          Connect AI agents to the Skillberry Store via MCP.
+          Once connected, your agent can list, create, update, and manage tools, skills, snippets, and VMCP servers.
+        </Text>
+        <Text style={{ marginTop: '0.75rem', color: '#6a6e73' }}>
+          Two endpoints are available:
+        </Text>
+        <ul style={{ margin: '0.25rem 0 0 0', paddingLeft: '1.25rem', color: '#6a6e73', lineHeight: '1.7' }}>
+          <li>
+            <strong>Curated</strong> (default, port 9999) — a compact, hand-picked set of ~15 tools with
+            LLM-friendly names and docstrings. Smaller context footprint, fewer tokens spent on tool discovery.
+            Recommended for most agent workflows.
+          </li>
+          <li>
+            <strong>Full</strong> (port 8000) — every FastAPI route auto-exposed as an MCP tool.
+            More complete coverage (delete, snippets, admin, import/export, etc.) but larger context footprint
+            and HTTP-style tool names. Pick this when the curated set is missing an operation you need.
+          </li>
+        </ul>
+      </PageSection>
+
+      <PageSection>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+          {loadError && (
+            <Alert variant="warning" title="Could not fetch server info" isInline>
+              {loadError}. Using default values.
+            </Alert>
+          )}
+
+          {/* MCP Endpoint Info */}
+          <Card>
+            <CardTitle>MCP Endpoint</CardTitle>
+            <CardBody>
+              <div style={{ marginBottom: '1rem' }}>
+                <Text component="small" style={{ fontWeight: 600, marginBottom: '0.5rem', display: 'block' }}>
+                  Connection mode:
+                </Text>
+                <ToggleGroup aria-label="MCP mode selection">
+                  <ToggleGroupItem
+                    text="Curated (recommended)"
+                    buttonId="mode-curated"
+                    isSelected={mcpMode === 'curated'}
+                    onChange={() => setMcpMode('curated')}
+                  />
+                  <ToggleGroupItem
+                    text="Full (all FastAPI endpoints)"
+                    buttonId="mode-full"
+                    isSelected={mcpMode === 'full'}
+                    onChange={() => setMcpMode('full')}
+                  />
+                </ToggleGroup>
+                <Text component="small" style={{ marginTop: '0.5rem', display: 'block', color: '#6a6e73', fontSize: '0.8rem' }}>
+                  {isCurated
+                    ? 'A compact, hand-picked set of ~15 tools with LLM-friendly names and docstrings. Smaller context footprint — the agent spends fewer tokens figuring out what to call. Recommended for most agent workflows.'
+                    : 'Exposes every FastAPI route as an MCP tool (auto-generated). More complete coverage (delete, snippets, admin, import/export, etc.) but larger context footprint and HTTP-style tool names. Pick this when the curated set is missing an operation you need.'}
+                </Text>
+              </div>
+              <DescriptionList isHorizontal>
+                <DescriptionListGroup>
+                  <DescriptionListTerm>{isCurated ? 'Agent MCP URL' : 'Full MCP URL'}</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    <code style={{ fontSize: '0.95rem' }}>{mcpUrl}</code>
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+                {serverInfo && (
+                  <>
+                    {!isCurated && (
+                      <DescriptionListGroup>
+                        <DescriptionListTerm>API Docs</DescriptionListTerm>
+                        <DescriptionListDescription>
+                          <a href={serverInfo.api_docs} target="_blank" rel="noopener noreferrer">
+                            {serverInfo.api_docs}
+                          </a>
+                          <Text component="small" style={{ display: 'block', color: '#6a6e73', fontSize: '0.8rem', marginTop: '0.25rem' }}>
+                            The Full MCP exposes every route from this OpenAPI surface.
+                          </Text>
+                        </DescriptionListDescription>
+                      </DescriptionListGroup>
+                    )}
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Status</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {isCurated ? (
+                          <Label color={serverInfo.agent_mcp_url ? 'green' : 'orange'}>
+                            {serverInfo.agent_mcp_url ? 'Running' : 'Not yet started'}
+                          </Label>
+                        ) : (
+                          <Label color="green">Running</Label>
+                        )}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                  </>
+                )}
+              </DescriptionList>
+            </CardBody>
+          </Card>
+
+          {/* Claude Code CLI Commands */}
+          <Card>
+            <CardTitle>Claude Code CLI Commands</CardTitle>
+            <CardBody>
+              <Text style={{ marginBottom: '1rem' }}>
+                Run these commands in your terminal to connect or disconnect Claude Code:
+              </Text>
+
+              <div style={{ marginBottom: '1rem' }}>
+                <Text component="small" style={{ fontWeight: 600, marginBottom: '0.5rem', display: 'block' }}>
+                  Install scope:
+                </Text>
+                <ToggleGroup aria-label="MCP scope selection">
+                  <ToggleGroupItem
+                    text="This project only"
+                    buttonId="scope-project"
+                    isSelected={mcpScope === 'project'}
+                    onChange={() => setMcpScope('project')}
+                  />
+                  <ToggleGroupItem
+                    text="Global (all projects)"
+                    buttonId="scope-user"
+                    isSelected={mcpScope === 'user'}
+                    onChange={() => setMcpScope('user')}
+                  />
+                </ToggleGroup>
+                <Text component="small" style={{ marginTop: '0.5rem', display: 'block', color: '#6a6e73', fontSize: '0.8rem' }}>
+                  {mcpScope === 'project'
+                    ? 'Saves to .claude/settings.json in your project — only available when working in this repo.'
+                    : 'Saves to ~/.claude/settings.json — available across all your projects.'}
+                </Text>
+              </div>
+
+              <div style={{ marginBottom: '1.5rem' }}>
+                <Text component="small" style={{ fontWeight: 600, marginBottom: '0.5rem', display: 'block' }}>
+                  Add MCP server:
+                </Text>
+                <CodeBlock
+                  actions={
+                    <ClipboardCopyButton
+                      id="copy-add-cmd"
+                      textId="add-cmd"
+                      aria-label="Copy add command"
+                      onClick={() => handleCopy(addCommand, 'add')}
+                      variant="plain"
+                    >
+                      {copiedField === 'add' ? 'Copied!' : 'Copy'}
+                    </ClipboardCopyButton>
+                  }
+                >
+                  <CodeBlockCode id="add-cmd">{addCommand}</CodeBlockCode>
+                </CodeBlock>
+              </div>
+
+              <div style={{ marginBottom: '1.5rem' }}>
+                <Text component="small" style={{ fontWeight: 600, marginBottom: '0.5rem', display: 'block' }}>
+                  Remove MCP server:
+                </Text>
+                <CodeBlock
+                  actions={
+                    <ClipboardCopyButton
+                      id="copy-remove-cmd"
+                      textId="remove-cmd"
+                      aria-label="Copy remove command"
+                      onClick={() => handleCopy(removeCommand, 'remove')}
+                      variant="plain"
+                    >
+                      {copiedField === 'remove' ? 'Copied!' : 'Copy'}
+                    </ClipboardCopyButton>
+                  }
+                >
+                  <CodeBlockCode id="remove-cmd">{removeCommand}</CodeBlockCode>
+                </CodeBlock>
+              </div>
+
+              <ExpandableSection
+                toggleText={isManualConfigExpanded ? 'Hide JSON config' : 'Or add JSON config to your agent'}
+                isExpanded={isManualConfigExpanded}
+                onToggle={(_event, expanded) => setIsManualConfigExpanded(expanded)}
+              >
+                <Text style={{ marginBottom: '0.75rem' }}>
+                  Add the following MCP server configuration to your agent:
+                </Text>
+                <CodeBlock
+                  actions={
+                    <ClipboardCopyButton
+                      id="copy-json"
+                      textId="json-config"
+                      aria-label="Copy JSON config"
+                      onClick={() => handleCopy(settingsJson, 'json')}
+                      variant="plain"
+                    >
+                      {copiedField === 'json' ? 'Copied!' : 'Copy'}
+                    </ClipboardCopyButton>
+                  }
+                >
+                  <CodeBlockCode id="json-config">{settingsJson}</CodeBlockCode>
+                </CodeBlock>
+              </ExpandableSection>
+            </CardBody>
+          </Card>
+
+          {/* Connection Test */}
+          <Card>
+            <CardTitle>Connection Test</CardTitle>
+            <CardBody>
+              <div style={{ marginBottom: '1rem' }}>
+                <Text component="small" style={{ fontWeight: 600, marginBottom: '0.5rem', display: 'block' }}>
+                  Test against:
+                </Text>
+                <ToggleGroup aria-label="Connection test target">
+                  <ToggleGroupItem
+                    text="Curated MCP"
+                    buttonId="test-mode-curated"
+                    isSelected={mcpMode === 'curated'}
+                    onChange={() => {
+                      if (isTestingConnection) {
+                        mcpClient.disconnect();
+                        setIsTestingConnection(false);
+                      }
+                      setMcpMode('curated');
+                    }}
+                  />
+                  <ToggleGroupItem
+                    text="Full MCP (over FastAPI)"
+                    buttonId="test-mode-full"
+                    isSelected={mcpMode === 'full'}
+                    onChange={() => {
+                      if (isTestingConnection) {
+                        mcpClient.disconnect();
+                        setIsTestingConnection(false);
+                      }
+                      setMcpMode('full');
+                    }}
+                  />
+                </ToggleGroup>
+                <Text component="small" style={{ marginTop: '0.5rem', display: 'block', color: '#6a6e73', fontSize: '0.8rem' }}>
+                  Currently targeting: <code>{mcpUrl}</code>
+                </Text>
+              </div>
+
+              {!isTestingConnection ? (
+                <Button
+                  variant="secondary"
+                  icon={<PluggedIcon />}
+                  onClick={() => setIsTestingConnection(true)}
+                >
+                  Test Connection
+                </Button>
+              ) : (
+                <div>
+                  {mcpClient.isConnecting && (
+                    <Alert variant="info" title="Connecting..." isInline>
+                      <Spinner size="sm" /> Attempting to connect to {mcpUrl}
+                    </Alert>
+                  )}
+                  {mcpClient.isConnected && (
+                    <>
+                      <Alert
+                        variant="success"
+                        title="Connected"
+                        isInline
+                        customIcon={<CheckCircleIcon />}
+                      >
+                        Successfully connected to the MCP server. Found{' '}
+                        <strong>{mcpClient.tools.length}</strong> tool(s) and{' '}
+                        <strong>{mcpClient.prompts.length}</strong> prompt(s).
+                      </Alert>
+
+                      <ExpandableSection
+                        toggleText={`Available Operations (${mcpClient.tools.length} tools, ${mcpClient.prompts.length} prompts)`}
+                        style={{ marginTop: '1rem' }}
+                      >
+                        {mcpClient.tools.length > 0 && (
+                          <div style={{ marginBottom: '1rem' }}>
+                            <Text component="small" style={{ fontWeight: 600, marginBottom: '0.5rem', display: 'block' }}>
+                              Tools:
+                            </Text>
+                            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+                              {mcpClient.tools.map((tool) => (
+                                <ExpandableSection
+                                  key={tool.name}
+                                  toggleContent={
+                                    <span style={{ fontSize: '0.875rem' }}>
+                                      <strong>{tool.name}</strong>
+                                      {tool.description && (
+                                        <span style={{ color: '#6a6e73', marginLeft: '0.5rem' }}>— {tool.description}</span>
+                                      )}
+                                    </span>
+                                  }
+                                >
+                                  <CodeBlock style={{ marginTop: '0.5rem', marginBottom: '0.5rem' }}>
+                                    <CodeBlockCode>{JSON.stringify(tool.inputSchema, null, 2)}</CodeBlockCode>
+                                  </CodeBlock>
+                                </ExpandableSection>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+                        {mcpClient.prompts.length > 0 && (
+                          <div>
+                            <Text component="small" style={{ fontWeight: 600, marginBottom: '0.5rem', display: 'block' }}>
+                              Prompts:
+                            </Text>
+                            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+                              {mcpClient.prompts.map((prompt) => (
+                                <ExpandableSection
+                                  key={prompt.name}
+                                  toggleContent={
+                                    <span style={{ fontSize: '0.875rem' }}>
+                                      <strong>{prompt.name}</strong>
+                                      {prompt.description && (
+                                        <span style={{ color: '#6a6e73', marginLeft: '0.5rem' }}>— {prompt.description}</span>
+                                      )}
+                                    </span>
+                                  }
+                                >
+                                  {prompt.arguments && prompt.arguments.length > 0 ? (
+                                    <CodeBlock style={{ marginTop: '0.5rem', marginBottom: '0.5rem' }}>
+                                      <CodeBlockCode>{JSON.stringify(prompt.arguments, null, 2)}</CodeBlockCode>
+                                    </CodeBlock>
+                                  ) : (
+                                    <Text component="small" style={{ color: '#6a6e73', marginTop: '0.5rem', display: 'block' }}>
+                                      No arguments
+                                    </Text>
+                                  )}
+                                </ExpandableSection>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+                      </ExpandableSection>
+                    </>
+                  )}
+                  {mcpClient.error && (
+                    <Alert
+                      variant="danger"
+                      title="Connection failed"
+                      isInline
+                      customIcon={<ExclamationCircleIcon />}
+                    >
+                      {mcpClient.error}
+                      <div style={{ marginTop: '0.5rem', fontSize: '0.875rem' }}>
+                        Make sure the Skillberry Store server is running and the Agent MCP server is started.
+                      </div>
+                    </Alert>
+                  )}
+                  <div style={{ marginTop: '0.75rem' }}>
+                    <Button
+                      variant="link"
+                      icon={<UnpluggedIcon />}
+                      onClick={() => {
+                        mcpClient.disconnect();
+                        setIsTestingConnection(false);
+                      }}
+                    >
+                      Disconnect
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </CardBody>
+          </Card>
+
+          {/* Example Use Cases */}
+          <Card>
+            <CardTitle>Example Use Cases</CardTitle>
+            <CardBody>
+              <ul style={{ margin: 0, paddingLeft: '1.25rem', lineHeight: '2' }}>
+                <li>"List all tools and their descriptions"</li>
+                <li>"Read the code of the calculator tool and add input validation"</li>
+                <li>"Create a new tool that fetches weather data from an API"</li>
+                <li>"Search for tools related to data processing"</li>
+                <li>"Create a skill called 'data-analysis' and add relevant tools to it"</li>
+                <li>"Create a VMCP server for the data-analysis skill so I can use it in Claude Code"</li>
+                <li>"Look at the execution metrics for the calculator tool and optimize it"</li>
+              </ul>
+            </CardBody>
+          </Card>
+        </div>
+      </PageSection>
+    </>
+  );
+}

--- a/src/skillberry_store/ui/src/pages/AgentConnectPage.tsx
+++ b/src/skillberry_store/ui/src/pages/AgentConnectPage.tsx
@@ -49,7 +49,7 @@ export function AgentConnectPage() {
       .finally(() => setIsLoading(false));
   }, []);
 
-  const curatedMcpUrl = serverInfo?.agent_mcp_url || `http://localhost:${serverInfo?.agent_mcp_port || 9999}/sse`;
+  const curatedMcpUrl = serverInfo?.curated_mcp_url || `http://localhost:${serverInfo?.curated_mcp_port || 9999}/sse`;
   const fullMcpUrl = serverInfo?.control_mcp_url || `http://localhost:${serverInfo?.port || 8000}/control_sse`;
 
   const isCurated = mcpMode === 'curated';
@@ -175,8 +175,8 @@ export function AgentConnectPage() {
                       <DescriptionListTerm>Status</DescriptionListTerm>
                       <DescriptionListDescription>
                         {isCurated ? (
-                          <Label color={serverInfo.agent_mcp_url ? 'green' : 'orange'}>
-                            {serverInfo.agent_mcp_url ? 'Running' : 'Not yet started'}
+                          <Label color={serverInfo.curated_mcp_url ? 'green' : 'orange'}>
+                            {serverInfo.curated_mcp_url ? 'Running' : 'Not yet started'}
                           </Label>
                         ) : (
                           <Label color="green">Running</Label>

--- a/src/skillberry_store/ui/src/services/api.ts
+++ b/src/skillberry_store/ui/src/services/api.ts
@@ -325,4 +325,22 @@ export const vmcpApi = {
   },
 };
 
+// Admin API
+
+export interface ServerInfo {
+  host: string;
+  port: number;
+  agent_mcp_port: number | null;
+  agent_mcp_url: string | null;
+  control_mcp_url: string;
+  api_docs: string;
+}
+
+export const adminApi = {
+  getServerInfo: async (): Promise<ServerInfo> => {
+    const response = await fetch(`${API_BASE}/admin/server-info`);
+    return handleResponse<ServerInfo>(response);
+  },
+};
+
 export { ApiError };

--- a/src/skillberry_store/ui/src/services/api.ts
+++ b/src/skillberry_store/ui/src/services/api.ts
@@ -330,8 +330,8 @@ export const vmcpApi = {
 export interface ServerInfo {
   host: string;
   port: number;
-  agent_mcp_port: number | null;
-  agent_mcp_url: string | null;
+  curated_mcp_port: number | null;
+  curated_mcp_url: string | null;
   control_mcp_url: string;
   api_docs: string;
 }


### PR DESCRIPTION
Closes #76

## Summary

- **Curated Agent MCP server** on `SBS_AGENT_MCP_PORT` (default 9999), a second MCP alongside the existing full MCP at `/control_sse`. Hand-picked 13-tool set; every tool is a **thin HTTP proxy to the local FastAPI** — no duplicated business logic.
- **`GET /admin/server-info`** returning host/port, both MCP URLs, and API docs URL so the UI can discover connection info.
- **Connect Your Agent** UI page (`/agent-connect`) with copy-ready `claude mcp add` commands (curated/full toggle, project/user scope toggle), JSON config for other agents, and a live connection test.

## Commits (6, each reviewable on its own)

1. Add `GET /admin/server-info` endpoint
2. Add curated Agent MCP server on `SBS_AGENT_MCP_PORT`
3. Print curated Agent MCP connect commands on startup
4. Let `useMCPClient` target an explicit SSE URL
5. Add `adminApi.getServerInfo` to the UI API client
6. Add Connect Your Agent page, route, and nav entry

## Why proxy instead of reimplement?

Earlier drafts reimplemented tool/skill/vmcp logic inside the MCP server. That drifts from the REST API, duplicates validation, and bypasses the observability counters. The curation value is the **smaller surface** and **better names**, not reimplemented logic — so every curated tool is now a 3–10 line proxy over `httpx`.

## Tool list (13)

- **Tools (6):** `list_tools`, `get_tool`, `get_tool_code`, `create_tool` (multipart `/tools/add`), `execute_tool`, `search_tools`
- **Skills (4):** `list_skills`, `get_skill`, `create_skill` (resolves tool names → UUIDs), `search_skills`
- **VMCP (3):** `list_vmcp_servers`, `create_vmcp_server` (resolves skill name → UUID), `delete_vmcp_server`

Everything `update_*` was dropped because PR4's split of a single REST PUT into `update_tool_code` + `update_tool_metadata` didn't match an actual endpoint. Agents needing those can still reach them via the full MCP at `/control_sse`.

## Scope note

This PR explicitly does **not** include: external-MCP import, plugins framework, tool-health / broken-state tracking, bundled-with-mcps flag, or skill-name validation. Those are separate concerns tracked in their own PRs.

## Test plan

- [x] `GET /admin/server-info` returns host, both MCP URLs, and API docs URL
- [x] Curated MCP listens on port 9999 and advertises exactly 13 tools
- [x] End-to-end via MCP client: `create_tool` → `list_tools` → `get_tool` → `get_tool_code` → `search_tools` → `create_skill` → `create_vmcp_server` → `list_vmcp_servers` → `delete_vmcp_server`
- [x] Existing unit tests: no regression vs main (same 17 pre-existing failures, all environmental — Docker/e2e)
- [ ] Connect Your Agent page manual smoke in the UI