### PR TITLE
fix: Add label validation to prevent Bob Shell from suggesting invalid labels

### DIFF
--- a/.github/workflows/label-new-issues.yml
+++ b/.github/workflows/label-new-issues.yml
@@ -178,12 +178,14 @@ jobs:
             1. Select ALL relevant labels that apply to this issue
             2. Use label descriptions to guide your selection
             3. CRITICAL: You MUST ONLY use labels from the AVAILABLE LABELS list above. DO NOT invent or create new labels.
-            4. For the 'fix-with-bob' label specifically:
+            4. CRITICAL: Every label you suggest MUST exist exactly as shown in the AVAILABLE LABELS list above
+            5. CRITICAL: Do NOT add labels like "---output---" or any other invented labels
+            6. For the 'fix-with-bob' label specifically:
                - ONLY add it if the issue describes a coding task
                - ONLY add it if the implementation is straightforward and not complex
                - ONLY add it if you believe Bob Shell can fix it with simple code changes
                - DO NOT add it for complex features, architectural changes, or unclear requirements
-            4. Common label mappings:
+            7. Common label mappings (only use if they exist in AVAILABLE LABELS):
                - 'bug': Issue reports something broken or not working correctly
                - 'enhancement': Issue requests a new feature or improvement
                - 'documentation': Issue relates to docs, README, or comments
@@ -199,7 +201,7 @@ jobs:
             Example: ["enhancement", "fix-with-bob"]
             Example: ["question"]
 
-            If no labels are appropriate, respond with an empty array: []
+            If no labels from the available list are appropriate, respond with an empty array: []
             PROMPT_EOF
 
             # Run Bob Shell with the prompt
@@ -207,6 +209,11 @@ jobs:
             
             echo "Bob Shell Response:"
             echo "${RESPONSE}"
+            
+            # Get list of valid repository labels
+            VALID_LABELS=$(cat /tmp/repo_labels.json | jq -r '.[].name')
+            echo "Valid repository labels:"
+            echo "${VALID_LABELS}"
             
             # Extract JSON array from response (Bob might add explanation text)
             # First, try to extract from ---output--- section if it exists
@@ -243,13 +250,36 @@ jobs:
               LABELS_JSON="[]"
             fi
             
