### PR TITLE
Add namespace filtering feature for organizing skills, tools, and snippets

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: '0 0 * * 0'  # Weekly on Sunday
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'python', 'javascript' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v3
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"
+
+# Made with Bob

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This service implements a smart skills repository for agentic workflows. Manage,
 - **Tools Search and list**: Shortlist tools using semantic and classic search.
 - **Tools Life Cycle Management**: Provides tools life cycle management (state, visibility, etc.).
 - **Tools Persistence**: Support persistence of tools into filesystem, GitHub repos etc.
+- **Namespaces**: Organize and label skills, tools, and snippets using namespaces for better categorization and filtering.
 - **Observability**: Provide metrics and traces for operational and behavioural analysis of tools usage.
 - **OpenAPI frontend**: FastAPI endpoint to interact and manage tools (using tools-manifest artifacts)
 - **CLI Support**: Command-line interface for all API operations.

--- a/src/skillberry_store/fast_api/skills_api.py
+++ b/src/skillberry_store/fast_api/skills_api.py
@@ -4,7 +4,7 @@ import json
 import logging
 import uuid
 from datetime import datetime, timezone
-from typing import Optional, Annotated
+from typing import Optional, Annotated, List
 from fastapi import FastAPI, HTTPException, Query, UploadFile, File, Form
 from fastapi.responses import Response
 from prometheus_client import Counter
@@ -423,6 +423,7 @@ def register_skills_api(
         folder_path: Optional[str] = Form(None),
         snippet_mode: str = Form("file"),
         treat_all_as_documents: bool = Form(False),
+        additional_tags: List[str] = Form([]),
     ):
         """Import an Anthropic skill from GitHub URL, ZIP file, or local folder.
 
@@ -432,6 +433,7 @@ def register_skills_api(
             zip_file: ZIP file upload (required if source_type='zip')
             folder_path: Local folder path (required if source_type='folder')
             snippet_mode: 'file' or 'paragraph' - how to import text files
+            additional_tags: List of additional tags to add to all imported objects (skills, tools, snippets)
 
         Returns:
             dict: Import result with created tools, snippets, and skill info
@@ -499,12 +501,18 @@ def register_skills_api(
                     )
                     module_filename = f"{tool_dict['name']}{ext}"
 
+                    # Add additional tags to tool tags
+                    tool_tags = tool_dict["tags"].copy() if tool_dict["tags"] else []
+                    for tag in additional_tags:
+                        if tag and tag not in tool_tags:
+                            tool_tags.append(tag)
+                    
                     tool_data = {
                         "uuid": tool_uuid,
                         "name": tool_dict["name"],
                         "version": tool_dict["version"],
                         "description": tool_dict["description"],
-                        "tags": tool_dict["tags"],
+                        "tags": tool_tags,
                         "programming_language": tool_dict["programmingLanguage"],
                         "module_name": module_filename,
                         "packaging_format": "code",
@@ -572,6 +580,12 @@ def register_skills_api(
                     snippet_dict = snippet.to_dict()
                     snippet_uuid = str(uuid.uuid4())
 
+                    # Add additional tags to snippet tags
+                    snippet_tags = snippet_dict["tags"].copy() if snippet_dict["tags"] else []
+                    for tag in additional_tags:
+                        if tag and tag not in snippet_tags:
+                            snippet_tags.append(tag)
+                    
                     # Prepare snippet data
                     snippet_data = {
                         "uuid": snippet_uuid,
@@ -579,7 +593,7 @@ def register_skills_api(
                         "version": snippet_dict["version"],
                         "description": snippet_dict["description"],
                         "content": snippet_dict["content"],
-                        "tags": snippet_dict["tags"],
+                        "tags": snippet_tags,
                         "content_type": "text/plain",
                         "state": "approved",
                     }
@@ -594,14 +608,19 @@ def register_skills_api(
                 except Exception as e:
                     logger.error(f"Failed to create snippet {snippet.name}: {e}")
 
-            # Create skill
+            # Create skill with additional tags
+            skill_tags = ["anthropic", "imported"]
+            for tag in additional_tags:
+                if tag and tag not in skill_tags:
+                    skill_tags.append(tag)
+            
             skill_uuid = str(uuid.uuid4())
             skill_data = {
                 "uuid": skill_uuid,
                 "name": skill_name,
                 "version": "1.0.0",
                 "description": skill_description,
-                "tags": ["anthropic", "imported"],
+                "tags": skill_tags,
                 "tool_uuids": created_tool_uuids,
                 "snippet_uuids": created_snippet_uuids,
                 "state": "approved",

--- a/src/skillberry_store/fast_api/skills_api.py
+++ b/src/skillberry_store/fast_api/skills_api.py
@@ -506,7 +506,7 @@ def register_skills_api(
                     for tag in additional_tags:
                         if tag and tag not in tool_tags:
                             tool_tags.append(tag)
-                    
+
                     tool_data = {
                         "uuid": tool_uuid,
                         "name": tool_dict["name"],
@@ -581,11 +581,13 @@ def register_skills_api(
                     snippet_uuid = str(uuid.uuid4())
 
                     # Add additional tags to snippet tags
-                    snippet_tags = snippet_dict["tags"].copy() if snippet_dict["tags"] else []
+                    snippet_tags = (
+                        snippet_dict["tags"].copy() if snippet_dict["tags"] else []
+                    )
                     for tag in additional_tags:
                         if tag and tag not in snippet_tags:
                             snippet_tags.append(tag)
-                    
+
                     # Prepare snippet data
                     snippet_data = {
                         "uuid": snippet_uuid,
@@ -613,7 +615,7 @@ def register_skills_api(
             for tag in additional_tags:
                 if tag and tag not in skill_tags:
                     skill_tags.append(tag)
-            
+
             skill_uuid = str(uuid.uuid4())
             skill_data = {
                 "uuid": skill_uuid,

--- a/src/skillberry_store/fast_api/skills_api.py
+++ b/src/skillberry_store/fast_api/skills_api.py
@@ -423,7 +423,7 @@ def register_skills_api(
         folder_path: Optional[str] = Form(None),
         snippet_mode: str = Form("file"),
         treat_all_as_documents: bool = Form(False),
-        additional_tags: List[str] = Form([]),
+        tags: List[str] = Form([]),
     ):
         """Import an Anthropic skill from GitHub URL, ZIP file, or local folder.
 
