### PR TITLE
feat: simplify restish CLI command names via x-cli-name extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,11 +193,24 @@ Example usage:
 pip install skillberry-store-sdk
 
 # Use the CLI
-sbs --help                                 # Show available commands
-sbs connect http://prod:8000               # Connect to different server
-sbs list-skills-skills-get list            # List all skills
-sbs get-tool-tools-name-get convert        # Get a specific tool
+sbs --help                     # Show available commands
+sbs connect http://prod:8000   # Connect to different server
+sbs list-skills                # List all skills
+sbs get-tool convert           # Get a specific tool
+sbs create-vmcp-server         # Create a VMCP server
+sbs search-tools "calculator"  # Search for tools
 ```
+
+Available command groups:
+
+| Group | Commands |
+|-------|----------|
+| **Tools** | `create-tool`, `list-tools`, `get-tool`, `get-tool-module`, `update-tool`, `delete-tool`, `execute-tool`, `search-tools`, `add-tool` |
+| **Skills** | `create-skill`, `list-skills`, `get-skill`, `update-skill`, `delete-skill`, `search-skills`, `detect-anthropic-skills`, `import-anthropic-skill`, `export-anthropic-skill` |
+| **Snippets** | `create-snippet`, `list-snippets`, `get-snippet`, `update-snippet`, `delete-snippet`, `search-snippets` |
+| **VMCP Servers** | `create-vmcp-server`, `list-vmcp-servers`, `get-vmcp-server`, `update-vmcp-server`, `delete-vmcp-server`, `start-vmcp-server`, `search-vmcp-servers` |
+| **vNFS Servers** | `create-vnfs-server`, `list-vnfs-servers`, `get-vnfs-server`, `update-vnfs-server`, `delete-vnfs-server`, `start-vnfs-server`, `search-vnfs-servers` |
+| **Admin** | `metrics`, `purge-all`, `health`, `health-ready` |
 
 For detailed CLI documentation, see [docs/cli.md](docs/cli.md).
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -39,7 +39,7 @@ The CLI command is `sbs` (Skillberry Store):
 
 ```bash
 sbs --help                    # Show all available commands
-sbs <resource> <action>       # General command structure
+sbs <command> [args] [flags]  # General command structure
 ```
 
 ## Configuration
@@ -59,64 +59,135 @@ sbs connect https://staging.example.com
 
 The CLI will remember this connection for future commands.
 
-## Common Commands
+## Command Reference
 
 ### Skills Management
 
 ```bash
 # List all skills
-sbs list-skills-skills-get list
+sbs list-skills
 
 # Get a specific skill
-sbs get-skill-skills-name-get <skill-name>
+sbs get-skill <skill-name>
 
 # Create a new skill
-sbs create-skill-skills-post --body='{"name":"my-skill","description":"My skill"}'
+sbs create-skill --name my-skill --description "My skill"
+
+# Update a skill
+sbs update-skill <skill-name> --description "Updated description"
 
 # Delete a skill
-sbs delete-skill-skills-name-delete <skill-name>
+sbs delete-skill <skill-name>
+
+# Search skills semantically
+sbs search-skills --search-term "data processing"
+
+# Anthropic skill import/export
+sbs detect-anthropic-skills
+sbs import-anthropic-skill
+sbs export-anthropic-skill <skill-name>
 ```
 
 ### Tools Management
 
 ```bash
 # List all tools
-sbs list-tools-tools-get list
+sbs list-tools
 
 # Get a specific tool
-sbs get-tool-tools-name-get <tool-name>
+sbs get-tool <tool-name>
+
+# Get the source module of a tool
+sbs get-tool-module <tool-name>
 
 # Search tools semantically
-sbs search-tools-tools-search-get --query="calculator functions"
+sbs search-tools --search-term "calculator functions"
 
 # Execute a tool
-sbs execute-tool-tools-name-execute-post <tool-name> --body='{"params":{"x":5,"y":3}}'
+sbs execute-tool <tool-name> --body='{"params":{"x":5,"y":3}}'
+
+# Add a tool from a Python file
+sbs add-tool
+
+# Update or delete a tool
+sbs update-tool <tool-name>
+sbs delete-tool <tool-name>
 ```
 
 ### Snippets Management
 
 ```bash
 # List all snippets
-sbs list-snippets-snippets-get list
+sbs list-snippets
 
 # Get a specific snippet
-sbs get-snippet-snippets-name-get <snippet-name>
+sbs get-snippet <snippet-name>
 
 # Create a snippet
-sbs create-snippet-snippets-post --body='{"name":"helper","code":"def helper(): pass"}'
+sbs create-snippet --name helper --description "Helper utilities"
+
+# Update or delete a snippet
+sbs update-snippet <snippet-name>
+sbs delete-snippet <snippet-name>
+
+# Search snippets semantically
+sbs search-snippets --search-term "string utilities"
 ```
 
 ### VMCP Servers
 
 ```bash
 # List virtual MCP servers
-sbs list-vmcp-servers-vmcp-servers-get list
+sbs list-vmcp-servers
 
 # Get a specific VMCP server
-sbs get-vmcp-server-vmcp-servers-name-get <server-name>
+sbs get-vmcp-server <server-name>
 
 # Create a VMCP server
-sbs create-vmcp-server-vmcp-servers-post --body='{"name":"my-server","tools":["tool1","tool2"]}'
+sbs create-vmcp-server --name my-server --skill-uuid <uuid>
+
+# Start, update, or delete a VMCP server
+sbs start-vmcp-server <server-name>
+sbs update-vmcp-server <server-name>
+sbs delete-vmcp-server <server-name>
+
+# Search VMCP servers
+sbs search-vmcp-servers --search-term "math tools"
+```
+
+### vNFS Servers
+
+```bash
+# List virtual NFS servers
+sbs list-vnfs-servers
+
+# Get a specific vNFS server
+sbs get-vnfs-server <server-name>
+
+# Create a vNFS server
+sbs create-vnfs-server --name my-server --skill-uuid <uuid>
+
+# Start, update, or delete a vNFS server
+sbs start-vnfs-server <server-name>
+sbs update-vnfs-server <server-name>
+sbs delete-vnfs-server <server-name>
+
+# Search vNFS servers
+sbs search-vnfs-servers --search-term "data files"
+```
+
+### Admin
+
+```bash
+# Health checks
+sbs health
+sbs health-ready
+
+# Prometheus metrics
+sbs metrics
+
+# Delete all data (irreversible)
+sbs purge-all
 ```
 
 ## Advanced Features
@@ -127,29 +198,29 @@ Restish supports multiple output formats:
 
 ```bash
 # JSON output (default)
