### PR TITLE
fix: Accept both test-with-bob and fix-with-bob labels in workflow

### DIFF
--- a/.github/workflows/test-pr-with-bob-trigger.yml
+++ b/.github/workflows/test-pr-with-bob-trigger.yml
@@ -14,8 +14,9 @@
 # allowing a second workflow to comment on the PR.
 #
 # USAGE:
-# Add the label `test-with-bob` to a PR. The workflow also reruns on synchronize,
-# reopened, and ready_for_review while the label remains attached.
+# Add the label `test-with-bob` or `fix-with-bob` to a PR. The workflow also
+# reruns on synchronize, reopened, and ready_for_review while either label
+# remains attached.
 # ============================================================================
 
 name: Test PR with Bob - Trigger
@@ -32,7 +33,8 @@ jobs:
   collect-pr-context:
     if: >-
       !github.event.pull_request.draft &&
-      contains(github.event.pull_request.labels.*.name, 'test-with-bob')
+      (contains(github.event.pull_request.labels.*.name, 'test-with-bob') ||
+       contains(github.event.pull_request.labels.*.name, 'fix-with-bob'))
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test-pr-with-bob.yml
+++ b/.github/workflows/test-pr-with-bob.yml
@@ -3,7 +3,7 @@
 # ============================================================================
 #
 # PURPOSE:
-# This workflow tests a PR after the `test-with-bob` label is added.
+# This workflow tests a PR after the `test-with-bob` or `fix-with-bob` label is added.
 # It is triggered by the unprivileged "Test PR with Bob - Trigger" workflow.
 #
 # WHAT IT DOES:
@@ -25,6 +25,10 @@
 # OPTIONAL REPOSITORY VARIABLE:
 # - BOB_ALLOWED_HEAD_OWNERS: comma-separated list of trusted GitHub org/user owners.
 #   Default: `${{ github.repository_owner }},skillberry-bot`
+#
+# LABELS:
+# - test-with-bob: Triggers the workflow for testing PRs
+# - fix-with-bob: Also triggers the workflow (alternative label)
 #
 # IMPORTANT SECURITY NOTE:
 # This workflow checks out and runs PR code. Keep the trusted-owner guard unless
@@ -112,9 +116,11 @@ jobs:
             });
 
             const labelName = process.env.TEST_WITH_BOB_LABEL || 'test-with-bob';
-            const hasLabel = pr.labels.some(label => label.name === labelName);
+            const hasLabel = pr.labels.some(label =>
+              label.name === labelName || label.name === 'fix-with-bob'
+            );
             if (!hasLabel) {
-              core.info(`PR #${pr.number} no longer has label ${labelName}; skipping`);
+              core.info(`PR #${pr.number} no longer has label ${labelName} or fix-with-bob; skipping`);
               core.setOutput('should_run', 'false');
               return;
             }


### PR DESCRIPTION
## Summary

Updates the 'Test PR with Bob' workflow to accept both `test-with-bob` and `fix-with-bob` labels.

## Changes

- Modified `.github/workflows/test-pr-with-bob-trigger.yml` to trigger on either label
- Modified `.github/workflows/test-pr-with-bob.yml` to check for either label
- Updated documentation in both workflows

## Why

PR #115 has the `fix-with-bob` label but the workflow was only checking for `test-with-bob`, causing it to be skipped.

## Testing

After merge, PR #115 should automatically trigger the workflow on the next push/synchronize event.