@@ -433,7 +433,7 @@ def register_skills_api(
             zip_file: ZIP file upload (required if source_type='zip')
             folder_path: Local folder path (required if source_type='folder')
             snippet_mode: 'file' or 'paragraph' - how to import text files
-            additional_tags: List of additional tags to add to all imported objects (skills, tools, snippets)
+            tags: List of additional tags to add to all imported objects (skills, tools, snippets)
 
         Returns:
             dict: Import result with created tools, snippets, and skill info
@@ -503,7 +503,7 @@ def register_skills_api(
 
                     # Add additional tags to tool tags
                     tool_tags = tool_dict["tags"].copy() if tool_dict["tags"] else []
-                    for tag in additional_tags:
+                    for tag in tags:
                         if tag and tag not in tool_tags:
                             tool_tags.append(tag)
 
@@ -584,7 +584,7 @@ def register_skills_api(
                     snippet_tags = (
                         snippet_dict["tags"].copy() if snippet_dict["tags"] else []
                     )
-                    for tag in additional_tags:
+                    for tag in tags:
                         if tag and tag not in snippet_tags:
                             snippet_tags.append(tag)
 
@@ -612,7 +612,7 @@ def register_skills_api(
 
             # Create skill with additional tags
             skill_tags = ["anthropic", "imported"]
-            for tag in additional_tags:
+            for tag in tags:
                 if tag and tag not in skill_tags:
                     skill_tags.append(tag)
 

--- a/src/skillberry_store/ui/src/components/AnthropicSkillImporter.tsx
+++ b/src/skillberry_store/ui/src/components/AnthropicSkillImporter.tsx
@@ -1,7 +1,7 @@
 // Copyright 2025 IBM Corp.
 // Licensed under the Apache License, Version 2.0
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import {
   Modal,
   ModalVariant,
@@ -16,7 +16,14 @@ import {
   ProgressMeasureLocation,
   List,
   ListItem,
+  Select,
+  SelectOption,
+  SelectList,
+  MenuToggle,
+  MenuToggleElement,
+  Label,
 } from '@patternfly/react-core';
+import { skillsApi } from '@/services/api';
 
 interface AnthropicSkillImporterProps {
   isOpen: boolean;
@@ -48,6 +55,39 @@ export function AnthropicSkillImporter({
   const [isImporting, setIsImporting] = useState(false);
   const [progress, setProgress] = useState(0);
   const [result, setResult] = useState<ImportResult | null>(null);
+  
+  // Namespace selection state
+  const [selectedNamespaces, setSelectedNamespaces] = useState<string[]>([]);
+  const [existingNamespaces, setExistingNamespaces] = useState<string[]>([]);
+  const [isNamespaceSelectOpen, setIsNamespaceSelectOpen] = useState(false);
+  const [namespaceInput, setNamespaceInput] = useState('');
+
+  // Fetch existing namespaces from skills when modal opens
+  useEffect(() => {
+    if (isOpen) {
+      fetchExistingNamespaces();
+    }
+  }, [isOpen]);
+
+  const fetchExistingNamespaces = async () => {
+    try {
+      const skills = await skillsApi.list();
+      const namespaceSet = new Set<string>();
+      
+      skills.forEach(skill => {
+        skill.tags?.forEach(tag => {
+          if (tag.startsWith('namespace:')) {
+            const namespace = tag.substring('namespace:'.length);
+            namespaceSet.add(namespace);
+          }
+        });
+      });
+      
+      setExistingNamespaces(Array.from(namespaceSet).sort());
+    } catch (error) {
+      console.error('Failed to fetch existing namespaces:', error);
+    }
+  };
 
   const resetState = () => {
     setGithubUrl('');
@@ -56,6 +96,8 @@ export function AnthropicSkillImporter({
     setFolderPath('');
     setProgress(0);
     setResult(null);
+    setSelectedNamespaces([]);
+    setNamespaceInput('');
   };
 
   const handleClose = () => {
@@ -63,6 +105,27 @@ export function AnthropicSkillImporter({
       resetState();
       onClose();
     }
+  };
+
+  const handleSelectNamespace = (_event: React.MouseEvent | undefined, value: string | number | undefined) => {
+    if (typeof value === 'string' && value && !selectedNamespaces.includes(value)) {
+      setSelectedNamespaces([...selectedNamespaces, value]);
+      setIsNamespaceSelectOpen(false);
+      setNamespaceInput('');
+    }
+  };
+
+  const handleAddCustomNamespace = () => {
+    const trimmedInput = namespaceInput.trim();
+    if (trimmedInput && !selectedNamespaces.includes(trimmedInput)) {
+      setSelectedNamespaces([...selectedNamespaces, trimmedInput]);
+      setNamespaceInput('');
+      setIsNamespaceSelectOpen(false);
+    }
+  };
+
+  const handleRemoveNamespace = (namespaceToRemove: string) => {
+    setSelectedNamespaces(selectedNamespaces.filter(ns => ns !== namespaceToRemove));
   };
 
   const handleImport = async () => {
@@ -76,6 +139,11 @@ export function AnthropicSkillImporter({
       formData.append('source_type', importSource);
       formData.append('snippet_mode', snippetMode);
       formData.append('treat_all_as_documents', treatAllAsDocuments.toString());
+      
+      // Add namespaces as additional tags with namespace: prefix
+      selectedNamespaces.forEach(namespace => {
+        formData.append('additional_tags', `namespace:${namespace}`);
+      });
 
       if (importSource === 'url') {
         if (!githubUrl) {
@@ -226,6 +294,91 @@ export function AnthropicSkillImporter({
           <div style={{ fontSize: '0.875rem', color: '#6a6e73' }}>
             When enabled, code files (e.g., .py, .sh) will be imported as document snippets instead of being parsed as tools. This preserves the original file structure without code analysis.
           </div>
+        </FormGroup>
+
+        <FormGroup label="Namespaces (Optional)" fieldId="namespaces">
+          <div style={{ fontSize: '0.875rem', color: '#6a6e73', marginBottom: '0.5rem' }}>
+            Add one or more namespaces to label all imported objects (skills, tools, snippets). Select from existing namespaces or add new ones.
+          </div>
+          <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.5rem' }}>
+            <Select
+              id="namespace-select"
+              isOpen={isNamespaceSelectOpen}
+              selected={null}
+              onSelect={handleSelectNamespace}
+              onOpenChange={(isOpen) => setIsNamespaceSelectOpen(isOpen)}
+              toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                <MenuToggle
+                  ref={toggleRef}
+                  onClick={() => setIsNamespaceSelectOpen(!isNamespaceSelectOpen)}
+                  isExpanded={isNamespaceSelectOpen}
+                  isDisabled={isImporting}
+                  style={{ width: '100%' }}
+                >
+                  {namespaceInput || 'Select or add namespace...'}
+                </MenuToggle>
+              )}
+            >
+              <SelectList>
+                <TextInput
+                  type="text"
+                  value={namespaceInput}
+                  onChange={(_, value) => setNamespaceInput(value)}
+                  placeholder="Type to search or add new..."
+                  onKeyPress={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      handleAddCustomNamespace();
+                    }
+                  }}
+                  style={{ padding: '0.5rem', borderBottom: '1px solid #d2d2d2' }}
+                />
+                {namespaceInput.trim() && !existingNamespaces.includes(namespaceInput.trim()) && (
+                  <SelectOption value={namespaceInput.trim()}>
+                    Add new: "{namespaceInput.trim()}"
+                  </SelectOption>
+                )}
+                {existingNamespaces
+                  .filter(ns =>
+                    ns.toLowerCase().includes(namespaceInput.toLowerCase()) &&
+                    !selectedNamespaces.includes(ns)
+                  )
+                  .map((namespace) => (
+                    <SelectOption key={namespace} value={namespace}>
+                      {namespace}
+                    </SelectOption>
+                  ))}
+                {existingNamespaces.length === 0 && !namespaceInput.trim() && (
+                  <SelectOption isDisabled>
+                    No existing namespaces. Type to add new.
+                  </SelectOption>
+                )}
+              </SelectList>
+            </Select>
+            {namespaceInput.trim() && (
+              <Button
+                variant="secondary"
+                onClick={handleAddCustomNamespace}
+                isDisabled={isImporting}
+              >
+                Add
+              </Button>
+            )}
+          </div>
+          {selectedNamespaces.length > 0 && (
+            <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+              {selectedNamespaces.map((namespace) => (
+                <Label
+                  key={namespace}
+                  color="blue"
+                  isCompact
+                  onClose={isImporting ? undefined : () => handleRemoveNamespace(namespace)}
+                >
+                  {namespace}
+                </Label>
+              ))}
+            </div>
+          )}
         </FormGroup>
 
         {importSource === 'url' ? (

--- a/src/skillberry_store/ui/src/components/AnthropicSkillImporter.tsx
+++ b/src/skillberry_store/ui/src/components/AnthropicSkillImporter.tsx
@@ -141,8 +141,10 @@ export function AnthropicSkillImporter({
       formData.append('treat_all_as_documents', treatAllAsDocuments.toString());
       
       // Add namespaces as additional tags with namespace: prefix
-      selectedNamespaces.forEach(namespace => {
-        formData.append('additional_tags', `namespace:${namespace}`);
+      // If no namespaces are selected, use "default" namespace
+      const namespacesToUse = selectedNamespaces.length > 0 ? selectedNamespaces : ['default'];
+      namespacesToUse.forEach(namespace => {
+        formData.append('tags', `namespace:${namespace}`);
       });
 
       if (importSource === 'url') {

--- a/src/skillberry_store/ui/src/components/NamespaceFilter.tsx
+++ b/src/skillberry_store/ui/src/components/NamespaceFilter.tsx
@@ -1,0 +1,131 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+
+import { useState, useMemo } from 'react';
+import {
+  Select,
+  SelectOption,
+  SelectList,
+  MenuToggle,
+  MenuToggleElement,
+  Label,
+  Button,
+} from '@patternfly/react-core';
+
+interface NamespaceFilterProps {
+  allNamespaces: string[];
+  selectedNamespaces: string[];
+  onNamespacesChange: (namespaces: string[]) => void;
+  placeholder?: string;
+}
+
+export function NamespaceFilter({ 
+  allNamespaces, 
+  selectedNamespaces, 
+  onNamespacesChange, 
+  placeholder = 'Filter by namespace...' 
+}: NamespaceFilterProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const filteredNamespaces = useMemo(() => {
+    const lowerSearch = searchTerm.toLowerCase();
+    return allNamespaces.filter(namespace =>
+      namespace.toLowerCase().includes(lowerSearch) &&
+      !selectedNamespaces.includes(namespace)
+    );
+  }, [allNamespaces, searchTerm, selectedNamespaces]);
+
+  const handleSelectNamespace = (_event: React.MouseEvent | undefined, value: string | number | undefined) => {
+    if (typeof value === 'string' && value && !selectedNamespaces.includes(value)) {
+      onNamespacesChange([...selectedNamespaces, value]);
+      setIsOpen(false);
+      setSearchTerm('');
+    }
+  };
+
+  const handleRemoveNamespace = (namespaceToRemove: string) => {
+    onNamespacesChange(selectedNamespaces.filter(namespace => namespace !== namespaceToRemove));
+  };
+
+  const handleClearAll = () => {
+    onNamespacesChange([]);
+  };
+
+  // Don't render if there are no namespaces available
+  if (allNamespaces.length === 0) {
+    return null;
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', minWidth: '250px' }}>
+      <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+        <Select
+          id="namespace-filter-select"
+          isOpen={isOpen}
+          selected={null}
+          onSelect={handleSelectNamespace}
+          onOpenChange={(isOpen) => setIsOpen(isOpen)}
+          toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+            <MenuToggle
+              ref={toggleRef}
+              onClick={() => setIsOpen(!isOpen)}
+              isExpanded={isOpen}
+              style={{ width: '200px' }}
+            >
+              {placeholder}
+            </MenuToggle>
+          )}
+        >
+          <SelectList>
+            <input
+              type="search"
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              placeholder="Search namespaces..."
+              style={{
+                width: '100%',
+                padding: '0.5rem',
+                border: 'none',
+                borderBottom: '1px solid #d2d2d2',
+                outline: 'none',
+              }}
+            />
+            {filteredNamespaces.length === 0 ? (
+              <SelectOption isDisabled>
+                {searchTerm ? 'No namespaces found' : 'All namespaces selected'}
+              </SelectOption>
+            ) : (
+              filteredNamespaces.map((namespace) => (
+                <SelectOption key={namespace} value={namespace}>
+                  {namespace}
+                </SelectOption>
+              ))
+            )}
+          </SelectList>
+        </Select>
+        {selectedNamespaces.length > 0 && (
+          <Button variant="link" onClick={handleClearAll} style={{ padding: '0.25rem 0.5rem' }}>
+            Clear all
+          </Button>
+        )}
+      </div>
+      {selectedNamespaces.length > 0 && (
+        <div style={{ display: 'flex', gap: '0.25rem', flexWrap: 'wrap' }}>
+          {selectedNamespaces.map((namespace) => (
+            <Label
+              key={namespace}
+              color="blue"
+              isCompact
+              onClose={() => handleRemoveNamespace(namespace)}
+            >
+              {namespace}
+            </Label>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Made with Bob

--- a/src/skillberry_store/ui/src/pages/ObservabilityPage.tsx
+++ b/src/skillberry_store/ui/src/pages/ObservabilityPage.tsx
@@ -594,7 +594,7 @@ export function ObservabilityPage() {
           
           {/* Plot lines for each metric */}
           {selectedMetrics.map((metricKey, metricIndex) => {
-            let data = timeSeriesData.filter(d => d[metricKey] !== undefined);
+            const data = timeSeriesData.filter(d => d[metricKey] !== undefined);
             if (data.length === 0) return null;
             
             // For counter metrics in rate mode, calculate rates

--- a/src/skillberry_store/ui/src/pages/SkillsPage.tsx
+++ b/src/skillberry_store/ui/src/pages/SkillsPage.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getTagColor } from '../utils/tagColors';
 import { TagFilter } from '../components/TagFilter';
+import { NamespaceFilter } from '../components/NamespaceFilter';
 import { SearchBox, SearchMode } from '../components/SearchBox';
 import { exportSkills, importSkills, downloadJSON } from '../utils/exportImportHelpers';
 import {
@@ -52,6 +53,7 @@ export function SkillsPage() {
   const [maxResults, setMaxResults] = useState(10);
   const [similarityThreshold, setSimilarityThreshold] = useState(1);
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [selectedNamespaces, setSelectedNamespaces] = useState<string[]>([]);
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [newSkill, setNewSkill] = useState({
     name: '',
@@ -342,14 +344,33 @@ export function SkillsPage() {
     ];
   };
 
-  // Get all unique tags from skills
+  // Get all unique tags from skills (excluding namespace tags)
   const allTags = useMemo(() => {
     if (!skills) return [];
     const tagSet = new Set<string>();
     skills.forEach(skill => {
-      skill.tags?.forEach(tag => tagSet.add(tag));
+      skill.tags?.forEach(tag => {
+        if (!tag.startsWith('namespace:')) {
+          tagSet.add(tag);
+        }
+      });
     });
     return Array.from(tagSet).sort();
+  }, [skills]);
+
+  // Get all unique namespaces from skills
+  const allNamespaces = useMemo(() => {
+    if (!skills) return [];
+    const namespaceSet = new Set<string>();
+    skills.forEach(skill => {
+      skill.tags?.forEach(tag => {
+        if (tag.startsWith('namespace:')) {
+          const namespace = tag.substring('namespace:'.length);
+          namespaceSet.add(namespace);
+        }
+      });
+    });
+    return Array.from(namespaceSet).sort();
   }, [skills]);
 
   const filteredSkills = useMemo(() => {
@@ -374,11 +395,20 @@ export function SkillsPage() {
       }
     }
 
-    // Apply tag filtering
+    // Apply tag filtering (excluding namespace tags)
     if (filtered && selectedTags.length > 0) {
       filtered = filtered.filter(skill =>
         selectedTags.every(selectedTag =>
           skill.tags?.includes(selectedTag)
+        )
+      );
+    }
+
+    // Apply namespace filtering
+    if (filtered && selectedNamespaces.length > 0) {
+      filtered = filtered.filter(skill =>
+        selectedNamespaces.every(selectedNamespace =>
+          skill.tags?.includes(`namespace:${selectedNamespace}`)
         )
       );
     }
@@ -398,7 +428,7 @@ export function SkillsPage() {
     }
 
     return filtered;
-  }, [skills, searchResults, searchTerm, searchMode, selectedTags, activeSortIndex, activeSortDirection]);
+  }, [skills, searchResults, searchTerm, searchMode, selectedTags, selectedNamespaces, activeSortIndex, activeSortDirection]);
 
   const getSortParams = (columnIndex: number): ThProps['sort'] => ({
     sortBy: {
@@ -456,6 +486,13 @@ export function SkillsPage() {
                 onMaxResultsChange={setMaxResults}
                 similarityThreshold={similarityThreshold}
                 onSimilarityThresholdChange={setSimilarityThreshold}
+              />
+            </ToolbarItem>
+            <ToolbarItem>
+              <NamespaceFilter
+                allNamespaces={allNamespaces}
+                selectedNamespaces={selectedNamespaces}
+                onNamespacesChange={setSelectedNamespaces}
               />
             </ToolbarItem>
             <ToolbarItem>
@@ -583,13 +620,15 @@ export function SkillsPage() {
                     onClick={() => navigate(`/skills/${skill.name}`)}
                     style={{ cursor: 'pointer' }}
                   >
-                    {skill.tags && skill.tags.length > 0 ? (
+                    {skill.tags && skill.tags.filter(tag => !tag.startsWith('namespace:')).length > 0 ? (
                       <div style={{ display: 'flex', gap: '0.25rem', flexWrap: 'wrap' }}>
-                        {skill.tags.map((tag) => (
-                          <Label key={tag} color={getTagColor(tag)} isCompact>
-                            {tag}
-                          </Label>
-                        ))}
+                        {skill.tags
+                          .filter(tag => !tag.startsWith('namespace:'))
+                          .map((tag) => (
+                            <Label key={tag} color={getTagColor(tag)} isCompact>
+                              {tag}
+                            </Label>
+                          ))}
                       </div>
                     ) : (
                       '-'

--- a/src/skillberry_store/ui/src/pages/SkillsPage.tsx
+++ b/src/skillberry_store/ui/src/pages/SkillsPage.tsx
@@ -16,7 +16,6 @@ import {
   ToolbarContent,
   ToolbarItem,
   Button,
-  SearchInput,
   Text,
   Spinner,
   EmptyState,
@@ -43,7 +42,6 @@ import { skillsApi, toolsApi, snippetsApi } from '@/services/api';
 import type { Skill } from '@/types';
 import { AnthropicSkillImporter } from '../components/AnthropicSkillImporter';
 
-type SortableColumn = 'name' | 'description' | 'version';
 
 export function SkillsPage() {
   const navigate = useNavigate();

--- a/src/skillberry_store/ui/src/pages/SnippetsPage.tsx
+++ b/src/skillberry_store/ui/src/pages/SnippetsPage.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getTagColor } from '../utils/tagColors';
 import { TagFilter } from '../components/TagFilter';
+import { NamespaceFilter } from '../components/NamespaceFilter';
 import { SearchBox, SearchMode } from '../components/SearchBox';
 import { exportSnippets, importSnippets, downloadJSON } from '../utils/exportImportHelpers';
 import {
@@ -48,6 +49,7 @@ export function SnippetsPage() {
   const [maxResults, setMaxResults] = useState(10);
   const [similarityThreshold, setSimilarityThreshold] = useState(1);
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [selectedNamespaces, setSelectedNamespaces] = useState<string[]>([]);
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [newSnippet, setNewSnippet] = useState({
     name: '',
@@ -213,14 +215,33 @@ export function SnippetsPage() {
     ];
   };
 
-  // Get all unique tags from snippets
+  // Get all unique tags from snippets (excluding namespace tags)
   const allTags = useMemo(() => {
     if (!snippets) return [];
     const tagSet = new Set<string>();
     snippets.forEach(snippet => {
-      snippet.tags?.forEach(tag => tagSet.add(tag));
+      snippet.tags?.forEach(tag => {
+        if (!tag.startsWith('namespace:')) {
+          tagSet.add(tag);
+        }
+      });
     });
     return Array.from(tagSet).sort();
+  }, [snippets]);
+
+  // Get all unique namespaces from snippets
+  const allNamespaces = useMemo(() => {
+    if (!snippets) return [];
+    const namespaceSet = new Set<string>();
+    snippets.forEach(snippet => {
+      snippet.tags?.forEach(tag => {
+        if (tag.startsWith('namespace:')) {
+          const namespace = tag.substring('namespace:'.length);
+          namespaceSet.add(namespace);
+        }
+      });
+    });
+    return Array.from(namespaceSet).sort();
   }, [snippets]);
 
   const filteredSnippets = useMemo(() => {
@@ -245,11 +266,20 @@ export function SnippetsPage() {
       }
     }
 
-    // Apply tag filtering
+    // Apply tag filtering (excluding namespace tags)
     if (filtered && selectedTags.length > 0) {
       filtered = filtered.filter(snippet =>
         selectedTags.every(selectedTag =>
           snippet.tags?.includes(selectedTag)
+        )
+      );
+    }
+
+    // Apply namespace filtering
+    if (filtered && selectedNamespaces.length > 0) {
+      filtered = filtered.filter(snippet =>
+        selectedNamespaces.every(selectedNamespace =>
+          snippet.tags?.includes(`namespace:${selectedNamespace}`)
         )
       );
     }
@@ -269,7 +299,7 @@ export function SnippetsPage() {
     }
 
     return filtered;
-  }, [snippets, searchResults, searchTerm, searchMode, selectedTags, activeSortIndex, activeSortDirection]);
+  }, [snippets, searchResults, searchTerm, searchMode, selectedTags, selectedNamespaces, activeSortIndex, activeSortDirection]);
 
   const getSortParams = (columnIndex: number): ThProps['sort'] => ({
     sortBy: {
@@ -327,6 +357,13 @@ export function SnippetsPage() {
                 onMaxResultsChange={setMaxResults}
                 similarityThreshold={similarityThreshold}
                 onSimilarityThresholdChange={setSimilarityThreshold}
+              />
+            </ToolbarItem>
+            <ToolbarItem>
+              <NamespaceFilter
+                allNamespaces={allNamespaces}
+                selectedNamespaces={selectedNamespaces}
+                onNamespacesChange={setSelectedNamespaces}
               />
             </ToolbarItem>
             <ToolbarItem>
@@ -452,13 +489,15 @@ export function SnippetsPage() {
                     onClick={() => navigate(`/snippets/${snippet.name}`)}
                     style={{ cursor: 'pointer' }}
                   >
-                    {snippet.tags && snippet.tags.length > 0 ? (
+                    {snippet.tags && snippet.tags.filter(tag => !tag.startsWith('namespace:')).length > 0 ? (
                       <div style={{ display: 'flex', gap: '0.25rem', flexWrap: 'wrap' }}>
-                        {snippet.tags.map((tag) => (
-                          <Label key={tag} color={getTagColor(tag)} isCompact>
-                            {tag}
-                          </Label>
-                        ))}
+                        {snippet.tags
+                          .filter(tag => !tag.startsWith('namespace:'))
+                          .map((tag) => (
+                            <Label key={tag} color={getTagColor(tag)} isCompact>
+                              {tag}
+                            </Label>
+                          ))}
                       </div>
                     ) : (
                       '-'

--- a/src/skillberry_store/ui/src/pages/SnippetsPage.tsx
+++ b/src/skillberry_store/ui/src/pages/SnippetsPage.tsx
@@ -16,7 +16,6 @@ import {
   ToolbarContent,
   ToolbarItem,
   Button,
-  SearchInput,
   Text,
   Spinner,
   EmptyState,
@@ -39,7 +38,6 @@ import { PlusIcon, FileCodeIcon, SearchIcon, TrashIcon, ExportIcon, ImportIcon }
 import { snippetsApi } from '@/services/api';
 import type { Snippet } from '@/types';
 
-type SortableColumn = 'name' | 'description' | 'state' | 'content_type' | 'version';
 
 export function SnippetsPage() {
   const navigate = useNavigate();

--- a/src/skillberry_store/ui/src/pages/ToolsPage.tsx
+++ b/src/skillberry_store/ui/src/pages/ToolsPage.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getTagColor } from '../utils/tagColors';
 import { TagFilter } from '../components/TagFilter';
+import { NamespaceFilter } from '../components/NamespaceFilter';
 import { SearchBox, SearchMode } from '../components/SearchBox';
 import { exportTools, importTools, downloadJSON } from '../utils/exportImportHelpers';
 import {
@@ -48,6 +49,7 @@ export function ToolsPage() {
   const [maxResults, setMaxResults] = useState(10);
   const [similarityThreshold, setSimilarityThreshold] = useState(1);
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [selectedNamespaces, setSelectedNamespaces] = useState<string[]>([]);
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [toolName, setToolName] = useState('');
   const [moduleFile, setModuleFile] = useState<File | null>(null);
@@ -184,14 +186,33 @@ export function ToolsPage() {
     ];
   };
 
-  // Get all unique tags from tools
+  // Get all unique tags from tools (excluding namespace tags)
   const allTags = useMemo(() => {
     if (!tools) return [];
     const tagSet = new Set<string>();
     tools.forEach(tool => {
-      tool.tags?.forEach(tag => tagSet.add(tag));
+      tool.tags?.forEach(tag => {
+        if (!tag.startsWith('namespace:')) {
+          tagSet.add(tag);
+        }
+      });
     });
     return Array.from(tagSet).sort();
+  }, [tools]);
+
+  // Get all unique namespaces from tools
+  const allNamespaces = useMemo(() => {
+    if (!tools) return [];
+    const namespaceSet = new Set<string>();
+    tools.forEach(tool => {
+      tool.tags?.forEach(tag => {
+        if (tag.startsWith('namespace:')) {
+          const namespace = tag.substring('namespace:'.length);
+          namespaceSet.add(namespace);
+        }
+      });
+    });
+    return Array.from(namespaceSet).sort();
   }, [tools]);
 
   const filteredTools = useMemo(() => {
@@ -216,11 +237,20 @@ export function ToolsPage() {
       }
     }
 
-    // Apply tag filtering
+    // Apply tag filtering (excluding namespace tags)
     if (filtered && selectedTags.length > 0) {
       filtered = filtered.filter(tool =>
         selectedTags.every(selectedTag =>
           tool.tags?.includes(selectedTag)
+        )
+      );
+    }
+
+    // Apply namespace filtering
+    if (filtered && selectedNamespaces.length > 0) {
+      filtered = filtered.filter(tool =>
+        selectedNamespaces.every(selectedNamespace =>
+          tool.tags?.includes(`namespace:${selectedNamespace}`)
         )
       );
     }
@@ -240,7 +270,7 @@ export function ToolsPage() {
     }
 
     return filtered;
-  }, [tools, searchResults, searchTerm, searchMode, selectedTags, activeSortIndex, activeSortDirection]);
+  }, [tools, searchResults, searchTerm, searchMode, selectedTags, selectedNamespaces, activeSortIndex, activeSortDirection]);
 
   const getSortParams = (columnIndex: number): ThProps['sort'] => ({
     sortBy: {
@@ -298,6 +328,13 @@ export function ToolsPage() {
                 onMaxResultsChange={setMaxResults}
                 similarityThreshold={similarityThreshold}
                 onSimilarityThresholdChange={setSimilarityThreshold}
+              />
+            </ToolbarItem>
+            <ToolbarItem>
+              <NamespaceFilter
+                allNamespaces={allNamespaces}
+                selectedNamespaces={selectedNamespaces}
+                onNamespacesChange={setSelectedNamespaces}
               />
             </ToolbarItem>
             <ToolbarItem>
@@ -423,13 +460,15 @@ export function ToolsPage() {
                     onClick={() => navigate(`/tools/${tool.name}`)}
                     style={{ cursor: 'pointer' }}
                   >
-                    {tool.tags && tool.tags.length > 0 ? (
+                    {tool.tags && tool.tags.filter(tag => !tag.startsWith('namespace:')).length > 0 ? (
                       <div style={{ display: 'flex', gap: '0.25rem', flexWrap: 'wrap' }}>
-                        {tool.tags.map((tag) => (
-                          <Label key={tag} color={getTagColor(tag)} isCompact>
-                            {tag}
-                          </Label>
-                        ))}
+                        {tool.tags
+                          .filter(tag => !tag.startsWith('namespace:'))
+                          .map((tag) => (
+                            <Label key={tag} color={getTagColor(tag)} isCompact>
+                              {tag}
+                            </Label>
+                          ))}
                       </div>
                     ) : (
                       '-'

--- a/src/skillberry_store/ui/src/pages/ToolsPage.tsx
+++ b/src/skillberry_store/ui/src/pages/ToolsPage.tsx
@@ -16,7 +16,6 @@ import {
   ToolbarContent,
   ToolbarItem,
   Button,
-  SearchInput,
   Text,
   Label,
   Spinner,
@@ -28,18 +27,14 @@ import {
   Form,
   FormGroup,
   TextInput,
-  TextArea,
   FileUpload,
   Alert,
-  FormSelect,
-  FormSelectOption,
 } from '@patternfly/react-core';
 import { Table, Thead, Tr, Th, Tbody, Td, ThProps } from '@patternfly/react-table';
 import { PlusIcon, CubeIcon, SearchIcon, TrashIcon, ExportIcon, ImportIcon } from '@patternfly/react-icons';
 import { toolsApi } from '@/services/api';
 import type { Tool } from '@/types';
 
-type SortableColumn = 'name' | 'description' | 'state' | 'module_name' | 'version';
 
 export function ToolsPage() {
   const navigate = useNavigate();


### PR DESCRIPTION
Closes #97

## Summary

This PR implements a comprehensive namespace filtering system that allows users to organize and filter imported Anthropic skills, tools, and snippets by namespace labels.

## Changes Made

### New Components
- **NamespaceFilter.tsx**: New reusable component for multi-select namespace filtering with search functionality

### Updated Components
- **AnthropicSkillImporter.tsx**: Added namespace selection UI allowing users to choose from existing namespaces or add new ones during import
- **SkillsPage.tsx**: Added namespace filtering capability and hides namespace tags from regular tag display
- **ToolsPage.tsx**: Added namespace filtering capability and hides namespace tags from regular tag display
- **SnippetsPage.tsx**: Added namespace filtering capability and hides namespace tags from regular tag display

### Backend Changes
- **skills_api.py**: Added `additional_tags` parameter to the import endpoint to accept namespace tags

## Technical Details

- Namespaces use the format `namespace:value` as tags
- Namespace tags are automatically added to all imported objects (skills, tools, snippets)
- NamespaceFilter component only renders when namespaces exist in the data
- Filtering uses AND logic (all selected namespaces must match)
- Namespace tags are filtered out from regular tag displays
- UI changes are isolated to `src/skillberry_store/ui` directory
- Backend changes are minimal, only in `skills_api.py`

## Testing Performed

- Verified namespace selection UI in Anthropic skill importer
- Tested importing skills with multiple namespaces
- Confirmed namespace tags are applied to skills, tools, and snippets
- Validated namespace filtering on all three pages (Skills, Tools, Snippets)
- Verified namespace tags don't appear in regular tag columns
- Tested multi-select functionality with search

## Design Decisions

1. Used special `namespace:` prefix to distinguish namespace tags from regular tags
2. Reused existing tag infrastructure rather than creating a separate namespace field
3. Made NamespaceFilter component similar to TagFilter for consistency
4. Used blue color for namespace labels to differentiate from regular tags
5. Kept changes UI-focused to minimize backend impact

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>