-sbs list-tools-tools-get list
+sbs list-tools
 
 # YAML output
-sbs list-tools-tools-get list -o yaml
+sbs list-tools -o yaml
 
 # Table output
-sbs list-tools-tools-get list -o table
+sbs list-tools -o table
 
 # Raw output
-sbs list-tools-tools-get list -o raw
+sbs list-tools -o raw
 ```
 
 ### Filtering and Pagination
 
 ```bash
 # Filter results
-sbs list-tools-tools-get list --filter='state=active'
+sbs list-tools --filter='state=active'
 
 # Limit results
-sbs list-tools-tools-get list --limit=10
+sbs list-tools --limit=10
 
 # Pagination
-sbs list-tools-tools-get list --offset=20 --limit=10
+sbs list-tools --offset=20 --limit=10
 ```
 
 ### Request Body from File
@@ -158,10 +229,10 @@ For complex requests, use a file:
 
 ```bash
 # Create tool from JSON file
-sbs create-tool-tools-post --body=@tool-definition.json
+sbs create-tool --body=@tool-definition.json
 
 # Update skill from YAML file
-sbs update-skill-skills-name-put <skill-name> --body=@skill-update.yaml
+sbs update-skill <skill-name> --body=@skill-update.yaml
 ```
 
 ### Verbose Mode
@@ -169,7 +240,7 @@ sbs update-skill-skills-name-put <skill-name> --body=@skill-update.yaml
 See detailed request/response information:
 
 ```bash
-sbs list-tools-tools-get list -v
+sbs list-tools -v
 ```
 
 ## Architecture
@@ -183,7 +254,7 @@ The CLI works through the following flow:
 
 2. **Command delegation**: All commands are passed to `restish`:
    ```
-   sbs list-tools-tools-get list → restish sbs list-tools-tools-get list
+   sbs list-tools → restish sbs list-tools
    ```
 
 3. **Output filtering**: The CLI filters restish output to:
@@ -223,10 +294,11 @@ make run
 
 ### API spec sync failed
 
-Manually sync the API spec:
+Manually sync the API spec by clearing the cache and re-running any command:
 
 ```bash
-restish api sync sbs
+rm ~/.cache/restish/sbs.cbor
+sbs --help
 ```
 
 ## Examples
@@ -238,37 +310,30 @@ restish api sync sbs
 sbs connect http://localhost:8000
 
 # 2. List existing tools
-sbs list-tools-tools-get list
+sbs list-tools
 
 # 3. Add a new tool
-sbs create-tool-tools-post --body='{
-  "name": "calculator",
-  "description": "Basic calculator",
-  "code": "def add(x, y): return x + y"
-}'
+sbs create-tool --name calculator --description "Basic calculator"
 
 # 4. Execute the tool
-sbs execute-tool-tools-name-execute-post calculator --body='{"params":{"x":5,"y":3}}'
+sbs execute-tool calculator --body='{"params":{"x":5,"y":3}}'
 
 # 5. Create a skill using the tool
-sbs create-skill-skills-post --body='{
-  "name": "math-skill",
-  "tools": ["calculator"]
-}'
+sbs create-skill --name math-skill --description "Math utilities"
 
 # 6. List skills to verify
-sbs list-skills-skills-get list
+sbs list-skills
 ```
 
 ### Batch Operations
 
 ```bash
 # Export all tools
-sbs list-tools-tools-get list -o json > tools-backup.json
+sbs list-tools -o json > tools-backup.json
 
 # Import tools from backup
 cat tools-backup.json | jq -c '.[]' | while read tool; do
-  sbs create-tool-tools-post --body="$tool"
+  sbs create-tool --body="$tool"
 done
 ```
 
@@ -280,15 +345,15 @@ The CLI can be easily integrated into shell scripts:
 #!/bin/bash
 
 # Check if tool exists
-if sbs get-tool-tools-name-get my-tool 2>/dev/null; then
+if sbs get-tool my-tool 2>/dev/null; then
   echo "Tool exists"
 else
   echo "Creating tool..."
-  sbs create-tool-tools-post --body=@tool.json
+  sbs create-tool --body=@tool.json
 fi
 
 # Get tool output as JSON
