### PR TITLE
Remove USE_LLM_SVCS Configuration

### DIFF
--- a/.mk/local.mk
+++ b/.mk/local.mk
@@ -6,9 +6,7 @@ ASSET_NAME := skillberry-store
 ACRONYM := SBS
 DESC_NAME := Skillberry Store service
 VERSION_LOCATION := src/skillberry_store/fast_api/git_version.py
-# Set to 1 if this asset is using LLM services - watsonx or RITS
-USE_LLM_SVCS := 0
-# Set these two below even if your asset is not a service - it allows execution control 
+# Set these two below even if your asset is not a service - it allows execution control
 SERVICE_ENTRY_MODULE := skillberry_store.main
 SERVICE_NAME := $(ASSET_NAME)
 # If this asset is an actual network service, define these service settings as well


### PR DESCRIPTION
# Remove USE_LLM_SVCS Configuration

## Overview
This pull request removes the `USE_LLM_SVCS` configuration flag along with hard coded Env vars across the skillberry project repositories as part of the OSS (Open Source Software) cleanup effort.
