### PR TITLE
fix: show execution errors in UI when tool execution fails

### DIFF
--- a/src/skillberry_store/ui/src/pages/ToolDetailPage.tsx
+++ b/src/skillberry_store/ui/src/pages/ToolDetailPage.tsx
@@ -87,6 +87,9 @@ export function ToolDetailPage() {
     onSuccess: (result) => {
       setExecutionResult(result);
     },
+    onError: (error: any) => {
+      setExecutionResult({ error: error.message || 'Execution failed' });
+    },
   });
 
   // Update mutation


### PR DESCRIPTION
Closes #121.

## Summary
- Added `onError` handler to `executeMutation` in `ToolDetailPage.tsx`
- When the API returns HTTP 500 (e.g. missing parameter, runtime error), the error message is now set in `executionResult` and rendered in the UI

## Root cause
Commit `9881ef9` changed server-side execution errors from 200 responses with `{error: ...}` bodies to HTTP 500 exceptions. The existing `onSuccess` handler handled the old 200 path, but no `onError` handler existed for the new 500 path — so errors were silently swallowed by React Query.

## Testing
Manually reproduced: execute `add_numbers` with `{"a": 101}` (missing `b`) — error is now displayed in the UI.

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>