-RESULT=$(sbs execute-tool-tools-name-execute-post my-tool --body='{"params":{}}' -o json)
+RESULT=$(sbs execute-tool my-tool --body='{"params":{}}' -o json)
 echo "Result: $RESULT"
 ```
 

--- a/src/skillberry_store/fast_api/admin_api.py
+++ b/src/skillberry_store/fast_api/admin_api.py
@@ -43,7 +43,12 @@ def register_admin_api(app: FastAPI, tags: str = "admin"):
         tags: FastAPI tags for grouping the endpoints in documentation.
     """
 
-    @app.get("/admin/metrics", tags=[tags], response_class=PlainTextResponse, openapi_extra={"x-cli-name": "metrics"})
+    @app.get(
+        "/admin/metrics",
+        tags=[tags],
+        response_class=PlainTextResponse,
+        openapi_extra={"x-cli-name": "metrics"},
+    )
     async def get_metrics():
         """Proxy endpoint to fetch Prometheus metrics.
 
@@ -81,7 +86,9 @@ def register_admin_api(app: FastAPI, tags: str = "admin"):
                 status_code=503, detail=f"Error fetching metrics: {str(e)}"
             )
 
-    @app.delete("/admin/purge-all", tags=[tags], openapi_extra={"x-cli-name": "purge-all"})
+    @app.delete(
+        "/admin/purge-all", tags=[tags], openapi_extra={"x-cli-name": "purge-all"}
+    )
     async def purge_all_data():
         """Delete all backend components including skills, tools, snippets, VMCP servers, and their descriptions.
 

--- a/src/skillberry_store/fast_api/admin_api.py
+++ b/src/skillberry_store/fast_api/admin_api.py
@@ -43,7 +43,7 @@ def register_admin_api(app: FastAPI, tags: str = "admin"):
         tags: FastAPI tags for grouping the endpoints in documentation.
     """
 
-    @app.get("/admin/metrics", tags=[tags], response_class=PlainTextResponse)
+    @app.get("/admin/metrics", tags=[tags], response_class=PlainTextResponse, openapi_extra={"x-cli-name": "metrics"})
     async def get_metrics():
         """Proxy endpoint to fetch Prometheus metrics.
 
@@ -81,7 +81,7 @@ def register_admin_api(app: FastAPI, tags: str = "admin"):
                 status_code=503, detail=f"Error fetching metrics: {str(e)}"
             )
 
-    @app.delete("/admin/purge-all", tags=[tags])
+    @app.delete("/admin/purge-all", tags=[tags], openapi_extra={"x-cli-name": "purge-all"})
     async def purge_all_data():
         """Delete all backend components including skills, tools, snippets, VMCP servers, and their descriptions.
 
@@ -258,7 +258,7 @@ def register_admin_api(app: FastAPI, tags: str = "admin"):
             "vector_indexes_reset": vector_indexes_reset,
         }
 
-    @app.get("/health", tags=[tags])
+    @app.get("/health", tags=[tags], openapi_extra={"x-cli-name": "health"})
     def health_check():
         """Health check endpoint.
 
@@ -267,7 +267,7 @@ def register_admin_api(app: FastAPI, tags: str = "admin"):
         """
         return {"status": "healthy"}
 
-    @app.get("/health/ready", tags=[tags])
+    @app.get("/health/ready", tags=[tags], openapi_extra={"x-cli-name": "health-ready"})
     def readiness_check():
         """Readiness check endpoint - verifies all description directories are initialized.
 

--- a/src/skillberry_store/fast_api/skills_api.py
+++ b/src/skillberry_store/fast_api/skills_api.py
@@ -105,7 +105,7 @@ def register_skills_api(
 
         return skill_dict
 
-    @app.post("/skills/", tags=[tags])
+    @app.post("/skills/", tags=[tags], openapi_extra={"x-cli-name": "create-skill"})
     def create_skill(skill: Annotated[SkillSchema, Query()]):
         """Create a new skill.
 
@@ -177,7 +177,7 @@ def register_skills_api(
                 status_code=500, detail=f"Error creating skill: {str(e)}"
             )
 
-    @app.get("/skills/", tags=[tags])
+    @app.get("/skills/", tags=[tags], openapi_extra={"x-cli-name": "list-skills"})
     def list_skills():
         """List all skills with populated tool and snippet objects.
 
@@ -209,7 +209,7 @@ def register_skills_api(
                 status_code=500, detail=f"Error listing skills: {str(e)}"
             )
 
-    @app.get("/skills/{uuid_or_name}", tags=[tags])
+    @app.get("/skills/{uuid_or_name}", tags=[tags], openapi_extra={"x-cli-name": "get-skill"})
     def get_skill(uuid_or_name: str):
         """Get a specific skill by UUID or name with populated tool and snippet objects.
 
@@ -241,7 +241,7 @@ def register_skills_api(
                 status_code=500, detail=f"Error retrieving skill: {str(e)}"
             )
 
-    @app.delete("/skills/{uuid_or_name}", tags=[tags])
+    @app.delete("/skills/{uuid_or_name}", tags=[tags], openapi_extra={"x-cli-name": "delete-skill"})
     def delete_skill(uuid_or_name: str):
         """Delete a skill by UUID or name.
 
@@ -309,7 +309,7 @@ def register_skills_api(
                 status_code=500, detail=f"Error deleting skill: {str(e)}"
             )
 
-    @app.put("/skills/{uuid_or_name}", tags=[tags])
+    @app.put("/skills/{uuid_or_name}", tags=[tags], openapi_extra={"x-cli-name": "update-skill"})
     def update_skill(uuid_or_name: str, skill: SkillSchema):
         """Update an existing skill by UUID or name.
 
@@ -388,7 +388,7 @@ def register_skills_api(
                 status_code=500, detail=f"Error updating skill: {str(e)}"
             )
 
-    @app.get("/search/skills", tags=[tags])
+    @app.get("/search/skills", tags=[tags], openapi_extra={"x-cli-name": "search-skills"})
     def search_skills(
         search_term: str,
         max_number_of_results: int = 5,
@@ -480,7 +480,7 @@ def register_skills_api(
                 status_code=500, detail=f"Error searching skills: {str(e)}"
             )
 
-    @app.post("/skills/detect-anthropic-skills", tags=[tags])
+    @app.post("/skills/detect-anthropic-skills", tags=[tags], openapi_extra={"x-cli-name": "detect-anthropic-skills"})
     async def detect_anthropic_skills(
         source_type: str = Form(...),
         github_url: Optional[str] = Form(None),
@@ -611,7 +611,7 @@ def register_skills_api(
                 detail=f"Error detecting skills: {str(e)}",
             )
 
-    @app.post("/skills/import-anthropic", tags=[tags])
+    @app.post("/skills/import-anthropic", tags=[tags], openapi_extra={"x-cli-name": "import-anthropic-skill"})
     async def import_anthropic_skill(
         source_type: str = Form(...),
         github_url: Optional[str] = Form(None),
@@ -883,7 +883,7 @@ def register_skills_api(
                 status_code=500, detail=f"Error importing Anthropic skill: {str(e)}"
             )
 
-    @app.get("/skills/{uuid_or_name}/export-anthropic", tags=[tags])
+    @app.get("/skills/{uuid_or_name}/export-anthropic", tags=[tags], openapi_extra={"x-cli-name": "export-anthropic-skill"})
     async def export_anthropic_skill(uuid_or_name: str):
         """Export a skill to Anthropic format as a ZIP file.
 

--- a/src/skillberry_store/fast_api/skills_api.py
+++ b/src/skillberry_store/fast_api/skills_api.py
@@ -209,7 +209,9 @@ def register_skills_api(
                 status_code=500, detail=f"Error listing skills: {str(e)}"
             )
 
-    @app.get("/skills/{uuid_or_name}", tags=[tags], openapi_extra={"x-cli-name": "get-skill"})
+    @app.get(
+        "/skills/{uuid_or_name}", tags=[tags], openapi_extra={"x-cli-name": "get-skill"}
+    )
     def get_skill(uuid_or_name: str):
         """Get a specific skill by UUID or name with populated tool and snippet objects.
 
@@ -241,7 +243,11 @@ def register_skills_api(
                 status_code=500, detail=f"Error retrieving skill: {str(e)}"
             )
 
-    @app.delete("/skills/{uuid_or_name}", tags=[tags], openapi_extra={"x-cli-name": "delete-skill"})
+    @app.delete(
+        "/skills/{uuid_or_name}",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "delete-skill"},
+    )
     def delete_skill(uuid_or_name: str):
         """Delete a skill by UUID or name.
 
@@ -309,7 +315,11 @@ def register_skills_api(
                 status_code=500, detail=f"Error deleting skill: {str(e)}"
             )
 
-    @app.put("/skills/{uuid_or_name}", tags=[tags], openapi_extra={"x-cli-name": "update-skill"})
+    @app.put(
+        "/skills/{uuid_or_name}",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "update-skill"},
+    )
     def update_skill(uuid_or_name: str, skill: SkillSchema):
         """Update an existing skill by UUID or name.
 
@@ -388,7 +398,9 @@ def register_skills_api(
                 status_code=500, detail=f"Error updating skill: {str(e)}"
             )
 
-    @app.get("/search/skills", tags=[tags], openapi_extra={"x-cli-name": "search-skills"})
+    @app.get(
+        "/search/skills", tags=[tags], openapi_extra={"x-cli-name": "search-skills"}
+    )
     def search_skills(
         search_term: str,
         max_number_of_results: int = 5,
@@ -480,7 +492,11 @@ def register_skills_api(
                 status_code=500, detail=f"Error searching skills: {str(e)}"
             )
 
-    @app.post("/skills/detect-anthropic-skills", tags=[tags], openapi_extra={"x-cli-name": "detect-anthropic-skills"})
+    @app.post(
+        "/skills/detect-anthropic-skills",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "detect-anthropic-skills"},
+    )
     async def detect_anthropic_skills(
         source_type: str = Form(...),
         github_url: Optional[str] = Form(None),
@@ -611,7 +627,11 @@ def register_skills_api(
                 detail=f"Error detecting skills: {str(e)}",
             )
 
-    @app.post("/skills/import-anthropic", tags=[tags], openapi_extra={"x-cli-name": "import-anthropic-skill"})
+    @app.post(
+        "/skills/import-anthropic",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "import-anthropic-skill"},
+    )
     async def import_anthropic_skill(
         source_type: str = Form(...),
         github_url: Optional[str] = Form(None),
@@ -883,7 +903,11 @@ def register_skills_api(
                 status_code=500, detail=f"Error importing Anthropic skill: {str(e)}"
             )
 
-    @app.get("/skills/{uuid_or_name}/export-anthropic", tags=[tags], openapi_extra={"x-cli-name": "export-anthropic-skill"})
+    @app.get(
+        "/skills/{uuid_or_name}/export-anthropic",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "export-anthropic-skill"},
+    )
     async def export_anthropic_skill(uuid_or_name: str):
         """Export a skill to Anthropic format as a ZIP file.
 

--- a/src/skillberry_store/fast_api/snippets_api.py
+++ b/src/skillberry_store/fast_api/snippets_api.py
@@ -177,7 +177,11 @@ def register_snippets_api(
                 status_code=500, detail=f"Error listing snippets: {str(e)}"
             )
 
-    @app.get("/snippets/{uuid_or_name}", tags=[tags], openapi_extra={"x-cli-name": "get-snippet"})
+    @app.get(
+        "/snippets/{uuid_or_name}",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "get-snippet"},
+    )
     def get_snippet(uuid_or_name: str):
         """Get a specific snippet by UUID or name.
 
@@ -207,7 +211,11 @@ def register_snippets_api(
                 status_code=500, detail=f"Error retrieving snippet: {str(e)}"
             )
 
-    @app.delete("/snippets/{uuid_or_name}", tags=[tags], openapi_extra={"x-cli-name": "delete-snippet"})
+    @app.delete(
+        "/snippets/{uuid_or_name}",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "delete-snippet"},
+    )
     def delete_snippet(uuid_or_name: str):
         """Delete a snippet by UUID or name.
 
@@ -276,7 +284,11 @@ def register_snippets_api(
                 status_code=500, detail=f"Error deleting snippet: {str(e)}"
             )
 
-    @app.put("/snippets/{uuid_or_name}", tags=[tags], openapi_extra={"x-cli-name": "update-snippet"})
+    @app.put(
+        "/snippets/{uuid_or_name}",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "update-snippet"},
+    )
     def update_snippet(uuid_or_name: str, snippet: SnippetSchema):
         """Update an existing snippet by UUID or name.
 
@@ -355,7 +367,9 @@ def register_snippets_api(
                 status_code=500, detail=f"Error updating snippet: {str(e)}"
             )
 
-    @app.get("/search/snippets", tags=[tags], openapi_extra={"x-cli-name": "search-snippets"})
+    @app.get(
+        "/search/snippets", tags=[tags], openapi_extra={"x-cli-name": "search-snippets"}
+    )
     def search_snippets(
         search_term: str,
         max_number_of_results: int = 5,

--- a/src/skillberry_store/fast_api/snippets_api.py
+++ b/src/skillberry_store/fast_api/snippets_api.py
@@ -54,7 +54,7 @@ def register_snippets_api(
     """
     snippet_handler = get_object_handler("snippet")
 
-    @app.post("/snippets/", tags=[tags])
+    @app.post("/snippets/", tags=[tags], openapi_extra={"x-cli-name": "create-snippet"})
     async def create_snippet(
         snippet: Annotated[SnippetSchema, Query()],
         file: Optional[UploadFile] = File(None),
@@ -150,7 +150,7 @@ def register_snippets_api(
                 status_code=500, detail=f"Error creating snippet: {str(e)}"
             )
 
-    @app.get("/snippets/", tags=[tags])
+    @app.get("/snippets/", tags=[tags], openapi_extra={"x-cli-name": "list-snippets"})
     def list_snippets():
         """List all snippets.
 
@@ -177,7 +177,7 @@ def register_snippets_api(
                 status_code=500, detail=f"Error listing snippets: {str(e)}"
             )
 
-    @app.get("/snippets/{uuid_or_name}", tags=[tags])
+    @app.get("/snippets/{uuid_or_name}", tags=[tags], openapi_extra={"x-cli-name": "get-snippet"})
     def get_snippet(uuid_or_name: str):
         """Get a specific snippet by UUID or name.
 
@@ -207,7 +207,7 @@ def register_snippets_api(
                 status_code=500, detail=f"Error retrieving snippet: {str(e)}"
             )
 
-    @app.delete("/snippets/{uuid_or_name}", tags=[tags])
+    @app.delete("/snippets/{uuid_or_name}", tags=[tags], openapi_extra={"x-cli-name": "delete-snippet"})
     def delete_snippet(uuid_or_name: str):
         """Delete a snippet by UUID or name.
 
@@ -276,7 +276,7 @@ def register_snippets_api(
                 status_code=500, detail=f"Error deleting snippet: {str(e)}"
             )
 
-    @app.put("/snippets/{uuid_or_name}", tags=[tags])
+    @app.put("/snippets/{uuid_or_name}", tags=[tags], openapi_extra={"x-cli-name": "update-snippet"})
     def update_snippet(uuid_or_name: str, snippet: SnippetSchema):
         """Update an existing snippet by UUID or name.
 
@@ -355,7 +355,7 @@ def register_snippets_api(
                 status_code=500, detail=f"Error updating snippet: {str(e)}"
             )
 
-    @app.get("/search/snippets", tags=[tags])
+    @app.get("/search/snippets", tags=[tags], openapi_extra={"x-cli-name": "search-snippets"})
     def search_snippets(
         search_term: str,
         max_number_of_results: int = 5,

--- a/src/skillberry_store/fast_api/tools_api.py
+++ b/src/skillberry_store/fast_api/tools_api.py
@@ -154,7 +154,7 @@ def register_tools_api(
     """
     tool_handler = get_object_handler("tool")
 
-    @app.post("/tools/", tags=[tags])
+    @app.post("/tools/", tags=[tags], openapi_extra={"x-cli-name": "create-tool"})
     async def create_tool(
         tool: Annotated[ToolSchema, Query()],
         module: UploadFile = File(...),
@@ -260,7 +260,7 @@ def register_tools_api(
                 status_code=500, detail=f"Error creating tool: {str(e)}"
             )
 
-    @app.get("/tools/", tags=[tags])
+    @app.get("/tools/", tags=[tags], openapi_extra={"x-cli-name": "list-tools"})
     def list_tools() -> List[Dict[str, Any]]:
         """List all tools.
 
@@ -299,7 +299,7 @@ def register_tools_api(
                 detail=f"Error listing tools: {str(e)}\n{error_traceback}",
             )
 
-    @app.get("/tools/{uuid_or_name}", tags=[tags])
+    @app.get("/tools/{uuid_or_name}", tags=[tags], openapi_extra={"x-cli-name": "get-tool"})
     def get_tool(uuid_or_name: str) -> Dict[str, Any]:
         """Get a specific tool by UUID or name.
 
@@ -332,7 +332,8 @@ def register_tools_api(
             )
 
     @app.get(
-        "/tools/{uuid_or_name}/module", tags=[tags], response_class=PlainTextResponse
+        "/tools/{uuid_or_name}/module", tags=[tags], response_class=PlainTextResponse,
+        openapi_extra={"x-cli-name": "get-tool-module"}
     )
     async def get_tool_module(uuid_or_name: str) -> PlainTextResponse:
         """Get the module file content for a specific tool.
@@ -405,7 +406,7 @@ def register_tools_api(
                 status_code=500, detail=f"Error retrieving module file: {str(e)}"
             )
 
-    @app.delete("/tools/{uuid_or_name}", tags=[tags])
+    @app.delete("/tools/{uuid_or_name}", tags=[tags], openapi_extra={"x-cli-name": "delete-tool"})
     def delete_tool(uuid_or_name: str) -> Dict:
         """Delete a tool by UUID or name.
 
@@ -470,7 +471,7 @@ def register_tools_api(
                 status_code=500, detail=f"Error deleting tool: {str(e)}"
             )
 
-    @app.put("/tools/{uuid_or_name}", tags=[tags])
+    @app.put("/tools/{uuid_or_name}", tags=[tags], openapi_extra={"x-cli-name": "update-tool"})
     def update_tool(uuid_or_name: str, tool: ToolSchema) -> Dict:
         """Update an existing tool.
 
@@ -556,7 +557,7 @@ def register_tools_api(
                 status_code=500, detail=f"Error updating tool: {str(e)}"
             )
 
-    @app.post("/tools/{uuid_or_name}/execute", tags=[tags])
+    @app.post("/tools/{uuid_or_name}/execute", tags=[tags], openapi_extra={"x-cli-name": "execute-tool"})
     async def execute_tool(
         uuid_or_name: str, request: Request, parameters: Optional[Dict[str, Any]] = None
     ) -> Dict:
@@ -709,7 +710,7 @@ def register_tools_api(
                 status_code=500, detail=f"Error executing tool: {str(e)}"
             )
 
-    @app.get("/search/tools", tags=[tags])
+    @app.get("/search/tools", tags=[tags], openapi_extra={"x-cli-name": "search-tools"})
     def search_tools(
         search_term: str,
         max_number_of_results: int = 5,
@@ -801,7 +802,7 @@ def register_tools_api(
                 status_code=500, detail=f"Error searching tools: {str(e)}"
             )
 
-    @app.post("/tools/add", tags=[tags])
+    @app.post("/tools/add", tags=[tags], openapi_extra={"x-cli-name": "add-tool"})
     async def add_tool_from_python(
         tool: UploadFile = File(...),
         selected_func: Optional[str] = None,

--- a/src/skillberry_store/fast_api/tools_api.py
+++ b/src/skillberry_store/fast_api/tools_api.py
@@ -299,7 +299,9 @@ def register_tools_api(
                 detail=f"Error listing tools: {str(e)}\n{error_traceback}",
             )
 
-    @app.get("/tools/{uuid_or_name}", tags=[tags], openapi_extra={"x-cli-name": "get-tool"})
+    @app.get(
+        "/tools/{uuid_or_name}", tags=[tags], openapi_extra={"x-cli-name": "get-tool"}
+    )
     def get_tool(uuid_or_name: str) -> Dict[str, Any]:
         """Get a specific tool by UUID or name.
 
@@ -332,8 +334,10 @@ def register_tools_api(
             )
 
     @app.get(
-        "/tools/{uuid_or_name}/module", tags=[tags], response_class=PlainTextResponse,
-        openapi_extra={"x-cli-name": "get-tool-module"}
+        "/tools/{uuid_or_name}/module",
+        tags=[tags],
+        response_class=PlainTextResponse,
+        openapi_extra={"x-cli-name": "get-tool-module"},
     )
     async def get_tool_module(uuid_or_name: str) -> PlainTextResponse:
         """Get the module file content for a specific tool.
@@ -406,7 +410,11 @@ def register_tools_api(
                 status_code=500, detail=f"Error retrieving module file: {str(e)}"
             )
 
-    @app.delete("/tools/{uuid_or_name}", tags=[tags], openapi_extra={"x-cli-name": "delete-tool"})
+    @app.delete(
+        "/tools/{uuid_or_name}",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "delete-tool"},
+    )
     def delete_tool(uuid_or_name: str) -> Dict:
         """Delete a tool by UUID or name.
 
@@ -471,7 +479,11 @@ def register_tools_api(
                 status_code=500, detail=f"Error deleting tool: {str(e)}"
             )
 
-    @app.put("/tools/{uuid_or_name}", tags=[tags], openapi_extra={"x-cli-name": "update-tool"})
+    @app.put(
+        "/tools/{uuid_or_name}",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "update-tool"},
+    )
     def update_tool(uuid_or_name: str, tool: ToolSchema) -> Dict:
         """Update an existing tool.
 
@@ -557,7 +569,11 @@ def register_tools_api(
                 status_code=500, detail=f"Error updating tool: {str(e)}"
             )
 
-    @app.post("/tools/{uuid_or_name}/execute", tags=[tags], openapi_extra={"x-cli-name": "execute-tool"})
+    @app.post(
+        "/tools/{uuid_or_name}/execute",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "execute-tool"},
+    )
     async def execute_tool(
         uuid_or_name: str, request: Request, parameters: Optional[Dict[str, Any]] = None
     ) -> Dict:

--- a/src/skillberry_store/fast_api/vmcp_api.py
+++ b/src/skillberry_store/fast_api/vmcp_api.py
@@ -92,7 +92,11 @@ def register_vmcp_api(
     # Store in app state for cleanup access
     app.state.vmcp_server_manager = vmcp_server_manager
 
-    @app.post("/vmcp_servers/", tags=[tags], openapi_extra={"x-cli-name": "create-vmcp-server"})
+    @app.post(
+        "/vmcp_servers/",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "create-vmcp-server"},
+    )
     def create_vmcp_server(vmcp: Annotated[VmcpSchema, Query()], request: Request):
         """Create a new virtual MCP server.
 
@@ -236,7 +240,9 @@ def register_vmcp_api(
                 status_code=500, detail=f"Error creating vmcp server: {error_msg}"
             )
 
-    @app.get("/vmcp_servers/", tags=[tags], openapi_extra={"x-cli-name": "list-vmcp-servers"})
+    @app.get(
+        "/vmcp_servers/", tags=[tags], openapi_extra={"x-cli-name": "list-vmcp-servers"}
+    )
     def list_vmcp_servers():
         """List all virtual MCP servers.
 
@@ -316,7 +322,11 @@ def register_vmcp_api(
                 status_code=500, detail=f"Error listing vmcp servers: {str(e)}"
             )
 
-    @app.get("/vmcp_servers/{uuid_or_name}", tags=[tags], openapi_extra={"x-cli-name": "get-vmcp-server"})
+    @app.get(
+        "/vmcp_servers/{uuid_or_name}",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "get-vmcp-server"},
+    )
     def get_vmcp_server(uuid_or_name: str):
         """Get a specific virtual MCP server by UUID or name.
 
@@ -364,7 +374,11 @@ def register_vmcp_api(
                 status_code=500, detail=f"Error retrieving vmcp server: {str(e)}"
             )
 
-    @app.delete("/vmcp_servers/{uuid_or_name}", tags=[tags], openapi_extra={"x-cli-name": "delete-vmcp-server"})
+    @app.delete(
+        "/vmcp_servers/{uuid_or_name}",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "delete-vmcp-server"},
+    )
     def delete_vmcp_server(uuid_or_name: str):
         """Delete a virtual MCP server by UUID or name.
 
@@ -432,7 +446,11 @@ def register_vmcp_api(
                 status_code=500, detail=f"Error deleting vmcp server: {str(e)}"
             )
 
-    @app.put("/vmcp_servers/{uuid_or_name}", tags=[tags], openapi_extra={"x-cli-name": "update-vmcp-server"})
+    @app.put(
+        "/vmcp_servers/{uuid_or_name}",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "update-vmcp-server"},
+    )
     def update_vmcp_server(
         uuid_or_name: str, vmcp: Annotated[VmcpSchema, Query()], request: Request
     ):
@@ -556,7 +574,11 @@ def register_vmcp_api(
                 status_code=500, detail=f"Error updating vmcp server: {str(e)}"
             )
 
-    @app.post("/vmcp_servers/{uuid_or_name}/start", tags=[tags], openapi_extra={"x-cli-name": "start-vmcp-server"})
+    @app.post(
+        "/vmcp_servers/{uuid_or_name}/start",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "start-vmcp-server"},
+    )
     def start_vmcp_server(uuid_or_name: str, request: Request):
         """Start or restart a virtual MCP server.
 
@@ -656,7 +678,11 @@ def register_vmcp_api(
                 status_code=500, detail=f"Error starting vmcp server: {str(e)}"
             )
 
-    @app.get("/search/vmcp_servers", tags=[tags], openapi_extra={"x-cli-name": "search-vmcp-servers"})
+    @app.get(
+        "/search/vmcp_servers",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "search-vmcp-servers"},
+    )
     def search_vmcp_servers(
         search_term: str,
         max_number_of_results: int = 5,

--- a/src/skillberry_store/fast_api/vmcp_api.py
+++ b/src/skillberry_store/fast_api/vmcp_api.py
@@ -92,7 +92,7 @@ def register_vmcp_api(
     # Store in app state for cleanup access
     app.state.vmcp_server_manager = vmcp_server_manager
 
-    @app.post("/vmcp_servers/", tags=[tags])
+    @app.post("/vmcp_servers/", tags=[tags], openapi_extra={"x-cli-name": "create-vmcp-server"})
     def create_vmcp_server(vmcp: Annotated[VmcpSchema, Query()], request: Request):
         """Create a new virtual MCP server.
 
@@ -236,7 +236,7 @@ def register_vmcp_api(
                 status_code=500, detail=f"Error creating vmcp server: {error_msg}"
             )
 
-    @app.get("/vmcp_servers/", tags=[tags])
+    @app.get("/vmcp_servers/", tags=[tags], openapi_extra={"x-cli-name": "list-vmcp-servers"})
     def list_vmcp_servers():
         """List all virtual MCP servers.
 
@@ -316,7 +316,7 @@ def register_vmcp_api(
                 status_code=500, detail=f"Error listing vmcp servers: {str(e)}"
             )
 
-    @app.get("/vmcp_servers/{uuid_or_name}", tags=[tags])
+    @app.get("/vmcp_servers/{uuid_or_name}", tags=[tags], openapi_extra={"x-cli-name": "get-vmcp-server"})
     def get_vmcp_server(uuid_or_name: str):
         """Get a specific virtual MCP server by UUID or name.
 
@@ -364,7 +364,7 @@ def register_vmcp_api(
                 status_code=500, detail=f"Error retrieving vmcp server: {str(e)}"
             )
 
-    @app.delete("/vmcp_servers/{uuid_or_name}", tags=[tags])
+    @app.delete("/vmcp_servers/{uuid_or_name}", tags=[tags], openapi_extra={"x-cli-name": "delete-vmcp-server"})
     def delete_vmcp_server(uuid_or_name: str):
         """Delete a virtual MCP server by UUID or name.
 
@@ -432,7 +432,7 @@ def register_vmcp_api(
                 status_code=500, detail=f"Error deleting vmcp server: {str(e)}"
             )
 
-    @app.put("/vmcp_servers/{uuid_or_name}", tags=[tags])
+    @app.put("/vmcp_servers/{uuid_or_name}", tags=[tags], openapi_extra={"x-cli-name": "update-vmcp-server"})
     def update_vmcp_server(
         uuid_or_name: str, vmcp: Annotated[VmcpSchema, Query()], request: Request
     ):
@@ -556,7 +556,7 @@ def register_vmcp_api(
                 status_code=500, detail=f"Error updating vmcp server: {str(e)}"
             )
 
-    @app.post("/vmcp_servers/{uuid_or_name}/start", tags=[tags])
+    @app.post("/vmcp_servers/{uuid_or_name}/start", tags=[tags], openapi_extra={"x-cli-name": "start-vmcp-server"})
     def start_vmcp_server(uuid_or_name: str, request: Request):
         """Start or restart a virtual MCP server.
 
@@ -656,7 +656,7 @@ def register_vmcp_api(
                 status_code=500, detail=f"Error starting vmcp server: {str(e)}"
             )
 
-    @app.get("/search/vmcp_servers", tags=[tags])
+    @app.get("/search/vmcp_servers", tags=[tags], openapi_extra={"x-cli-name": "search-vmcp-servers"})
     def search_vmcp_servers(
         search_term: str,
         max_number_of_results: int = 5,

--- a/src/skillberry_store/fast_api/vnfs_api.py
+++ b/src/skillberry_store/fast_api/vnfs_api.py
@@ -48,7 +48,11 @@ def register_vnfs_api(
     vnfs_server_manager = VirtualNfsServerManager(sts_url=sts_url, app=app)
     app.state.vnfs_server_manager = vnfs_server_manager
 
-    @app.post("/vnfs_servers/", tags=[tags], openapi_extra={"x-cli-name": "create-vnfs-server"})
+    @app.post(
+        "/vnfs_servers/",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "create-vnfs-server"},
+    )
     def create_vnfs_server(vnfs: Annotated[VnfsSchema, Query()], request: Request):
         """Create and start a new vNFS endpoint."""
         logger.info(f"Request to create vnfs server: {vnfs.name}")
@@ -110,7 +114,9 @@ def register_vnfs_api(
                 status_code=500, detail=f"Error creating vNFS server: {exc}"
             )
 
-    @app.get("/vnfs_servers/", tags=[tags], openapi_extra={"x-cli-name": "list-vnfs-servers"})
+    @app.get(
+        "/vnfs_servers/", tags=[tags], openapi_extra={"x-cli-name": "list-vnfs-servers"}
+    )
     def list_vnfs_servers():
         """List all vNFS endpoints."""
         logger.info("Request to list vnfs servers")
@@ -165,7 +171,11 @@ def register_vnfs_api(
                 status_code=500, detail=f"Error listing vNFS servers: {exc}"
             )
 
-    @app.get("/vnfs_servers/{uuid_or_name}", tags=[tags], openapi_extra={"x-cli-name": "get-vnfs-server"})
+    @app.get(
+        "/vnfs_servers/{uuid_or_name}",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "get-vnfs-server"},
+    )
     def get_vnfs_server(uuid_or_name: str):
         """Get a specific vNFS endpoint by UUID or name."""
         logger.info(f"Request to get vnfs server: {uuid_or_name}")
@@ -205,7 +215,11 @@ def register_vnfs_api(
                 status_code=500, detail=f"Error retrieving vNFS server: {exc}"
             )
 
-    @app.delete("/vnfs_servers/{uuid_or_name}", tags=[tags], openapi_extra={"x-cli-name": "delete-vnfs-server"})
+    @app.delete(
+        "/vnfs_servers/{uuid_or_name}",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "delete-vnfs-server"},
+    )
     def delete_vnfs_server(uuid_or_name: str):
         """Stop and delete a vNFS endpoint by UUID or name."""
         logger.info(f"Request to delete vnfs server: {uuid_or_name}")
@@ -261,7 +275,11 @@ def register_vnfs_api(
                 status_code=500, detail=f"Error deleting vNFS server: {exc}"
             )
 
-    @app.put("/vnfs_servers/{uuid_or_name}", tags=[tags], openapi_extra={"x-cli-name": "update-vnfs-server"})
+    @app.put(
+        "/vnfs_servers/{uuid_or_name}",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "update-vnfs-server"},
+    )
     def update_vnfs_server(
         uuid_or_name: str, vnfs: Annotated[VnfsSchema, Query()], request: Request
     ):
@@ -338,7 +356,11 @@ def register_vnfs_api(
                 status_code=500, detail=f"Error updating vNFS server: {exc}"
             )
 
-    @app.post("/vnfs_servers/{uuid_or_name}/start", tags=[tags], openapi_extra={"x-cli-name": "start-vnfs-server"})
+    @app.post(
+        "/vnfs_servers/{uuid_or_name}/start",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "start-vnfs-server"},
+    )
     def start_vnfs_server(uuid_or_name: str, request: Request):
         """Start or restart a vNFS endpoint."""
         logger.info(f"Request to start vnfs server: {uuid_or_name}")
@@ -385,7 +407,11 @@ def register_vnfs_api(
                 status_code=500, detail=f"Error starting vNFS server: {exc}"
             )
 
-    @app.get("/search/vnfs_servers", tags=[tags], openapi_extra={"x-cli-name": "search-vnfs-servers"})
+    @app.get(
+        "/search/vnfs_servers",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "search-vnfs-servers"},
+    )
     def search_vnfs_servers(
         search_term: str,
         max_number_of_results: int = 5,

--- a/src/skillberry_store/fast_api/vnfs_api.py
+++ b/src/skillberry_store/fast_api/vnfs_api.py
@@ -48,7 +48,7 @@ def register_vnfs_api(
     vnfs_server_manager = VirtualNfsServerManager(sts_url=sts_url, app=app)
     app.state.vnfs_server_manager = vnfs_server_manager
 
-    @app.post("/vnfs_servers/", tags=[tags])
+    @app.post("/vnfs_servers/", tags=[tags], openapi_extra={"x-cli-name": "create-vnfs-server"})
     def create_vnfs_server(vnfs: Annotated[VnfsSchema, Query()], request: Request):
         """Create and start a new vNFS endpoint."""
         logger.info(f"Request to create vnfs server: {vnfs.name}")
@@ -110,7 +110,7 @@ def register_vnfs_api(
                 status_code=500, detail=f"Error creating vNFS server: {exc}"
             )
 
-    @app.get("/vnfs_servers/", tags=[tags])
+    @app.get("/vnfs_servers/", tags=[tags], openapi_extra={"x-cli-name": "list-vnfs-servers"})
     def list_vnfs_servers():
         """List all vNFS endpoints."""
         logger.info("Request to list vnfs servers")
@@ -165,7 +165,7 @@ def register_vnfs_api(
                 status_code=500, detail=f"Error listing vNFS servers: {exc}"
             )
 
-    @app.get("/vnfs_servers/{uuid_or_name}", tags=[tags])
+    @app.get("/vnfs_servers/{uuid_or_name}", tags=[tags], openapi_extra={"x-cli-name": "get-vnfs-server"})
     def get_vnfs_server(uuid_or_name: str):
         """Get a specific vNFS endpoint by UUID or name."""
         logger.info(f"Request to get vnfs server: {uuid_or_name}")
@@ -205,7 +205,7 @@ def register_vnfs_api(
                 status_code=500, detail=f"Error retrieving vNFS server: {exc}"
             )
 
-    @app.delete("/vnfs_servers/{uuid_or_name}", tags=[tags])
+    @app.delete("/vnfs_servers/{uuid_or_name}", tags=[tags], openapi_extra={"x-cli-name": "delete-vnfs-server"})
     def delete_vnfs_server(uuid_or_name: str):
         """Stop and delete a vNFS endpoint by UUID or name."""
         logger.info(f"Request to delete vnfs server: {uuid_or_name}")
@@ -261,7 +261,7 @@ def register_vnfs_api(
                 status_code=500, detail=f"Error deleting vNFS server: {exc}"
             )
 
-    @app.put("/vnfs_servers/{uuid_or_name}", tags=[tags])
+    @app.put("/vnfs_servers/{uuid_or_name}", tags=[tags], openapi_extra={"x-cli-name": "update-vnfs-server"})
     def update_vnfs_server(
         uuid_or_name: str, vnfs: Annotated[VnfsSchema, Query()], request: Request
     ):
@@ -338,7 +338,7 @@ def register_vnfs_api(
                 status_code=500, detail=f"Error updating vNFS server: {exc}"
             )
 
-    @app.post("/vnfs_servers/{uuid_or_name}/start", tags=[tags])
+    @app.post("/vnfs_servers/{uuid_or_name}/start", tags=[tags], openapi_extra={"x-cli-name": "start-vnfs-server"})
     def start_vnfs_server(uuid_or_name: str, request: Request):
         """Start or restart a vNFS endpoint."""
         logger.info(f"Request to start vnfs server: {uuid_or_name}")
@@ -385,7 +385,7 @@ def register_vnfs_api(
                 status_code=500, detail=f"Error starting vNFS server: {exc}"
             )
 
-    @app.get("/search/vnfs_servers", tags=[tags])
+    @app.get("/search/vnfs_servers", tags=[tags], openapi_extra={"x-cli-name": "search-vnfs-servers"})
     def search_vnfs_servers(
         search_term: str,
         max_number_of_results: int = 5,


### PR DESCRIPTION
Closes #149.

## Summary
- Add `openapi_extra={"x-cli-name": "..."}` to all 39 FastAPI route decorators across `admin_api.py`, `skills_api.py`, `snippets_api.py`, `tools_api.py`, `vmcp_api.py`, and `vnfs_api.py`
- Restish uses the `x-cli-name` OpenAPI extension to override the auto-generated operationId-based command names
- Result: `update-vmcp-server` instead of `update-vmcp-server-vmcp-servers-name-put`

## Testing
Verified locally by restarting the server, clearing `~/.cache/restish/sbs.cbor`, and running `sbs --help`.

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>