### PR TITLE
feat: add card view with list/card toggle to Skills page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 
 .idea/
 
+# Superpowers brainstorming / spec docs
+docs/superpowers/
+.superpowers/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/src/skillberry_store/ui/src/components/SkillCard.tsx
+++ b/src/skillberry_store/ui/src/components/SkillCard.tsx
@@ -3,6 +3,7 @@
 
 import { useNavigate } from 'react-router-dom';
 import { Label } from '@patternfly/react-core';
+import { WrenchIcon, FileCodeIcon } from '@patternfly/react-icons';
 import { getTagColor } from '../utils/tagColors';
 import type { Skill } from '@/types';
 
@@ -12,17 +13,17 @@ interface SkillCardProps {
   onSelect: (isSelected: boolean) => void;
 }
 
-const STATE_COLORS: Record<string, { background: string; color: string }> = {
-  approved: { background: '#d3f7d3', color: '#1e4620' },
-  checked:  { background: '#bee1f4', color: '#002952' },
-  new:      { background: '#d2f4ea', color: '#0d5738' },
-  unknown:  { background: '#f2f2f2', color: '#555555' },
-  any:      { background: '#f2f2f2', color: '#555555' },
+const STATE_LABEL_COLOR: Record<string, 'green' | 'blue' | 'cyan' | 'orange' | 'grey'> = {
+  approved: 'green',
+  checked:  'blue',
+  new:      'cyan',
+  unknown:  'grey',
+  any:      'grey',
 };
 
 export function SkillCard({ skill, isSelected, onSelect }: SkillCardProps) {
   const navigate = useNavigate();
-  const stateColor = STATE_COLORS[skill.state ?? 'unknown'] ?? STATE_COLORS.unknown;
+  const stateLabelColor = STATE_LABEL_COLOR[skill.state ?? 'unknown'] ?? 'grey';
   const visibleTags = skill.tags?.filter(t => !t.startsWith('namespace:')) ?? [];
 
   return (
@@ -63,18 +64,9 @@ export function SkillCard({ skill, isSelected, onSelect }: SkillCardProps) {
               {skill.name}
             </span>
             {skill.state && (
-              <span style={{
-                background: stateColor.background,
-                color: stateColor.color,
-                fontSize: '11px',
-                padding: '2px 6px',
-                borderRadius: '10px',
-                flexShrink: 0,
-                marginLeft: '6px',
-                whiteSpace: 'nowrap',
-              }}>
+              <Label color={stateLabelColor} isCompact style={{ flexShrink: 0, marginLeft: '6px' }}>
                 {skill.state}
-              </span>
+              </Label>
             )}
           </div>
         </div>
@@ -117,15 +109,13 @@ export function SkillCard({ skill, isSelected, onSelect }: SkillCardProps) {
         alignItems: 'center',
         marginTop: 'auto',
       }}>
-        <span>
-          {skill.tools && skill.tools.length > 0
-            ? `🔧 ${skill.tools.length} tools`
-            : '— tools'}
+        <span style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+          <WrenchIcon />
+          {skill.tools && skill.tools.length > 0 ? `${skill.tools.length} tools` : '—'}
         </span>
-        <span>
-          {skill.snippets && skill.snippets.length > 0
-            ? `📄 ${skill.snippets.length} snippets`
-            : '— snippets'}
+        <span style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+          <FileCodeIcon />
+          {skill.snippets && skill.snippets.length > 0 ? `${skill.snippets.length} snippets` : '—'}
         </span>
         {skill.version && (
           <span style={{ marginLeft: 'auto', color: '#6a6e73' }}>{skill.version}</span>

--- a/src/skillberry_store/ui/src/components/SkillCard.tsx
+++ b/src/skillberry_store/ui/src/components/SkillCard.tsx
@@ -1,0 +1,136 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+
+import { useNavigate } from 'react-router-dom';
+import { Label } from '@patternfly/react-core';
+import { getTagColor } from '../utils/tagColors';
+import type { Skill } from '@/types';
+
+interface SkillCardProps {
+  skill: Skill;
+  isSelected: boolean;
+  onSelect: (isSelected: boolean) => void;
+}
+
+const STATE_COLORS: Record<string, { background: string; color: string }> = {
+  approved: { background: '#d3f7d3', color: '#1e4620' },
+  checked:  { background: '#bee1f4', color: '#002952' },
+  new:      { background: '#d2f4ea', color: '#0d5738' },
+  unknown:  { background: '#f2f2f2', color: '#555555' },
+  any:      { background: '#f2f2f2', color: '#555555' },
+};
+
+export function SkillCard({ skill, isSelected, onSelect }: SkillCardProps) {
+  const navigate = useNavigate();
+  const stateColor = STATE_COLORS[skill.state ?? 'unknown'] ?? STATE_COLORS.unknown;
+  const visibleTags = skill.tags?.filter(t => !t.startsWith('namespace:')) ?? [];
+
+  return (
+    <div
+      style={{
+        background: '#fff',
+        border: isSelected ? '2px solid #0f62fe' : '1px solid #d2d2d2',
+        borderRadius: '6px',
+        overflow: 'hidden',
+        boxShadow: '0 1px 4px rgba(0,0,0,0.05)',
+        cursor: 'pointer',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+      onClick={() => navigate(`/skills/${skill.name}`)}
+    >
+      {/* Header */}
+      <div
+        style={{
+          padding: '14px 14px 10px',
+          background: isSelected ? '#f0f7ff' : '#fff',
+        }}
+      >
+        {/* Checkbox + name + state badge */}
+        <div style={{ display: 'flex', alignItems: 'flex-start', gap: '8px', marginBottom: '6px' }}>
+          <input
+            type="checkbox"
+            checked={isSelected}
+            onChange={e => {
+              e.stopPropagation();
+              onSelect(e.target.checked);
+            }}
+            onClick={e => e.stopPropagation()}
+            style={{ marginTop: '2px', flexShrink: 0, cursor: 'pointer' }}
+          />
+          <div style={{ flex: 1, minWidth: 0, display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+            <span style={{ fontWeight: 600, fontSize: '14px', color: isSelected ? '#0f62fe' : '#151515' }}>
+              {skill.name}
+            </span>
+            {skill.state && (
+              <span style={{
+                background: stateColor.background,
+                color: stateColor.color,
+                fontSize: '11px',
+                padding: '2px 6px',
+                borderRadius: '10px',
+                flexShrink: 0,
+                marginLeft: '6px',
+                whiteSpace: 'nowrap',
+              }}>
+                {skill.state}
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Description — 2-line clamp */}
+        <p style={{
+          color: '#444',
+          margin: '0 0 8px',
+          lineHeight: '1.4',
+          fontSize: '13px',
+          display: '-webkit-box',
+          WebkitLineClamp: 2,
+          WebkitBoxOrient: 'vertical',
+          overflow: 'hidden',
+          paddingLeft: '22px',
+        }}>
+          {skill.description || 'No description'}
+        </p>
+
+        {/* Tags */}
+        <div style={{ display: 'flex', gap: '4px', flexWrap: 'wrap', paddingLeft: '22px', minHeight: '20px' }}>
+          {visibleTags.length > 0
+            ? visibleTags.map(tag => (
+                <Label key={tag} color={getTagColor(tag)} isCompact>{tag}</Label>
+              ))
+            : <span style={{ fontSize: '12px', color: '#aaa' }}>no tags</span>
+          }
+        </div>
+      </div>
+
+      {/* Footer strip */}
+      <div style={{
+        background: '#f5f5f5',
+        borderTop: '1px solid #e0e0e0',
+        padding: '8px 14px',
+        display: 'flex',
+        gap: '12px',
+        color: '#555',
+        fontSize: '12px',
+        alignItems: 'center',
+        marginTop: 'auto',
+      }}>
+        <span>
+          {skill.tools && skill.tools.length > 0
+            ? `🔧 ${skill.tools.length} tools`
+            : '— tools'}
+        </span>
+        <span>
+          {skill.snippets && skill.snippets.length > 0
+            ? `📄 ${skill.snippets.length} snippets`
+            : '— snippets'}
+        </span>
+        {skill.version && (
+          <span style={{ marginLeft: 'auto', color: '#6a6e73' }}>{skill.version}</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/skillberry_store/ui/src/components/SkillCard.tsx
+++ b/src/skillberry_store/ui/src/components/SkillCard.tsx
@@ -43,7 +43,7 @@ export function SkillCard({ skill, isSelected, onSelect }: SkillCardProps) {
       {/* Header */}
       <div
         style={{
-          padding: '14px 14px 10px',
+          padding: '16px 16px 12px',
           background: isSelected ? '#f0f7ff' : '#fff',
         }}
       >
@@ -71,14 +71,14 @@ export function SkillCard({ skill, isSelected, onSelect }: SkillCardProps) {
           </div>
         </div>
 
-        {/* Description — 2-line clamp */}
+        {/* Description — 3-line clamp */}
         <p style={{
           color: '#444',
-          margin: '0 0 8px',
-          lineHeight: '1.4',
+          margin: '0 0 10px',
+          lineHeight: '1.5',
           fontSize: '13px',
           display: '-webkit-box',
-          WebkitLineClamp: 2,
+          WebkitLineClamp: 3,
           WebkitBoxOrient: 'vertical',
           overflow: 'hidden',
           paddingLeft: '22px',

--- a/src/skillberry_store/ui/src/components/SkillCardView.tsx
+++ b/src/skillberry_store/ui/src/components/SkillCardView.tsx
@@ -1,0 +1,30 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+
+import type { Skill } from '@/types';
+import { SkillCard } from './SkillCard';
+
+interface SkillCardViewProps {
+  skills: Skill[];
+  selectedSkills: string[];
+  onSelectSkill: (name: string, isSelected: boolean) => void;
+}
+
+export function SkillCardView({ skills, selectedSkills, onSelectSkill }: SkillCardViewProps) {
+  return (
+    <div style={{
+      display: 'grid',
+      gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))',
+      gap: '14px',
+    }}>
+      {skills.map(skill => (
+        <SkillCard
+          key={skill.uuid}
+          skill={skill}
+          isSelected={selectedSkills.includes(skill.name)}
+          onSelect={(isSelected) => onSelectSkill(skill.name, isSelected)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/skillberry_store/ui/src/components/SkillCardView.tsx
+++ b/src/skillberry_store/ui/src/components/SkillCardView.tsx
@@ -14,8 +14,9 @@ export function SkillCardView({ skills, selectedSkills, onSelectSkill }: SkillCa
   return (
     <div style={{
       display: 'grid',
-      gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))',
-      gap: '14px',
+      gridTemplateColumns: 'repeat(auto-fill, minmax(380px, 1fr))',
+      gap: '16px',
+      marginTop: '1rem',
     }}>
       {skills.map(skill => (
         <SkillCard

--- a/src/skillberry_store/ui/src/components/SkillListView.tsx
+++ b/src/skillberry_store/ui/src/components/SkillListView.tsx
@@ -1,0 +1,110 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+
+import { useNavigate } from 'react-router-dom';
+import { getTagColor } from '../utils/tagColors';
+import { Label } from '@patternfly/react-core';
+import { Table, Thead, Tr, Th, Tbody, Td, ThProps } from '@patternfly/react-table';
+import type { Skill } from '@/types';
+
+interface SkillListViewProps {
+  skills: Skill[];
+  selectedSkills: string[];
+  onSelectSkill: (name: string, isSelected: boolean) => void;
+  onSelectAll: (isSelected: boolean) => void;
+  getSortParams: (columnIndex: number) => ThProps['sort'];
+}
+
+export function SkillListView({
+  skills,
+  selectedSkills,
+  onSelectSkill,
+  onSelectAll,
+  getSortParams,
+}: SkillListViewProps) {
+  const navigate = useNavigate();
+
+  return (
+    <Table aria-label="Skills table" variant="compact">
+      <Thead>
+        <Tr>
+          <Th
+            select={{
+              onSelect: (_event, isSelected) => onSelectAll(isSelected),
+              isSelected: selectedSkills.length === skills.length && skills.length > 0,
+            }}
+          />
+          <Th sort={getSortParams(0)}>Name</Th>
+          <Th sort={getSortParams(1)}>Description</Th>
+          <Th>Tags</Th>
+          <Th>Tools</Th>
+          <Th>Snippets</Th>
+          <Th sort={getSortParams(2)}>Version</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {skills.map((skill, index) => (
+          <Tr key={skill.uuid}>
+            <Td
+              select={{
+                rowIndex: index,
+                onSelect: (_event, isSelected) => onSelectSkill(skill.name, isSelected),
+                isSelected: selectedSkills.includes(skill.name),
+              }}
+            />
+            <Td
+              dataLabel="Name"
+              onClick={() => navigate(`/skills/${skill.name}`)}
+              style={{ cursor: 'pointer' }}
+            >
+              {skill.name}
+            </Td>
+            <Td
+              dataLabel="Description"
+              onClick={() => navigate(`/skills/${skill.name}`)}
+              style={{ cursor: 'pointer' }}
+            >
+              {skill.description || 'No description'}
+            </Td>
+            <Td
+              dataLabel="Tags"
+              onClick={() => navigate(`/skills/${skill.name}`)}
+              style={{ cursor: 'pointer' }}
+            >
+              {skill.tags && skill.tags.filter(tag => !tag.startsWith('namespace:')).length > 0 ? (
+                <div style={{ display: 'flex', gap: '0.25rem', flexWrap: 'wrap' }}>
+                  {skill.tags
+                    .filter(tag => !tag.startsWith('namespace:'))
+                    .map((tag) => (
+                      <Label key={tag} color={getTagColor(tag)} isCompact>{tag}</Label>
+                    ))}
+                </div>
+              ) : '-'}
+            </Td>
+            <Td
+              dataLabel="Tools"
+              onClick={() => navigate(`/skills/${skill.name}`)}
+              style={{ cursor: 'pointer' }}
+            >
+              {skill.tools && skill.tools.length > 0 ? skill.tools.length : '-'}
+            </Td>
+            <Td
+              dataLabel="Snippets"
+              onClick={() => navigate(`/skills/${skill.name}`)}
+              style={{ cursor: 'pointer' }}
+            >
+              {skill.snippets && skill.snippets.length > 0 ? skill.snippets.length : '-'}
+            </Td>
+            <Td
+              dataLabel="Version"
+              onClick={() => navigate(`/skills/${skill.name}`)}
+              style={{ cursor: 'pointer' }}
+            >
+              {skill.version || '-'}
+            </Td>
+          </Tr>
+        ))}
+      </Tbody>
+    </Table>
+  );
+}

--- a/src/skillberry_store/ui/src/pages/SkillsPage.tsx
+++ b/src/skillberry_store/ui/src/pages/SkillsPage.tsx
@@ -71,9 +71,10 @@ export function SkillsPage() {
   const [isAnthropicImportModalOpen, setIsAnthropicImportModalOpen] = useState(false);
   const [activeSortIndex, setActiveSortIndex] = useState<number | null>(null);
   const [activeSortDirection, setActiveSortDirection] = useState<'asc' | 'desc'>('asc');
-  const [viewMode, setViewMode] = useState<'cards' | 'list'>(
-    () => (localStorage.getItem('skills-view-mode') as 'cards' | 'list') ?? 'cards'
-  );
+  const [viewMode, setViewMode] = useState<'cards' | 'list'>(() => {
+    const stored = localStorage.getItem('skills-view-mode');
+    return stored === 'cards' || stored === 'list' ? stored : 'cards';
+  });
 
   // Select dropdown states
   const [isToolSelectOpen, setIsToolSelectOpen] = useState(false);
@@ -443,12 +444,6 @@ export function SkillsPage() {
     columnIndex,
   });
 
-  const handleViewModeChange = (_event: React.MouseEvent, isSelected: boolean, mode: 'cards' | 'list') => {
-    if (isSelected) {
-      setViewMode(mode);
-      localStorage.setItem('skills-view-mode', mode);
-    }
-  };
 
   if (isLoading) {
     return (
@@ -563,13 +558,23 @@ export function SkillsPage() {
                   icon={<ThLargeIcon />}
                   text="Cards"
                   isSelected={viewMode === 'cards'}
-                  onChange={(_event, isSelected) => handleViewModeChange(_event as React.MouseEvent, isSelected, 'cards')}
+                  onChange={(_event, isSelected) => {
+                    if (isSelected) {
+                      setViewMode('cards');
+                      localStorage.setItem('skills-view-mode', 'cards');
+                    }
+                  }}
                 />
                 <ToggleGroupItem
                   icon={<ListIcon />}
                   text="List"
                   isSelected={viewMode === 'list'}
-                  onChange={(_event, isSelected) => handleViewModeChange(_event as React.MouseEvent, isSelected, 'list')}
+                  onChange={(_event, isSelected) => {
+                    if (isSelected) {
+                      setViewMode('list');
+                      localStorage.setItem('skills-view-mode', 'list');
+                    }
+                  }}
                 />
               </ToggleGroup>
             </ToolbarItem>

--- a/src/skillberry_store/ui/src/pages/SkillsPage.tsx
+++ b/src/skillberry_store/ui/src/pages/SkillsPage.tsx
@@ -2,9 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 
 import { useState, useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getTagColor } from '../utils/tagColors';
 import { TagFilter } from '../components/TagFilter';
 import { NamespaceFilter } from '../components/NamespaceFilter';
 import { SearchBox, SearchMode } from '../components/SearchBox';
@@ -28,23 +26,25 @@ import {
   FormGroup,
   TextInput,
   TextArea,
-  Label,
   FileUpload,
   Select,
   SelectOption,
   SelectList,
   MenuToggle,
   MenuToggleElement,
+  ToggleGroup,
+  ToggleGroupItem,
 } from '@patternfly/react-core';
-import { Table, Thead, Tr, Th, Tbody, Td, ThProps } from '@patternfly/react-table';
-import { PlusIcon, CodeIcon, SearchIcon, TrashIcon, ExportIcon, ImportIcon, UploadIcon } from '@patternfly/react-icons';
+import type { ThProps } from '@patternfly/react-table';
+import { PlusIcon, CodeIcon, SearchIcon, TrashIcon, ExportIcon, ImportIcon, UploadIcon, ThLargeIcon, ListIcon } from '@patternfly/react-icons';
 import { skillsApi, toolsApi, snippetsApi } from '@/services/api';
 import type { Skill } from '@/types';
 import { AnthropicSkillImporter } from '../components/AnthropicSkillImporter';
+import { SkillCardView } from '../components/SkillCardView';
+import { SkillListView } from '../components/SkillListView';
 
 
 export function SkillsPage() {
-  const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [searchTerm, setSearchTerm] = useState('');
   const [searchMode, setSearchMode] = useState<SearchMode>('text');
@@ -71,7 +71,10 @@ export function SkillsPage() {
   const [isAnthropicImportModalOpen, setIsAnthropicImportModalOpen] = useState(false);
   const [activeSortIndex, setActiveSortIndex] = useState<number | null>(null);
   const [activeSortDirection, setActiveSortDirection] = useState<'asc' | 'desc'>('asc');
-  
+  const [viewMode, setViewMode] = useState<'cards' | 'list'>(
+    () => (localStorage.getItem('skills-view-mode') as 'cards' | 'list') ?? 'cards'
+  );
+
   // Select dropdown states
   const [isToolSelectOpen, setIsToolSelectOpen] = useState(false);
   const [isSnippetSelectOpen, setIsSnippetSelectOpen] = useState(false);
@@ -122,7 +125,7 @@ export function SkillsPage() {
       setSnippetSearchTerm('');
       setCreateError('');
     },
-    onError: (error: any) => {
+    onError: (error: Error) => {
       setCreateError(error.message || 'Failed to create skill');
     },
   });
@@ -440,6 +443,13 @@ export function SkillsPage() {
     columnIndex,
   });
 
+  const handleViewModeChange = (_event: React.MouseEvent, isSelected: boolean, mode: 'cards' | 'list') => {
+    if (isSelected) {
+      setViewMode(mode);
+      localStorage.setItem('skills-view-mode', mode);
+    }
+  };
+
   if (isLoading) {
     return (
       <PageSection>
@@ -547,6 +557,22 @@ export function SkillsPage() {
                 Create Skill
               </Button>
             </ToolbarItem>
+            <ToolbarItem>
+              <ToggleGroup aria-label="Skills view mode">
+                <ToggleGroupItem
+                  icon={<ThLargeIcon />}
+                  text="Cards"
+                  isSelected={viewMode === 'cards'}
+                  onChange={(_event, isSelected) => handleViewModeChange(_event as React.MouseEvent, isSelected, 'cards')}
+                />
+                <ToggleGroupItem
+                  icon={<ListIcon />}
+                  text="List"
+                  isSelected={viewMode === 'list'}
+                  onChange={(_event, isSelected) => handleViewModeChange(_event as React.MouseEvent, isSelected, 'list')}
+                />
+              </ToggleGroup>
+            </ToolbarItem>
           </ToolbarContent>
         </Toolbar>
 
@@ -571,92 +597,20 @@ export function SkillsPage() {
               </Button>
             )}
           </EmptyState>
+        ) : viewMode === 'cards' ? (
+          <SkillCardView
+            skills={filteredSkills}
+            selectedSkills={selectedSkills}
+            onSelectSkill={handleSelectSkill}
+          />
         ) : (
-          <Table aria-label="Skills table" variant="compact">
-            <Thead>
-              <Tr>
-                <Th
-                  select={{
-                    onSelect: (_event, isSelected) => handleSelectAll(isSelected),
-                    isSelected: selectedSkills.length === filteredSkills.length && filteredSkills.length > 0,
-                  }}
-                />
-                <Th sort={getSortParams(0)}>Name</Th>
-                <Th sort={getSortParams(1)}>Description</Th>
-                <Th>Tags</Th>
-                <Th>Tools</Th>
-                <Th>Snippets</Th>
-                <Th sort={getSortParams(2)}>Version</Th>
-              </Tr>
-            </Thead>
-            <Tbody>
-              {filteredSkills.map((skill, index) => (
-                <Tr key={skill.uuid}>
-                  <Td
-                    select={{
-                      rowIndex: index,
-                      onSelect: (_event, isSelected) => handleSelectSkill(skill.name, isSelected),
-                      isSelected: selectedSkills.includes(skill.name),
-                    }}
-                  />
-                  <Td
-                    dataLabel="Name"
-                    onClick={() => navigate(`/skills/${skill.name}`)}
-                    style={{ cursor: 'pointer' }}
-                  >
-                    {skill.name}
-                  </Td>
-                  <Td
-                    dataLabel="Description"
-                    onClick={() => navigate(`/skills/${skill.name}`)}
-                    style={{ cursor: 'pointer' }}
-                  >
-                    {skill.description || 'No description'}
-                  </Td>
-                  <Td
-                    dataLabel="Tags"
-                    onClick={() => navigate(`/skills/${skill.name}`)}
-                    style={{ cursor: 'pointer' }}
-                  >
-                    {skill.tags && skill.tags.filter(tag => !tag.startsWith('namespace:')).length > 0 ? (
-                      <div style={{ display: 'flex', gap: '0.25rem', flexWrap: 'wrap' }}>
-                        {skill.tags
-                          .filter(tag => !tag.startsWith('namespace:'))
-                          .map((tag) => (
-                            <Label key={tag} color={getTagColor(tag)} isCompact>
-                              {tag}
-                            </Label>
-                          ))}
-                      </div>
-                    ) : (
-                      '-'
-                    )}
-                  </Td>
-                  <Td
-                    dataLabel="Tools"
-                    onClick={() => navigate(`/skills/${skill.name}`)}
-                    style={{ cursor: 'pointer' }}
-                  >
-                    {skill.tools && skill.tools.length > 0 ? skill.tools.length : '-'}
-                  </Td>
-                  <Td
-                    dataLabel="Snippets"
-                    onClick={() => navigate(`/skills/${skill.name}`)}
-                    style={{ cursor: 'pointer' }}
-                  >
-                    {skill.snippets && skill.snippets.length > 0 ? skill.snippets.length : '-'}
-                  </Td>
-                  <Td
-                    dataLabel="Version"
-                    onClick={() => navigate(`/skills/${skill.name}`)}
-                    style={{ cursor: 'pointer' }}
-                  >
-                    {skill.version || '-'}
-                  </Td>
-                </Tr>
-              ))}
-            </Tbody>
-          </Table>
+          <SkillListView
+            skills={filteredSkills}
+            selectedSkills={selectedSkills}
+            onSelectSkill={handleSelectSkill}
+            onSelectAll={handleSelectAll}
+            getSortParams={getSortParams}
+          />
         )}
       </PageSection>
 
@@ -989,7 +943,7 @@ export function SkillsPage() {
           id="import-file"
           value={importFile || undefined}
           filename={importFile?.name}
-          onFileInputChange={(_event: any, file: File) => setImportFile(file)}
+          onFileInputChange={(_event, file: File) => setImportFile(file)}
           onClearClick={() => setImportFile(null)}
           hideDefaultPreview
           browseButtonText="Select JSON File"


### PR DESCRIPTION
## Summary

- Add a **card view** as the default display mode for the Skills page, alongside the existing table (list) view
- Each card shows: skill name, state badge, truncated description (3 lines), tags, tool/snippet counts, and version
- Cards support checkbox selection for bulk export and delete — clicking the card body navigates to the detail page; clicking the checkbox selects without navigating
- A **Cards / List toggle** in the toolbar switches between views; preference is persisted in `localStorage`

## Changes

- `SkillListView.tsx` (new) — table view extracted from `SkillsPage` into a standalone component
- `SkillCard.tsx` (new) — single card component with selection, state badge (PatternFly Label), PF icons in footer
- `SkillCardView.tsx` (new) — responsive CSS grid of `SkillCard` components
- `SkillsPage.tsx` — adds `viewMode` state + localStorage persistence, `ToggleGroup` in toolbar, conditionally renders `SkillCardView` or `SkillListView`; all existing modals, filters, and data fetching unchanged
- `.gitignore` — ignore `docs/superpowers/` and `.superpowers/` directories

## Test plan

- [ ] Skills page loads with card view by default
- [ ] Cards show name, state badge, description (≤3 lines), tags, tool/snippet counts, version
- [ ] Skills with no tags show "no tags"; skills with no tools/snippets show a dash
- [ ] Clicking a card body navigates to the skill detail page
- [ ] Clicking a card checkbox selects it without navigating; selected card has blue border and light blue header
- [ ] Export / Delete toolbar buttons reflect correct selection count
- [ ] Toggle to List view shows the table (identical to previous behaviour)
- [ ] Selection state preserved when switching between views
- [ ] Refreshing the page restores the last-used view mode from localStorage
- [ ] Search, namespace filter, and tag filter work correctly in both views

🤖 Generated with [Claude Code](https://claude.com/claude-code)