### PR TITLE
Fix skills importer repo-level processing

### DIFF
--- a/src/skillberry_store/contrib/examples/skills-sh-importer/README.md
+++ b/src/skillberry_store/contrib/examples/skills-sh-importer/README.md
@@ -121,14 +121,14 @@ When using `--clone-only`, the script will:
 
 ### Phase 1: Extract Repository Metadata from skills.sh
 - Fetches skills.sh homepage
-- Parses HTML to extract ALL repository metadata
-- Sorts by popularity (install count)
+- Parses HTML to extract repository sources
+- Prepares repository records for cloning
 - **No limiting at this phase** - Phase 2 will clone until N skills found
 
-**Example:** Extracts all ~500 repositories from skills.sh, sorted by popularity.
+**Example:** Extracts repository records from skills.sh for Phase 2 cloning.
 
 ### Phase 2: Clone Repositories Until N Skills Found
-- Clones repositories one at a time in popularity order
+- Clones repositories one at a time from the extracted repository list
 - After each clone, checks for `/skills/` directory
 - Counts subfolders in `/skills/` that contain `SKILL.md`
 - Accumulates skill count until reaching `--max-skills` target
@@ -139,9 +139,9 @@ When using `--clone-only`, the script will:
 
 **Output:**
 - `clone-results.json` - Contains:
-  - `cloned_repos`: Repos with skills (includes skill count per repo)
-  - `skipped_repos`: Repos without /skills/ folder
-  - `failed_repos`: Repos that failed to clone
+  - `cloned_repos`: Repositories with skills
+  - `skipped_repos`: Repositories without `/skills/` folder
+  - `failed_repos`: Repositories that failed to clone
   - `summary`: Statistics
 - `skills-sh-repos/` - Cloned repositories
 
@@ -184,7 +184,7 @@ When using `--clone-only`, the script will:
 
 ### Phase 5: Validation
 - Verifies API accessibility
-- Checks imported skill count
+- Checks the number of skills returned by the API
 - Validates data integrity
 
 **Output:**
@@ -204,16 +204,16 @@ When using `--clone-only`, the script will:
 After execution, the following files are created:
 
 ```
-skill-scale-issue-analysis/
+src/skillberry_store/contrib/examples/skills-sh-importer/
 ├── download_and_import_skills.py    # Main script
-├── import-skills-from-skills-sh-plan.md  # Implementation plan
+├── README.md                        # This document
 ├── clone-results.json               # Repository clone results
 ├── discovered-skills.json           # Discovered skills
 ├── import-results.json              # Import results
 ├── validation-report.json           # Validation results
 ├── final-report.json                # Final summary report
 ├── import-skills.log                # Detailed execution log
-└── skills-sh-repos/                 # Cloned repositories
+└── /tmp/skills-sh-repos/            # Default clone location on Linux
     ├── vercel__ai/
     ├── anthropics__skills/
     └── ...

--- a/src/skillberry_store/contrib/examples/skills-sh-importer/README.md
+++ b/src/skillberry_store/contrib/examples/skills-sh-importer/README.md
@@ -352,35 +352,6 @@ Total execution time: 123.45 seconds
 - Review validation-report.json for details
 - Check skillberry-store logs
 
-## Advanced Configuration
-
-### Custom Skill Discovery
-Edit the `discover_skills()` method to add custom search patterns:
-```python
-# Add custom directory
-search_dirs.append(repo_path / 'custom' / 'skills')
-
-# Add custom file extension
-for ext in ['.md', '.py', '.js', '.ts', '.json', '.yaml']:
-    skill_files.extend(search_dir.glob(f'*{ext}'))
-```
-
-### Retry Failed Imports
-```bash
-# Extract failed skills from import-results.json
-# Re-run import for specific skills
-python3 -c "
-import json
-import requests
-
-with open('import-results.json') as f:
-    data = json.load(f)
-    
-failed = [r for r in data['results'] if r['status'] != 'success']
-print(f'Found {len(failed)} failed imports')
-"
-```
-
 ## Performance Tips
 
 1. **Use shallow clones** (default): `--clone-depth 1`
@@ -403,24 +374,3 @@ curl http://localhost:8000/skills/{uuid}
 # Search skills
 curl "http://localhost:8000/skills/search?query=ai"
 ```