-            echo "Extracted labels: ${LABELS_JSON}"
+            echo "Extracted labels (before validation): ${LABELS_JSON}"
+            
+            # Validate each label against repository labels
+            VALIDATED_LABELS="[]"
+            INVALID_LABELS=""
+            
+            if [ "${LABELS_JSON}" != "[]" ]; then
+              # Extract labels from JSON and validate each one
+              VALIDATED_LABELS=$(echo "${LABELS_JSON}" | jq -c --argjson valid "$(echo "${VALID_LABELS}" | jq -R -s -c 'split("\n") | map(select(length > 0))')" '
+                map(select(. as $label | $valid | index($label) != null))
+              ')
+              
+              # Find invalid labels for reporting
+              INVALID_LABELS=$(echo "${LABELS_JSON}" | jq -r --argjson valid "$(echo "${VALID_LABELS}" | jq -R -s -c 'split("\n") | map(select(length > 0))')" '
+                map(select(. as $label | $valid | index($label) == null)) | join(", ")
+              ')
+            fi
+            
+            # Report invalid labels
+            if [ -n "${INVALID_LABELS}" ] && [ "${INVALID_LABELS}" != "" ]; then
+              echo "⚠️ Warning: Bob suggested invalid labels that don't exist in repository: ${INVALID_LABELS}"
+            fi
+            
+            echo "Validated labels: ${VALIDATED_LABELS}"
             
             # Save to output
-            echo "selected_labels=${LABELS_JSON}" >> $GITHUB_OUTPUT
+            echo "selected_labels=${VALIDATED_LABELS}" >> $GITHUB_OUTPUT
             
             # Also save to file for next step
-            echo "${LABELS_JSON}" > /tmp/selected_labels.json
+            echo "${VALIDATED_LABELS}" > /tmp/selected_labels.json
         env:
           BOBSHELL_API_KEY: ${{ secrets.BOBSHELL_API_KEY }}
       

--- a/.github/workflows/label-new-prs.yml
+++ b/.github/workflows/label-new-prs.yml
@@ -273,12 +273,14 @@ jobs:
 
             **Instructions:**
             1. Analyze the PR title, description, and changed files
-            2. Select the most relevant labels from the available labels list
+            2. Select the most relevant labels from the available labels list above
             3. Consider the label descriptions to ensure accurate categorization
             4. You can suggest multiple labels if appropriate
-            5. IMPORTANT: Do NOT suggest the 'fix-with-bob' label - it is reserved for other workflows
-            6. Output ONLY the label names, one per line, nothing else
-            7. If no labels are appropriate, output 'NONE'
+            5. CRITICAL: You MUST ONLY select labels that exist in the "Available Repository Labels" list above
+            6. CRITICAL: Do NOT invent, create, or suggest any labels that are not in the available labels list
+            7. IMPORTANT: Do NOT suggest the 'fix-with-bob' label - it is reserved for other workflows
+            8. Output ONLY the label names, one per line, nothing else
+            9. If no labels from the available list are appropriate, output 'NONE'
 
             **Output Format:**
             label-name-1
@@ -294,19 +296,55 @@ jobs:
             echo "Bob Shell output:"
             echo "${BOB_OUTPUT}"
             
+            # Get list of valid repository labels (excluding fix-with-bob)
+            VALID_LABELS=$(cat /tmp/labels_info.txt | grep -oP '(?<=\*\*)[^*]+(?=\*\*)' | grep -v "^fix-with-bob$")
+            
+            echo "Valid repository labels:"
+            echo "${VALID_LABELS}"
+            
             # Extract label suggestions (last lines of output, one label per line)
             # Filter out any non-label text and empty lines
-            SUGGESTED_LABELS=$(echo "${BOB_OUTPUT}" | grep -v "^$" | tail -n 20 | grep -E "^[a-z0-9-]+$" || echo "")
+            RAW_SUGGESTIONS=$(echo "${BOB_OUTPUT}" | grep -v "^$" | tail -n 20 | grep -E "^[a-z0-9-]+$" || echo "")
             
-            if [ -z "${SUGGESTED_LABELS}" ] || [ "${SUGGESTED_LABELS}" = "NONE" ]; then
-              echo "No labels suggested by Bob Shell"
+            # Validate each suggested label against repository labels
+            VALIDATED_LABELS=""
+            INVALID_LABELS=""
+            
+            if [ -n "${RAW_SUGGESTIONS}" ] && [ "${RAW_SUGGESTIONS}" != "NONE" ]; then
+              while IFS= read -r label; do
+                if [ -n "${label}" ]; then
+                  # Check if label exists in valid labels list
+                  if echo "${VALID_LABELS}" | grep -qx "${label}"; then
+                    if [ -z "${VALIDATED_LABELS}" ]; then
+                      VALIDATED_LABELS="${label}"
+                    else
+                      VALIDATED_LABELS="${VALIDATED_LABELS}"$'\n'"${label}"
+                    fi
+                  else
+                    if [ -z "${INVALID_LABELS}" ]; then
+                      INVALID_LABELS="${label}"
+                    else
+                      INVALID_LABELS="${INVALID_LABELS}, ${label}"
+                    fi
+                  fi
+                fi
+              done <<< "${RAW_SUGGESTIONS}"
+            fi
+            
+            # Report invalid labels
+            if [ -n "${INVALID_LABELS}" ]; then
+              echo "⚠️ Warning: Bob suggested invalid labels that don't exist in repository: ${INVALID_LABELS}"
+            fi
+            
+            if [ -z "${VALIDATED_LABELS}" ]; then
+              echo "No valid labels suggested by Bob Shell"
               echo "suggested_labels=" >> $GITHUB_OUTPUT
             else
-              echo "Suggested labels:"
-              echo "${SUGGESTED_LABELS}"
+              echo "Validated labels:"
+              echo "${VALIDATED_LABELS}"
               
               # Convert to comma-separated for GitHub API
-              LABELS_CSV=$(echo "${SUGGESTED_LABELS}" | tr '\n' ',' | sed 's/,$//')
+              LABELS_CSV=$(echo "${VALIDATED_LABELS}" | tr '\n' ',' | sed 's/,$//')
               echo "suggested_labels=${LABELS_CSV}" >> $GITHUB_OUTPUT
             fi
         env:


### PR DESCRIPTION
Closes #101

## Summary
This PR adds validation logic to GitHub workflows to prevent Bob Shell from suggesting labels that don't exist in the repository.

## Problem
The automated labeling workflows using Bob Shell could suggest labels that don't exist in the repository, causing errors when attempting to apply them to issues and PRs.

## Solution
Enhanced both `label-new-issues.yml` and `label-new-prs.yml` workflows with:

1. **Label Validation**: Added logic to validate Bob's suggestions against the actual repository labels
2. **Filtering**: Invalid labels are now filtered out before being applied
3. **Warning Messages**: Added clear warnings when Bob suggests non-existent labels
4. **Improved Prompts**: Updated Bob's instructions to emphasize using only available labels
5. **Better Error Handling**: Enhanced error reporting and debugging output

## Changes Made
- Modified `.github/workflows/label-new-issues.yml`:
  - Added validation step to check suggested labels against repository labels
  - Implemented filtering logic using jq to remove invalid labels
  - Added warning output for invalid label suggestions
  - Updated prompt with critical instructions about label validity

- Modified `.github/workflows/label-new-prs.yml`:
  - Added similar validation logic for PR labeling
  - Implemented label filtering before applying to PRs
  - Added warning messages for invalid suggestions
  - Enhanced prompt instructions

## Testing
The validation logic:
- Retrieves valid repository labels
- Compares Bob's suggestions against the valid list
- Filters out any non-existent labels
- Reports which labels were invalid (if any)
- Only applies validated labels to issues/PRs

## Impact
- Prevents workflow errors from invalid label suggestions
- Improves reliability of automated labeling
- Provides better visibility into Bob's label suggestions
- Maintains backward compatibility with existing workflows

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>