-
-## Contributing
-
-To extend this tool:
-
-1. Add new phases in the `SkillsImporter` class
-2. Update the `run()` method to include new phases
-3. Add CLI arguments as needed
-4. Update documentation
-
-## License
-
-Same as skillberry-store project.
-
-## Support
-
-For issues or questions:
-1. Check the `import-skills.log` file
-2. Review `final-report.json` for summary
-3. Check individual phase output files
-4. Consult the implementation plan: `import-skills-from-skills-sh-plan.md`

--- a/src/skillberry_store/contrib/examples/skills-sh-importer/README.md
+++ b/src/skillberry_store/contrib/examples/skills-sh-importer/README.md
@@ -354,15 +354,6 @@ Total execution time: 123.45 seconds
 
 ## Advanced Configuration
 
-### Environment Variables
-```bash
-# Override SBS URL
-export SKILLBERRY_SBS_URL=http://localhost:9000
-
-# Run script
-python3 download_and_import_skills.py
-```
-
 ### Custom Skill Discovery
 Edit the `discover_skills()` method to add custom search patterns:
 ```python

--- a/src/skillberry_store/contrib/examples/skills-sh-importer/download_and_import_skills.py
+++ b/src/skillberry_store/contrib/examples/skills-sh-importer/download_and_import_skills.py
@@ -17,16 +17,14 @@ Usage:
 import argparse
 import json
 import logging
-import os
 import re
 import subprocess
 import sys
 import tempfile
 import time
-import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any
 
 import requests
 

--- a/src/skillberry_store/contrib/examples/skills-sh-importer/download_and_import_skills.py
+++ b/src/skillberry_store/contrib/examples/skills-sh-importer/download_and_import_skills.py
@@ -78,10 +78,10 @@ class SkillsImporter:
     
     def extract_skills_metadata(self) -> List[Dict[str, Any]]:
         """
-        Phase 1: Extract repository metadata from skills.sh
+        Phase 1: Extract unique repository metadata from skills.sh
         
         Returns:
-            List of skill metadata dictionaries
+            List of repository metadata dictionaries
         """
         logger.info("=" * 60)
         logger.info("PHASE 1: Extracting repository URLs from skills.sh")
@@ -95,52 +95,48 @@ class SkillsImporter:
             html_content = response.text
             logger.info(f"Received {len(html_content)} bytes")
             
-            # Extract skills data using regex
-            # The data is in escaped JSON format within the HTML
-            pattern = r'\\"source\\":\\"([^\\]+)\\"[^}]*\\"skillId\\":\\"([^\\]+)\\"[^}]*\\"name\\":\\"([^\\]+)\\"[^}]*\\"installs\\":(\d+)(?:[^}]*\\"isOfficial\\":true)?'
-            
+            # Extract repository sources from skills.sh HTML.
+            # The page may contain multiple skill entries for the same repository,
+            # so Phase 1 deduplicates by source and keeps only repo-level fields.
+            pattern = r'\\"source\\":\\"([^\\]+)\\"'
             matches = re.findall(pattern, html_content)
             
             if not matches:
-                logger.warning("No skills found with primary pattern, trying alternative...")
-                # Try simpler pattern
-                pattern2 = r'"source":"([^"]+)".*?"skillId":"([^"]+)".*?"name":"([^"]+)".*?"installs":(\d+)'
+                logger.warning("No repositories found with primary pattern, trying alternative...")
+                pattern2 = r'"source":"([^"]+)"'
                 matches = re.findall(pattern2, html_content)
             
             if not matches:
-                logger.error("Could not extract skills from HTML")
+                logger.error("Could not extract repository sources from HTML")
                 return []
             
-            # Convert matches to dictionaries
-            skills = []
-            for source, skill_id, name, installs in matches:
-                skill = {
+            # Deduplicate while preserving order of first appearance
+            seen_sources = set()
+            repos = []
+            for source in matches:
+                if source in seen_sources:
+                    continue
+                seen_sources.add(source)
+                repo_name = source.replace('/', '__').replace(':', '_')
+                repo_path = str(self.repos_dir / repo_name)
+                repos.append({
                     "source": source,
-                    "skillId": skill_id,
-                    "name": name,
-                    "installs": int(installs),
-                    "isOfficial": True  # Assume official if on skills.sh
-                }
-                skills.append(skill)
+                    "repo_name": repo_name,
+                    "repo_path": repo_path,
+                    "skills_count": None,
+                })
             
-            # Sort by installs (descending) - this determines clone order
-            skills.sort(key=lambda x: x['installs'], reverse=True)
+            logger.info(f"Extracted {len(repos)} unique repositories from skills.sh")
             
-            logger.info(f"Extracted {len(skills)} total skills from skills.sh")
-            logger.info(f"Sorted by popularity (installs)")
+            logger.info(f"\nTop 10 repositories by appearance order:")
+            for i, repo in enumerate(repos[:10], 1):
+                logger.info(f"  {i}. {repo['source']} -> {repo['repo_name']}")
             
-            # Show top skills
-            logger.info(f"\nTop 10 most popular repositories:")
-            for i, skill in enumerate(skills[:10], 1):
-                logger.info(f"  {i}. {skill['name']} ({skill['source']}) - {skill['installs']:,} installs")
-            
-            # Count unique repositories
-            unique_repos = set(skill['source'] for skill in skills)
-            logger.info(f"\nTotal: {len(skills)} skill entries from {len(unique_repos)} unique repositories")
+            logger.info(f"\nTotal: {len(repos)} unique repositories")
             logger.info(f"Phase 2 will clone repos until finding {self.args.max_skills} actual skills (subfolders with SKILL.md)")
             
-            self.metadata = skills
-            return skills
+            self.metadata = repos
+            return repos
             
         except Exception as e:
             logger.error(f"Error extracting metadata: {e}", exc_info=True)
@@ -201,12 +197,10 @@ class SkillsImporter:
                 break
             
             source = repo_meta['source']
+            repo_name = repo_meta['repo_name']
+            repo_path = Path(repo_meta['repo_path'])
             logger.info(f"\n[Repo {i}] Processing {source}...")
             repos_processed += 1
-            
-            # Sanitize repo name for filesystem
-            repo_name = source.replace('/', '__').replace(':', '_')
-            repo_path = self.repos_dir / repo_name
             
             try:
                 
@@ -268,7 +262,6 @@ class SkillsImporter:
                     'repo_path': str(repo_path),
                     'skills_count': skill_count,
                     'already_existed': already_existed,
-                    **repo_meta  # Include original metadata (installs, isOfficial, etc.)
                 })
                     
             except subprocess.TimeoutExpired:
@@ -589,11 +582,11 @@ class SkillsImporter:
                 'clone_depth': self.args.clone_depth
             },
             'phase_1_extract': {
-                'total_skills_found': len(self.metadata),
-                'skills_selected': self.args.max_skills
+                'total_repositories_found': len(self.metadata),
+                'target_skills': self.args.max_skills
             },
             'phase_2_clone': {
-                'skills_cloned': len(self.cloned_repos),
+                'repositories_cloned': len(self.cloned_repos),
                 'unique_repos_cloned': len(set(s.get('repo_name', '') for s in self.cloned_repos))
             },
             'phase_3_discover': {
@@ -615,9 +608,9 @@ class SkillsImporter:
         logger.info(f"\n{'='*60}")
         logger.info("FINAL REPORT")
         logger.info(f"{'='*60}")
-        logger.info(f"Skills selected: {report['phase_1_extract']['skills_selected']}")
+        logger.info(f"Repositories extracted: {report['phase_1_extract']['total_repositories_found']}")
         logger.info(f"Unique repos cloned: {report['phase_2_clone']['unique_repos_cloned']}")
-        logger.info(f"Skills from cloned repos: {report['phase_2_clone']['skills_cloned']}")
+        logger.info(f"Repositories cloned: {report['phase_2_clone']['repositories_cloned']}")
         logger.info(f"Skills discovered in repos: {report['phase_3_discover']['skills_discovered']}")
         logger.info(f"Skills imported: {report['phase_4_import']['successful']}")
         logger.info(f"Import failures: {report['phase_4_import']['failed']}")


### PR DESCRIPTION
# Fix skills importer repo-level processing

## Summary
- Change Phase 1 to work with unique repositories instead of skill-level entries
- Keep clone results repo-focused and avoid carrying skill metadata into Phase 2 output
- Remove unused imports
- Trim inaccurate README sections for the skills importer example

## Details
- Deduplicate extracted sources by repository
- Store repo-level fields only:
  - `source`
  - `repo_name`
  - `repo_path`
  - `skills_count`
- Update final report wording to reflect repository-oriented counts
- Remove README content that described unsupported env-var handling and unsupported retry/custom-discovery flows