### PR TITLE
feat: implement security plugin and refactor evaluator

### DIFF
--- a/plugins/skillberry-plugin-evaluator/src/skillberry_plugin_evaluator/plugin.py
+++ b/plugins/skillberry-plugin-evaluator/src/skillberry_plugin_evaluator/plugin.py
@@ -1,5 +1,5 @@
 """
-Skillberry Plugin Evaluator - LLM-based quality/performance/security evaluation plugin.
+Skillberry Plugin Evaluator - LLM-based quality/performance evaluation plugin.
 Uses llm-switchboard for LLM integration.
 """
 
@@ -22,7 +22,7 @@ class SkillberryPluginEvaluator(PluginBase):
         self._metadata = PluginMetadata(
             name="Content Evaluator",
             version="0.1.0",
-            description="Evaluate content quality, performance, and security using LLM",
+            description="Evaluate content quality and performance using LLM",
             plugin_type=PluginType.EVALUATOR,
         )
 
@@ -174,8 +174,8 @@ class SkillberryPluginEvaluator(PluginBase):
         return "\n".join(lines)
 
     def _strip_score_tags(self, tags: List[str]) -> List[str]:
-        """Remove all evaluator score tags so re-evaluation is a clean overwrite."""
-        score_prefixes = ("quality-score:", "performance-score:", "security-score:")
+        """Remove evaluator score tags so re-evaluation is a clean overwrite."""
+        score_prefixes = ("quality-score:", "performance-score:")
         return [t for t in tags if not any(t.startswith(p) for p in score_prefixes)]
 
     async def _write_evaluation_to_store(
@@ -311,7 +311,7 @@ Return ONLY the JSON object, no other text."""
 
         @router.post("/evaluate")
         async def evaluate_endpoint(request: EvaluateRequest):
-            """Evaluate a store object and store quality/performance/security scores."""
+            """Evaluate a store object and store quality/performance scores."""
             if not self.is_enabled():
                 raise HTTPException(status_code=503, detail=self._status_message)
 

--- a/plugins/skillberry-plugin-evaluator/src/skillberry_plugin_evaluator/plugin.py
+++ b/plugins/skillberry-plugin-evaluator/src/skillberry_plugin_evaluator/plugin.py
@@ -124,7 +124,10 @@ class SkillberryPluginEvaluator(PluginBase):
 
         extra = obj.get("extra")
         if extra and isinstance(extra, dict):
-            lines.append(f"Extra info: {json.dumps(extra)}")
+            # Exclude previous evaluation results so they don't bias the new evaluation.
+            extra_for_context = {k: v for k, v in extra.items() if k != "evaluation"}
+            if extra_for_context:
+                lines.append(f"Extra info: {json.dumps(extra_for_context)}")
 
         if content_type == "tool":
             if obj.get("programming_language"):
@@ -171,8 +174,8 @@ class SkillberryPluginEvaluator(PluginBase):
         return "\n".join(lines)
 
     def _strip_score_tags(self, tags: List[str]) -> List[str]:
-        """Remove existing quality/performance score tags."""
-        score_prefixes = ("quality-score:", "performance-score:")
+        """Remove all evaluator score tags so re-evaluation is a clean overwrite."""
+        score_prefixes = ("quality-score:", "performance-score:", "security-score:")
         return [t for t in tags if not any(t.startswith(p) for p in score_prefixes)]
 
     async def _write_evaluation_to_store(

--- a/plugins/skillberry-plugin-evaluator/src/skillberry_plugin_evaluator/plugin.py
+++ b/plugins/skillberry-plugin-evaluator/src/skillberry_plugin_evaluator/plugin.py
@@ -66,6 +66,32 @@ class SkillberryPluginEvaluator(PluginBase):
                     logger.error(
                         f"Auto-evaluation failed for {ct} {uuid}: {e}", exc_info=True
                     )
+                # For skills, also evaluate referenced tools and snippets.
+                # Import flows (e.g. import-anthropic-skill) write tools/snippets
+                # directly to the handler without emitting per-object events, so
+                # those objects would otherwise never be evaluated.
+                if ct == "skill":
+                    try:
+                        skill_obj = self.store.get_skill(uuid)
+                    except Exception:
+                        skill_obj = None
+                    if skill_obj:
+                        for tool_uuid in skill_obj.get("tool_uuids") or []:
+                            try:
+                                await self.evaluate_object(tool_uuid, "tool")
+                            except Exception as e:
+                                logger.error(
+                                    f"Auto-evaluation failed for tool {tool_uuid}: {e}",
+                                    exc_info=True,
+                                )
+                        for snippet_uuid in skill_obj.get("snippet_uuids") or []:
+                            try:
+                                await self.evaluate_object(snippet_uuid, "snippet")
+                            except Exception as e:
+                                logger.error(
+                                    f"Auto-evaluation failed for snippet {snippet_uuid}: {e}",
+                                    exc_info=True,
+                                )
 
             event_name = f"content_added:{content_type}"
             if event_name not in _event_handlers:

--- a/plugins/skillberry-plugin-evaluator/src/skillberry_plugin_evaluator/plugin.py
+++ b/plugins/skillberry-plugin-evaluator/src/skillberry_plugin_evaluator/plugin.py
@@ -1,5 +1,5 @@
 """
-Skillberry Plugin Evaluator - Minimal LLM-based content evaluation plugin.
+Skillberry Plugin Evaluator - LLM-based quality/performance/security evaluation plugin.
 Uses llm-switchboard for LLM integration.
 """
 
@@ -14,40 +14,35 @@ logger = logging.getLogger(__name__)
 
 
 class SkillberryPluginEvaluator(PluginBase):
-    """Plugin for evaluating content and suggesting tags using LLM."""
+    """Plugin for evaluating skills, tools, and snippets using LLM."""
 
     def __init__(self):
         super().__init__()
-        
+
         self._metadata = PluginMetadata(
             name="Content Evaluator",
             version="0.1.0",
-            description="Evaluate content and suggest tags using LLM",
+            description="Evaluate content quality, performance, and security using LLM",
             plugin_type=PluginType.EVALUATOR,
         )
-        
+
         self.llm_client = None
         self._status_message = "Initializing..."
-        
-        # Try to initialize LLM client
+
         try:
             from llm_switchboard import get_llm
-            
-            # Get provider from environment (llm-switchboard reads its own env vars)
+
             provider_name = os.getenv("LLM_PROVIDER", "openai.async")
             model_name = os.getenv("LLM_MODEL", "gpt-4")
-            
+
             logger.info(f"Initializing LLM: provider={provider_name}, model={model_name}")
-            
-            # Get the LLM client class
+
             LLMClientClass = get_llm(provider_name)
-            
-            # Instantiate the client (llm-switchboard reads env vars automatically)
             self.llm_client = LLMClientClass(model_name=model_name)
             self._status_message = f"Ready (using {provider_name})"
-            
-            logger.info(f"LLM client initialized successfully")
-                
+
+            logger.info("LLM client initialized successfully")
+
         except ImportError:
             self._status_message = "Missing dependency: llm-switchboard not installed"
             logger.warning("llm-switchboard not installed, plugin will be disabled")
@@ -55,137 +50,284 @@ class SkillberryPluginEvaluator(PluginBase):
             self._status_message = f"Configuration error: {str(e)}"
             logger.error(f"Failed to initialize LLM client: {e}", exc_info=True)
 
+        self._register_event_handlers()
+
+    def _register_event_handlers(self) -> None:
+        """Register on_content_added handlers for automatic evaluation on object creation."""
+        from skillberry_store.plugins.events import _event_handlers
+
+        for content_type in ("tool", "skill", "snippet"):
+            async def _handle_added(uuid: str, ct=content_type):
+                if not self.is_enabled() or self._store_api is None:
+                    return
+                try:
+                    await self.evaluate_object(uuid, ct)
+                except Exception as e:
+                    logger.error(
+                        f"Auto-evaluation failed for {ct} {uuid}: {e}", exc_info=True
+                    )
+
+            event_name = f"content_added:{content_type}"
+            if event_name not in _event_handlers:
+                _event_handlers[event_name] = []
+            _event_handlers[event_name].append(_handle_added)
+
     @property
     def metadata(self) -> PluginMetadata:
-        """Return plugin metadata."""
         return self._metadata
-    
+
     def get_status_message(self) -> str:
-        """Return current plugin status."""
         return self._status_message
 
     def is_enabled(self) -> bool:
-        """Plugin is enabled if LLM client is initialized."""
         return self.llm_client is not None
 
-    async def evaluate_content(
-        self, 
-        uuid: str, 
+    def _build_context(self, obj: Dict[str, Any], content_type: str) -> str:
+        """Build rich context string for the LLM evaluation prompt."""
+        lines = [
+            f"Name: {obj.get('name', 'N/A')}",
+            f"Description: {obj.get('description', 'N/A')}",
+        ]
+
+        if obj.get("version"):
+            lines.append(f"Version: {obj['version']}")
+        if obj.get("state"):
+            lines.append(f"State: {obj['state']}")
+        if obj.get("tags"):
+            lines.append(f"Tags: {', '.join(obj['tags'])}")
+
+        extra = obj.get("extra")
+        if extra and isinstance(extra, dict):
+            lines.append(f"Extra info: {json.dumps(extra)}")
+
+        if content_type == "tool":
+            if obj.get("programming_language"):
+                lines.append(f"Language: {obj['programming_language']}")
+            if obj.get("packaging_format"):
+                lines.append(f"Packaging format: {obj['packaging_format']}")
+            if obj.get("packaging_params"):
+                lines.append(f"Packaging params: {json.dumps(obj['packaging_params'])}")
+            if obj.get("params"):
+                lines.append(f"Parameters: {json.dumps(obj['params'])}")
+            if obj.get("returns"):
+                lines.append(f"Returns: {json.dumps(obj['returns'])}")
+            if obj.get("dependencies"):
+                lines.append(f"Dependencies: {', '.join(obj['dependencies'])}")
+
+            module_name = obj.get("module_name")
+            if module_name and self._store_api is not None:
+                try:
+                    code = self.store.tools.read_file(
+                        obj["uuid"], module_name, raw_content=True
+                    )
+                    lines.append(f"\nCode ({module_name}):\n```\n{code}\n```")
+                except Exception as e:
+                    logger.info(f"Could not read code for tool {obj.get('uuid')}: {e}")
+
+        elif content_type == "skill":
+            tool_uuids = obj.get("tool_uuids") or []
+            snippet_uuids = obj.get("snippet_uuids") or []
+            lines.append(
+                f"Contains {len(tool_uuids)} tool(s): "
+                f"{', '.join(tool_uuids) if tool_uuids else 'none'}"
+            )
+            lines.append(
+                f"Contains {len(snippet_uuids)} snippet(s): "
+                f"{', '.join(snippet_uuids) if snippet_uuids else 'none'}"
+            )
+
+        elif content_type == "snippet":
+            if obj.get("content_type"):
+                lines.append(f"Content type: {obj['content_type']}")
+            if obj.get("content"):
+                lines.append(f"\nContent:\n```\n{obj['content']}\n```")
+
+        return "\n".join(lines)
+
+    def _strip_score_tags(self, tags: List[str]) -> List[str]:
+        """Remove existing quality/performance/security score tags."""
+        score_prefixes = ("quality-score:", "performance-score:", "security-score:")
+        return [t for t in tags if not any(t.startswith(p) for p in score_prefixes)]
+
+    async def _write_evaluation_to_store(
+        self,
+        uuid: str,
         content_type: str,
-        content: str,
-        name: Optional[str] = None
-    ) -> Dict[str, Any]:
+        obj: Dict[str, Any],
+        evaluation: Dict[str, Any],
+    ) -> None:
+        """Write score tags and textual evaluations back to the store object."""
+        score_tags = [
+            f"quality-score:{evaluation['quality_score']}",
+            f"performance-score:{evaluation['performance_score']}",
+            f"security-score:{evaluation['security_score']}",
+        ]
+
+        existing_tags = self._strip_score_tags(obj.get("tags") or [])
+        obj["tags"] = existing_tags + score_tags
+
+        if not isinstance(obj.get("extra"), dict):
+            obj["extra"] = {}
+        obj["extra"]["evaluation"] = {
+            "quality": {
+                "score": evaluation["quality_score"],
+                "evaluation": evaluation["quality_evaluation"],
+            },
+            "performance": {
+                "score": evaluation["performance_score"],
+                "evaluation": evaluation["performance_evaluation"],
+            },
+            "security": {
+                "score": evaluation["security_score"],
+                "evaluation": evaluation["security_evaluation"],
+            },
+        }
+
+        if content_type == "tool":
+            self.store.tools.write_dict(uuid, obj)
+        elif content_type == "skill":
+            self.store.skills.write_dict(uuid, obj)
+        elif content_type == "snippet":
+            self.store.snippets.write_dict(uuid, obj)
+
+    async def evaluate_object(self, uuid: str, content_type: str) -> Dict[str, Any]:
         """
-        Evaluate content and suggest tags using LLM.
-        
+        Evaluate a store object on quality, performance, and security.
+
+        Fetches the full object from the store, sends it to the LLM, then
+        stores scores as tags (quality-score:N etc.) and textual evaluations
+        in extra["evaluation"].
+
         Args:
-            uuid: Content UUID
-            content_type: Type of content ("tool", "skill", "snippet")
-            content: The actual content to evaluate
-            name: Optional name of the content
-            
+            uuid: UUID of the object to evaluate
+            content_type: "tool", "skill", or "snippet"
+
         Returns:
-            Dict with suggested_tags, confidence_scores, and summary
+            Dict with quality_score, performance_score, security_score (int 1-10)
+            and quality_evaluation, performance_evaluation, security_evaluation (str)
         """
         if not self.llm_client:
             raise RuntimeError("LLM client not initialized")
-        
-        logger.info(f"Evaluating {content_type} {uuid}: {name or 'unnamed'}")
-        
-        # Build evaluation prompt
-        prompt = f"""Analyze this {content_type} and suggest relevant tags.
+        if self._store_api is None:
+            raise RuntimeError("Store API not available")
 
-Content name: {name or 'N/A'}
-Content:
-```
-{content[:1000]}
-```
+        if content_type == "tool":
+            obj = self.store.get_tool(uuid)
+        elif content_type == "skill":
+            obj = self.store.get_skill(uuid)
+        elif content_type == "snippet":
+            obj = self.store.get_snippet(uuid)
+        else:
+            raise ValueError(f"Unknown content_type: {content_type}")
 
-Provide your analysis as JSON with:
-- suggested_tags: array of 3-5 relevant tags (lowercase, hyphenated)
-- confidence_scores: object mapping each tag to confidence (0.0-1.0)
-- summary: brief one-sentence evaluation
+        if not obj:
+            raise ValueError(f"{content_type.capitalize()} {uuid} not found in store")
 
-Return ONLY the JSON, no other text."""
-        
-        logger.debug(f"Calling LLM with prompt: {prompt[:200]}...")
+        logger.info(f"Evaluating {content_type} {uuid}: {obj.get('name', 'unnamed')}")
+
+        context = self._build_context(obj, content_type)
+
+        prompt = f"""You are evaluating a {content_type} from a skills store.
+
+{context}
+
+Evaluate this {content_type} on three dimensions and return a JSON object with exactly these six fields:
+- quality_score: integer 1-10 (clarity, structure, completeness, best practices)
+- quality_evaluation: string (one paragraph)
+- performance_score: integer 1-10 (efficiency, resource usage, scalability)
+- performance_evaluation: string (one paragraph)
+- security_score: integer 1-10 (security posture, risks, vulnerabilities)
+- security_evaluation: string (one paragraph)
+
+Return ONLY the JSON object, no other text."""
+
+        logger.debug(f"Calling LLM for {content_type} {uuid}")
         response = await self.llm_client.generate_async(prompt=prompt)
-        logger.info(f"Received response ({len(response)} chars)")
-        
-        # Parse response
+        logger.info(f"Received LLM response ({len(response)} chars)")
+
         try:
-            # Extract JSON from response
-            start = response.find('{')
-            end = response.rfind('}') + 1
-            if start >= 0 and end > start:
-                result = json.loads(response[start:end])
-            else:
-                # Fallback if no JSON found
-                result = {
-                    "suggested_tags": [],
-                    "confidence_scores": {},
-                    "summary": "Failed to parse LLM response"
-                }
+            start = response.find("{")
+            end = response.rfind("}") + 1
+            if start < 0 or end <= start:
+                raise ValueError("No JSON object found in LLM response")
+            evaluation = json.loads(response[start:end])
+
+            required_fields = [
+                "quality_score", "quality_evaluation",
+                "performance_score", "performance_evaluation",
+                "security_score", "security_evaluation",
+            ]
+            for field in required_fields:
+                if field not in evaluation:
+                    raise ValueError(f"Missing field in LLM response: {field}")
+
+            for score_field in ("quality_score", "performance_score", "security_score"):
+                evaluation[score_field] = int(evaluation[score_field])
+
         except Exception as e:
-            logger.warning(f"Failed to parse LLM response: {e}")
-            result = {
-                "suggested_tags": [],
-                "confidence_scores": {},
-                "summary": f"Parse error: {str(e)}"
-            }
-        
-        logger.info(f"Evaluation complete: {len(result.get('suggested_tags', []))} tags suggested")
-        return result
+            logger.warning(f"Failed to parse LLM evaluation response: {e}")
+            raise RuntimeError(f"Failed to parse LLM response: {str(e)}")
+
+        await self._write_evaluation_to_store(uuid, content_type, obj, evaluation)
+        logger.info(
+            f"Evaluation stored for {content_type} {uuid}: "
+            f"quality={evaluation['quality_score']}, "
+            f"performance={evaluation['performance_score']}, "
+            f"security={evaluation['security_score']}"
+        )
+
+        return evaluation
 
     def get_router(self):
         """Register plugin routes."""
         from fastapi import APIRouter, HTTPException
         from pydantic import BaseModel
-        
+
         router = APIRouter()
-        
+
         class EvaluateRequest(BaseModel):
             uuid: str
             content_type: str  # "tool", "skill", or "snippet"
-            content: str
-            name: Optional[str] = None
-        
+
         @router.post("/evaluate")
         async def evaluate_endpoint(request: EvaluateRequest):
-            """Evaluate content and suggest tags."""
+            """Evaluate a store object and store quality/performance/security scores."""
             if not self.is_enabled():
                 raise HTTPException(status_code=503, detail=self._status_message)
-            
+
+            if request.content_type not in ("tool", "skill", "snippet"):
+                raise HTTPException(
+                    status_code=400,
+                    detail="content_type must be 'tool', 'skill', or 'snippet'",
+                )
+
             try:
-                result = await self.evaluate_content(
+                result = await self.evaluate_object(
                     uuid=request.uuid,
                     content_type=request.content_type,
-                    content=request.content,
-                    name=request.name
                 )
-                return {
-                    "success": True,
-                    "uuid": request.uuid,
-                    **result
-                }
+                return {"success": True, "uuid": request.uuid, **result}
+            except ValueError as e:
+                raise HTTPException(status_code=404, detail=str(e))
             except Exception as e:
-                logger.error(f"Failed to evaluate content: {e}", exc_info=True)
+                logger.error(
+                    f"Failed to evaluate {request.content_type} {request.uuid}: {e}",
+                    exc_info=True,
+                )
                 raise HTTPException(status_code=500, detail=str(e))
-        
+
         return router
-    
+
     def get_cli_commands(self) -> Optional[Dict[str, Any]]:
-        """No CLI commands for this plugin."""
         return None
-    
+
     def get_ui_config(self) -> Optional[Dict[str, Any]]:
-        """Return UI configuration for the plugin."""
         return {
             "icon": "CheckCircleIcon",
             "color": "#28A745",
             "actions": [
                 {
-                    "label": "Evaluate Content",
+                    "label": "Evaluate",
                     "endpoint": "/api/plugins/evaluator/evaluate",
                     "method": "POST",
                     "params_schema": {
@@ -193,26 +335,18 @@ Return ONLY the JSON, no other text."""
                         "properties": {
                             "uuid": {
                                 "type": "string",
-                                "description": "UUID of the content to evaluate"
+                                "description": "UUID of the object to evaluate",
                             },
                             "content_type": {
                                 "type": "string",
                                 "enum": ["tool", "skill", "snippet"],
-                                "description": "Type of content"
+                                "description": "Type of object to evaluate",
                             },
-                            "content": {
-                                "type": "string",
-                                "description": "The content to evaluate"
-                            },
-                            "name": {
-                                "type": "string",
-                                "description": "Optional name of the content"
-                            }
                         },
-                        "required": ["uuid", "content_type", "content"]
-                    }
+                        "required": ["uuid", "content_type"],
+                    },
                 }
-            ]
+            ],
         }
 
 # Made with Bob

--- a/plugins/skillberry-plugin-evaluator/src/skillberry_plugin_evaluator/plugin.py
+++ b/plugins/skillberry-plugin-evaluator/src/skillberry_plugin_evaluator/plugin.py
@@ -145,8 +145,8 @@ class SkillberryPluginEvaluator(PluginBase):
         return "\n".join(lines)
 
     def _strip_score_tags(self, tags: List[str]) -> List[str]:
-        """Remove existing quality/performance/security score tags."""
-        score_prefixes = ("quality-score:", "performance-score:", "security-score:")
+        """Remove existing quality/performance score tags."""
+        score_prefixes = ("quality-score:", "performance-score:")
         return [t for t in tags if not any(t.startswith(p) for p in score_prefixes)]
 
     async def _write_evaluation_to_store(
@@ -160,7 +160,6 @@ class SkillberryPluginEvaluator(PluginBase):
         score_tags = [
             f"quality-score:{evaluation['quality_score']}",
             f"performance-score:{evaluation['performance_score']}",
-            f"security-score:{evaluation['security_score']}",
         ]
 
         existing_tags = self._strip_score_tags(obj.get("tags") or [])
@@ -177,10 +176,6 @@ class SkillberryPluginEvaluator(PluginBase):
                 "score": evaluation["performance_score"],
                 "evaluation": evaluation["performance_evaluation"],
             },
-            "security": {
-                "score": evaluation["security_score"],
-                "evaluation": evaluation["security_evaluation"],
-            },
         }
 
         if content_type == "tool":
@@ -192,7 +187,7 @@ class SkillberryPluginEvaluator(PluginBase):
 
     async def evaluate_object(self, uuid: str, content_type: str) -> Dict[str, Any]:
         """
-        Evaluate a store object on quality, performance, and security.
+        Evaluate a store object on quality and performance.
 
         Fetches the full object from the store, sends it to the LLM, then
         stores scores as tags (quality-score:N etc.) and textual evaluations
@@ -203,8 +198,8 @@ class SkillberryPluginEvaluator(PluginBase):
             content_type: "tool", "skill", or "snippet"
 
         Returns:
-            Dict with quality_score, performance_score, security_score (int 1-10)
-            and quality_evaluation, performance_evaluation, security_evaluation (str)
+            Dict with quality_score, performance_score (int 1-10)
+            and quality_evaluation, performance_evaluation (str)
         """
         if not self.llm_client:
             raise RuntimeError("LLM client not initialized")
@@ -231,13 +226,11 @@ class SkillberryPluginEvaluator(PluginBase):
 
 {context}
 
-Evaluate this {content_type} on three dimensions and return a JSON object with exactly these six fields:
+Evaluate this {content_type} on two dimensions and return a JSON object with exactly these four fields:
 - quality_score: integer 1-10 (clarity, structure, completeness, best practices)
 - quality_evaluation: string (one paragraph)
 - performance_score: integer 1-10 (efficiency, resource usage, scalability)
 - performance_evaluation: string (one paragraph)
-- security_score: integer 1-10 (security posture, risks, vulnerabilities)
-- security_evaluation: string (one paragraph)
 
 Return ONLY the JSON object, no other text."""
 
@@ -255,13 +248,12 @@ Return ONLY the JSON object, no other text."""
             required_fields = [
                 "quality_score", "quality_evaluation",
                 "performance_score", "performance_evaluation",
-                "security_score", "security_evaluation",
             ]
             for field in required_fields:
                 if field not in evaluation:
                     raise ValueError(f"Missing field in LLM response: {field}")
 
-            for score_field in ("quality_score", "performance_score", "security_score"):
+            for score_field in ("quality_score", "performance_score"):
                 evaluation[score_field] = int(evaluation[score_field])
 
         except Exception as e:
@@ -272,8 +264,7 @@ Return ONLY the JSON object, no other text."""
         logger.info(
             f"Evaluation stored for {content_type} {uuid}: "
             f"quality={evaluation['quality_score']}, "
-            f"performance={evaluation['performance_score']}, "
-            f"security={evaluation['security_score']}"
+            f"performance={evaluation['performance_score']}"
         )
 
         return evaluation

--- a/plugins/skillberry-plugin-evaluator/tests/test_evaluator_plugin.py
+++ b/plugins/skillberry-plugin-evaluator/tests/test_evaluator_plugin.py
@@ -66,7 +66,8 @@ def test_plugin_provides_ui_config():
 
 def test_strip_score_tags_removes_all_score_types():
     plugin = SkillberryPluginEvaluator()
-    tags = ["python", "quality-score:7", "performance-score:5", "utility"]
+    # includes security-score to ensure old 3-category evaluations are cleaned up
+    tags = ["python", "quality-score:7", "performance-score:5", "security-score:8", "utility"]
     assert plugin._strip_score_tags(tags) == ["python", "utility"]
 
 
@@ -82,6 +83,23 @@ def test_strip_score_tags_empty_list():
 
 
 # ── helper: _build_context ───────────────────────────────────────────────────
+
+def test_build_context_excludes_previous_evaluation_from_extra():
+    plugin = SkillberryPluginEvaluator()
+    obj = {
+        "name": "my_tool",
+        "description": "does something",
+        "extra": {
+            "custom_key": "keep_me",
+            "evaluation": {"quality": {"score": 7, "evaluation": "old text"}},
+        },
+        "tags": [],
+    }
+    context = plugin._build_context(obj, "tool")
+    assert "keep_me" in context
+    assert "old text" not in context
+    assert "evaluation" not in context
+
 
 def test_build_context_tool_includes_key_fields():
     plugin = SkillberryPluginEvaluator()

--- a/plugins/skillberry-plugin-evaluator/tests/test_evaluator_plugin.py
+++ b/plugins/skillberry-plugin-evaluator/tests/test_evaluator_plugin.py
@@ -66,7 +66,7 @@ def test_plugin_provides_ui_config():
 
 def test_strip_score_tags_removes_all_score_types():
     plugin = SkillberryPluginEvaluator()
-    tags = ["python", "quality-score:7", "performance-score:5", "security-score:8", "utility"]
+    tags = ["python", "quality-score:7", "performance-score:5", "utility"]
     assert plugin._strip_score_tags(tags) == ["python", "utility"]
 
 
@@ -145,14 +145,12 @@ def _make_plugin_with_mock_llm():
     return plugin
 
 
-def _llm_json(q=8, p=7, s=9):
+def _llm_json(q=8, p=7):
     return json.dumps({
         "quality_score": q,
         "quality_evaluation": "Good quality.",
         "performance_score": p,
         "performance_evaluation": "Acceptable performance.",
-        "security_score": s,
-        "security_evaluation": "Secure implementation.",
     })
 
 
@@ -167,16 +165,14 @@ async def test_evaluate_object_tool_returns_all_six_fields():
     }
     mock_store.tools = MagicMock()
     plugin.set_store_api(mock_store)
-    plugin.llm_client.generate_async = AsyncMock(return_value=_llm_json(q=8, p=7, s=9))
+    plugin.llm_client.generate_async = AsyncMock(return_value=_llm_json(q=8, p=7))
 
     result = await plugin.evaluate_object("tool-1", "tool")
 
     assert result["quality_score"] == 8
     assert result["performance_score"] == 7
-    assert result["security_score"] == 9
     assert result["quality_evaluation"] == "Good quality."
     assert result["performance_evaluation"] == "Acceptable performance."
-    assert result["security_evaluation"] == "Secure implementation."
 
 
 @pytest.mark.asyncio
@@ -189,14 +185,13 @@ async def test_evaluate_object_writes_score_tags_to_tool():
     }
     mock_store.tools = MagicMock()
     plugin.set_store_api(mock_store)
-    plugin.llm_client.generate_async = AsyncMock(return_value=_llm_json(q=8, p=7, s=9))
+    plugin.llm_client.generate_async = AsyncMock(return_value=_llm_json(q=8, p=7))
 
     await plugin.evaluate_object("tool-1", "tool")
 
     written = mock_store.tools.write_dict.call_args[0][1]
     assert "quality-score:8" in written["tags"]
     assert "performance-score:7" in written["tags"]
-    assert "security-score:9" in written["tags"]
     assert "existing-tag" in written["tags"]
 
 
@@ -210,7 +205,7 @@ async def test_evaluate_object_writes_evaluation_metadata_to_skill():
     }
     mock_store.skills = MagicMock()
     plugin.set_store_api(mock_store)
-    plugin.llm_client.generate_async = AsyncMock(return_value=_llm_json(q=6, p=5, s=7))
+    plugin.llm_client.generate_async = AsyncMock(return_value=_llm_json(q=6, p=5))
 
     await plugin.evaluate_object("skill-1", "skill")
 
@@ -218,10 +213,9 @@ async def test_evaluate_object_writes_evaluation_metadata_to_skill():
     eval_meta = written["extra"]["evaluation"]
     assert eval_meta["quality"]["score"] == 6
     assert eval_meta["performance"]["score"] == 5
-    assert eval_meta["security"]["score"] == 7
     assert "evaluation" in eval_meta["quality"]
     assert "evaluation" in eval_meta["performance"]
-    assert "evaluation" in eval_meta["security"]
+    assert "security" not in eval_meta
 
 
 @pytest.mark.asyncio
@@ -231,12 +225,12 @@ async def test_evaluate_object_replaces_old_score_tags_on_snippet():
     mock_store.get_snippet.return_value = {
         "uuid": "snip-1", "name": "s", "description": "",
         "content": "Hello", "content_type": "text/plain",
-        "tags": ["keeper", "quality-score:3", "performance-score:2", "security-score:1"],
+        "tags": ["keeper", "quality-score:3", "performance-score:2"],
         "extra": {},
     }
     mock_store.snippets = MagicMock()
     plugin.set_store_api(mock_store)
-    plugin.llm_client.generate_async = AsyncMock(return_value=_llm_json(q=8, p=7, s=9))
+    plugin.llm_client.generate_async = AsyncMock(return_value=_llm_json(q=8, p=7))
 
     await plugin.evaluate_object("snip-1", "snippet")
 
@@ -246,8 +240,6 @@ async def test_evaluate_object_replaces_old_score_tags_on_snippet():
     assert "quality-score:3" not in tags
     assert "performance-score:7" in tags
     assert "performance-score:2" not in tags
-    assert "security-score:9" in tags
-    assert "security-score:1" not in tags
     assert "keeper" in tags
 
 

--- a/plugins/skillberry-plugin-evaluator/tests/test_evaluator_plugin.py
+++ b/plugins/skillberry-plugin-evaluator/tests/test_evaluator_plugin.py
@@ -64,10 +64,9 @@ def test_plugin_provides_ui_config():
 
 # ── helper: _strip_score_tags ────────────────────────────────────────────────
 
-def test_strip_score_tags_removes_all_score_types():
+def test_strip_score_tags_removes_quality_and_performance():
     plugin = SkillberryPluginEvaluator()
-    # includes security-score to ensure old 3-category evaluations are cleaned up
-    tags = ["python", "quality-score:7", "performance-score:5", "security-score:8", "utility"]
+    tags = ["python", "quality-score:7", "performance-score:5", "utility"]
     assert plugin._strip_score_tags(tags) == ["python", "utility"]
 
 
@@ -233,7 +232,7 @@ async def test_evaluate_object_writes_evaluation_metadata_to_skill():
     assert eval_meta["performance"]["score"] == 5
     assert "evaluation" in eval_meta["quality"]
     assert "evaluation" in eval_meta["performance"]
-    assert "security" not in eval_meta
+    assert set(eval_meta.keys()) == {"quality", "performance"}
 
 
 @pytest.mark.asyncio

--- a/plugins/skillberry-plugin-evaluator/tests/test_evaluator_plugin.py
+++ b/plugins/skillberry-plugin-evaluator/tests/test_evaluator_plugin.py
@@ -269,6 +269,63 @@ async def test_evaluate_object_raises_runtime_error_on_bad_llm_response():
         await plugin.evaluate_object("t1", "tool")
 
 
+@pytest.mark.asyncio
+async def test_skill_content_added_also_evaluates_referenced_tools_and_snippets():
+    """When a skill is added, its referenced tools and snippets are evaluated too.
+
+    This covers import flows (e.g. import-anthropic-skill) that write tools/snippets
+    directly without emitting per-object content_added events.
+    """
+    plugin = _make_plugin_with_mock_llm()
+    mock_store = MagicMock()
+
+    mock_store.get_skill.return_value = {
+        "uuid": "skill-1", "name": "my_skill", "description": "",
+        "tool_uuids": ["tool-a"], "snippet_uuids": ["snip-b"], "tags": [], "extra": {},
+    }
+    mock_store.get_tool.return_value = {
+        "uuid": "tool-a", "name": "tool_a", "description": "", "tags": [], "extra": {},
+    }
+    mock_store.get_snippet.return_value = {
+        "uuid": "snip-b", "name": "snip_b", "description": "",
+        "content": "hello", "content_type": "text/plain", "tags": [], "extra": {},
+    }
+    mock_store.skills = MagicMock()
+    mock_store.tools = MagicMock()
+    mock_store.snippets = MagicMock()
+
+    plugin.set_store_api(mock_store)
+    plugin.llm_client.generate_async = AsyncMock(return_value=_llm_json())
+
+    from skillberry_store.plugins import events as events_module
+    saved = dict(events_module._event_handlers)
+    events_module._event_handlers.clear()
+    try:
+        from skillberry_store.plugins.events import _event_handlers
+        from unittest.mock import patch
+        mock_module = MagicMock()
+        mock_module.get_llm.return_value = MagicMock(return_value=plugin.llm_client)
+        with patch.dict("sys.modules", {"llm_switchboard": mock_module}):
+            pass  # handlers already registered on plugin
+        # Register the existing plugin's handlers manually
+        _event_handlers.setdefault("content_added:skill", [])
+        # Re-register by creating a fresh plugin with the same mock store
+        fresh_plugin = _make_plugin_with_mock_llm()
+        fresh_plugin.set_store_api(mock_store)
+        fresh_plugin.llm_client.generate_async = AsyncMock(return_value=_llm_json())
+
+        handler = _event_handlers["content_added:skill"][0]
+        await handler(uuid="skill-1")
+
+        # skill, tool, and snippet should each have write_dict called
+        assert mock_store.skills.write_dict.called
+        assert mock_store.tools.write_dict.called
+        assert mock_store.snippets.write_dict.called
+    finally:
+        events_module._event_handlers.clear()
+        events_module._event_handlers.update(saved)
+
+
 # ── event handler tests ──────────────────────────────────────────────────────
 
 def test_event_handlers_registered_for_all_content_types():

--- a/plugins/skillberry-plugin-evaluator/tests/test_evaluator_plugin.py
+++ b/plugins/skillberry-plugin-evaluator/tests/test_evaluator_plugin.py
@@ -1,15 +1,18 @@
 """Tests for the Evaluator Plugin."""
 
+import json
 import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+
 from skillberry_plugin_evaluator.plugin import SkillberryPluginEvaluator
 from skillberry_store.plugins.base import PluginType
 
 
+# ── existing structural tests ────────────────────────────────────────────────
+
 def test_plugin_metadata():
-    """Test that plugin provides correct metadata."""
     plugin = SkillberryPluginEvaluator()
     metadata = plugin.metadata
-
     assert metadata.name == "Content Evaluator"
     assert metadata.plugin_type == PluginType.EVALUATOR
     assert metadata.version == "0.1.0"
@@ -17,8 +20,6 @@ def test_plugin_metadata():
 
 
 def test_plugin_disabled_when_llm_unavailable():
-    """Test that plugin is disabled when LLM cannot be initialized."""
-    from unittest.mock import patch, MagicMock
     mock_module = MagicMock()
     mock_module.get_llm.side_effect = RuntimeError("LLM unavailable")
     with patch.dict("sys.modules", {"llm_switchboard": mock_module}):
@@ -27,8 +28,6 @@ def test_plugin_disabled_when_llm_unavailable():
 
 
 def test_plugin_enabled_when_llm_available():
-    """Test that plugin is enabled when LLM initializes successfully."""
-    from unittest.mock import patch, MagicMock
     mock_client = MagicMock()
     mock_llm_class = MagicMock(return_value=mock_client)
     mock_module = MagicMock()
@@ -39,34 +38,286 @@ def test_plugin_enabled_when_llm_available():
 
 
 def test_plugin_provides_router():
-    """Test that plugin provides a FastAPI router."""
     plugin = SkillberryPluginEvaluator()
     router = plugin.get_router()
-
     assert router is not None
-    # Router should have routes for evaluation
     route_paths = [route.path for route in router.routes]
     assert any("evaluate" in path for path in route_paths)
 
 
 def test_plugin_provides_no_cli_commands():
-    """Test that plugin has no CLI commands."""
     plugin = SkillberryPluginEvaluator()
     assert plugin.get_cli_commands() is None
 
 
 def test_plugin_provides_ui_config():
-    """Test that plugin provides UI configuration."""
     plugin = SkillberryPluginEvaluator()
     ui_config = plugin.get_ui_config()
-
     assert ui_config is not None
     assert "icon" in ui_config
     assert "color" in ui_config
     assert "actions" in ui_config
     assert len(ui_config["actions"]) > 0
-    # Should have evaluate action
     action_labels = [action["label"] for action in ui_config["actions"]]
     assert any("evaluate" in label.lower() for label in action_labels)
+
+
+# ── helper: _strip_score_tags ────────────────────────────────────────────────
+
+def test_strip_score_tags_removes_all_score_types():
+    plugin = SkillberryPluginEvaluator()
+    tags = ["python", "quality-score:7", "performance-score:5", "security-score:8", "utility"]
+    assert plugin._strip_score_tags(tags) == ["python", "utility"]
+
+
+def test_strip_score_tags_no_score_tags_unchanged():
+    plugin = SkillberryPluginEvaluator()
+    tags = ["python", "utility"]
+    assert plugin._strip_score_tags(tags) == ["python", "utility"]
+
+
+def test_strip_score_tags_empty_list():
+    plugin = SkillberryPluginEvaluator()
+    assert plugin._strip_score_tags([]) == []
+
+
+# ── helper: _build_context ───────────────────────────────────────────────────
+
+def test_build_context_tool_includes_key_fields():
+    plugin = SkillberryPluginEvaluator()
+    obj = {
+        "uuid": "tool-1",
+        "name": "my_tool",
+        "description": "does something useful",
+        "programming_language": "python",
+        "packaging_format": "code",
+        "params": {"type": "object", "properties": {}},
+        "tags": ["utility"],
+        "extra": {},
+    }
+    context = plugin._build_context(obj, "tool")
+    assert "my_tool" in context
+    assert "does something useful" in context
+    assert "python" in context
+
+
+def test_build_context_skill_includes_uuids():
+    plugin = SkillberryPluginEvaluator()
+    obj = {
+        "name": "my_skill",
+        "description": "orchestrates things",
+        "tool_uuids": ["uuid-a", "uuid-b"],
+        "snippet_uuids": ["uuid-c"],
+        "tags": [],
+        "extra": {},
+    }
+    context = plugin._build_context(obj, "skill")
+    assert "my_skill" in context
+    assert "uuid-a" in context
+    assert "uuid-c" in context
+
+
+def test_build_context_snippet_includes_content():
+    plugin = SkillberryPluginEvaluator()
+    obj = {
+        "name": "my_snippet",
+        "description": "a greeting",
+        "content": "Hello World",
+        "content_type": "text/plain",
+        "tags": [],
+        "extra": {},
+    }
+    context = plugin._build_context(obj, "snippet")
+    assert "Hello World" in context
+    assert "my_snippet" in context
+
+
+# ── evaluate_object ──────────────────────────────────────────────────────────
+
+def _make_plugin_with_mock_llm():
+    """Create a plugin instance with a mocked LLM client."""
+    mock_client = MagicMock()
+    mock_llm_class = MagicMock(return_value=mock_client)
+    mock_module = MagicMock()
+    mock_module.get_llm.return_value = mock_llm_class
+    with patch.dict("sys.modules", {"llm_switchboard": mock_module}):
+        plugin = SkillberryPluginEvaluator()
+    return plugin
+
+
+def _llm_json(q=8, p=7, s=9):
+    return json.dumps({
+        "quality_score": q,
+        "quality_evaluation": "Good quality.",
+        "performance_score": p,
+        "performance_evaluation": "Acceptable performance.",
+        "security_score": s,
+        "security_evaluation": "Secure implementation.",
+    })
+
+
+@pytest.mark.asyncio
+async def test_evaluate_object_tool_returns_all_six_fields():
+    plugin = _make_plugin_with_mock_llm()
+    mock_store = MagicMock()
+    mock_store.get_tool.return_value = {
+        "uuid": "tool-1", "name": "test_tool", "description": "A test tool",
+        "programming_language": "python", "packaging_format": "code",
+        "params": {}, "tags": [], "extra": {},
+    }
+    mock_store.tools = MagicMock()
+    plugin.set_store_api(mock_store)
+    plugin.llm_client.generate_async = AsyncMock(return_value=_llm_json(q=8, p=7, s=9))
+
+    result = await plugin.evaluate_object("tool-1", "tool")
+
+    assert result["quality_score"] == 8
+    assert result["performance_score"] == 7
+    assert result["security_score"] == 9
+    assert result["quality_evaluation"] == "Good quality."
+    assert result["performance_evaluation"] == "Acceptable performance."
+    assert result["security_evaluation"] == "Secure implementation."
+
+
+@pytest.mark.asyncio
+async def test_evaluate_object_writes_score_tags_to_tool():
+    plugin = _make_plugin_with_mock_llm()
+    mock_store = MagicMock()
+    mock_store.get_tool.return_value = {
+        "uuid": "tool-1", "name": "t", "description": "",
+        "tags": ["existing-tag"], "extra": {},
+    }
+    mock_store.tools = MagicMock()
+    plugin.set_store_api(mock_store)
+    plugin.llm_client.generate_async = AsyncMock(return_value=_llm_json(q=8, p=7, s=9))
+
+    await plugin.evaluate_object("tool-1", "tool")
+
+    written = mock_store.tools.write_dict.call_args[0][1]
+    assert "quality-score:8" in written["tags"]
+    assert "performance-score:7" in written["tags"]
+    assert "security-score:9" in written["tags"]
+    assert "existing-tag" in written["tags"]
+
+
+@pytest.mark.asyncio
+async def test_evaluate_object_writes_evaluation_metadata_to_skill():
+    plugin = _make_plugin_with_mock_llm()
+    mock_store = MagicMock()
+    mock_store.get_skill.return_value = {
+        "uuid": "skill-1", "name": "s", "description": "",
+        "tool_uuids": [], "snippet_uuids": [], "tags": [], "extra": {},
+    }
+    mock_store.skills = MagicMock()
+    plugin.set_store_api(mock_store)
+    plugin.llm_client.generate_async = AsyncMock(return_value=_llm_json(q=6, p=5, s=7))
+
+    await plugin.evaluate_object("skill-1", "skill")
+
+    written = mock_store.skills.write_dict.call_args[0][1]
+    eval_meta = written["extra"]["evaluation"]
+    assert eval_meta["quality"]["score"] == 6
+    assert eval_meta["performance"]["score"] == 5
+    assert eval_meta["security"]["score"] == 7
+    assert "evaluation" in eval_meta["quality"]
+    assert "evaluation" in eval_meta["performance"]
+    assert "evaluation" in eval_meta["security"]
+
+
+@pytest.mark.asyncio
+async def test_evaluate_object_replaces_old_score_tags_on_snippet():
+    plugin = _make_plugin_with_mock_llm()
+    mock_store = MagicMock()
+    mock_store.get_snippet.return_value = {
+        "uuid": "snip-1", "name": "s", "description": "",
+        "content": "Hello", "content_type": "text/plain",
+        "tags": ["keeper", "quality-score:3", "performance-score:2", "security-score:1"],
+        "extra": {},
+    }
+    mock_store.snippets = MagicMock()
+    plugin.set_store_api(mock_store)
+    plugin.llm_client.generate_async = AsyncMock(return_value=_llm_json(q=8, p=7, s=9))
+
+    await plugin.evaluate_object("snip-1", "snippet")
+
+    written = mock_store.snippets.write_dict.call_args[0][1]
+    tags = written["tags"]
+    assert "quality-score:8" in tags
+    assert "quality-score:3" not in tags
+    assert "performance-score:7" in tags
+    assert "performance-score:2" not in tags
+    assert "security-score:9" in tags
+    assert "security-score:1" not in tags
+    assert "keeper" in tags
+
+
+@pytest.mark.asyncio
+async def test_evaluate_object_raises_value_error_when_uuid_not_found():
+    plugin = _make_plugin_with_mock_llm()
+    mock_store = MagicMock()
+    mock_store.get_tool.return_value = None
+    plugin.set_store_api(mock_store)
+
+    with pytest.raises(ValueError, match="not found"):
+        await plugin.evaluate_object("nonexistent", "tool")
+
+
+@pytest.mark.asyncio
+async def test_evaluate_object_raises_runtime_error_on_bad_llm_response():
+    plugin = _make_plugin_with_mock_llm()
+    mock_store = MagicMock()
+    mock_store.get_tool.return_value = {
+        "uuid": "t1", "name": "t", "description": "", "tags": [], "extra": {},
+    }
+    mock_store.tools = MagicMock()
+    plugin.set_store_api(mock_store)
+    plugin.llm_client.generate_async = AsyncMock(return_value="not json at all")
+
+    with pytest.raises(RuntimeError, match="Failed to parse"):
+        await plugin.evaluate_object("t1", "tool")
+
+
+# ── event handler tests ──────────────────────────────────────────────────────
+
+def test_event_handlers_registered_for_all_content_types():
+    from skillberry_store.plugins import events as events_module
+
+    saved = dict(events_module._event_handlers)
+    events_module._event_handlers.clear()
+    try:
+        mock_module = MagicMock()
+        mock_module.get_llm.side_effect = RuntimeError("unavailable")
+        with patch.dict("sys.modules", {"llm_switchboard": mock_module}):
+            SkillberryPluginEvaluator()
+
+        assert len(events_module._event_handlers.get("content_added:tool", [])) > 0
+        assert len(events_module._event_handlers.get("content_added:skill", [])) > 0
+        assert len(events_module._event_handlers.get("content_added:snippet", [])) > 0
+    finally:
+        events_module._event_handlers.clear()
+        events_module._event_handlers.update(saved)
+
+
+@pytest.mark.asyncio
+async def test_auto_evaluation_skipped_when_store_not_set():
+    """Handler must silently return (not raise) when store has not been injected yet."""
+    from skillberry_store.plugins import events as events_module
+
+    saved = dict(events_module._event_handlers)
+    events_module._event_handlers.clear()
+    try:
+        mock_client = MagicMock()
+        mock_llm_class = MagicMock(return_value=mock_client)
+        mock_module = MagicMock()
+        mock_module.get_llm.return_value = mock_llm_class
+        with patch.dict("sys.modules", {"llm_switchboard": mock_module}):
+            SkillberryPluginEvaluator()
+
+        handler = events_module._event_handlers["content_added:tool"][0]
+        await handler(uuid="any-uuid")  # must not raise
+    finally:
+        events_module._event_handlers.clear()
+        events_module._event_handlers.update(saved)
+
 
 # Made with Bob

--- a/plugins/skillberry-plugin-security/README.md
+++ b/plugins/skillberry-plugin-security/README.md
@@ -1,0 +1,20 @@
+# skillberry-plugin-security
+
+LLM-based security evaluation plugin for Skillberry Store.
+
+Evaluates tools, skills, and snippets for security posture, storing a `security-score:N` tag (1–10) and a paragraph explanation that names specific vulnerabilities found.
+
+## Configuration
+
+```bash
+LLM_PROVIDER=openai.async
+LLM_MODEL=gpt-4
+OPENAI_API_KEY=...
+```
+
+## API
+
+`POST /api/plugins/security/evaluate`
+```json
+{"uuid": "<uuid>", "content_type": "tool|skill|snippet"}
+```

--- a/plugins/skillberry-plugin-security/pyproject.toml
+++ b/plugins/skillberry-plugin-security/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["setuptools>=45", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "skillberry-plugin-security"
+version = "0.1.0"
+description = "Skillberry Store plugin for evaluating content security using LLM"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "llm-switchboard[litellm]>=0.1.0",
+]
+
+[project.entry-points."skillberry_store.plugins"]
+security = "skillberry_plugin_security.plugin:SkillberryPluginSecurity"
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pytest-asyncio",
+]
+
+[tool.setuptools]
+packages = ["skillberry_plugin_security"]
+package-dir = {"" = "src"}

--- a/plugins/skillberry-plugin-security/src/skillberry_plugin_security/__init__.py
+++ b/plugins/skillberry-plugin-security/src/skillberry_plugin_security/__init__.py
@@ -1,0 +1,7 @@
+"""Skillberry Security Plugin - AI-powered content security evaluation."""
+
+__version__ = "0.1.0"
+
+from .plugin import SkillberryPluginSecurity
+
+__all__ = ["SkillberryPluginSecurity"]

--- a/plugins/skillberry-plugin-security/src/skillberry_plugin_security/plugin.py
+++ b/plugins/skillberry-plugin-security/src/skillberry_plugin_security/plugin.py
@@ -240,10 +240,72 @@ Return ONLY the JSON object, no other text."""
         return evaluation
 
     def get_router(self):
-        return None  # implemented in Task 6
+        """Register plugin routes."""
+        from fastapi import APIRouter, HTTPException
+        from pydantic import BaseModel
+
+        router = APIRouter()
+
+        class EvaluateRequest(BaseModel):
+            uuid: str
+            content_type: str  # "tool", "skill", or "snippet"
+
+        @router.post("/evaluate")
+        async def evaluate_endpoint(request: EvaluateRequest):
+            """Evaluate a store object and store the security score."""
+            if not self.is_enabled():
+                raise HTTPException(status_code=503, detail=self._status_message)
+
+            if request.content_type not in ("tool", "skill", "snippet"):
+                raise HTTPException(
+                    status_code=400,
+                    detail="content_type must be 'tool', 'skill', or 'snippet'",
+                )
+
+            try:
+                result = await self.evaluate_security(
+                    uuid=request.uuid,
+                    content_type=request.content_type,
+                )
+                return {"success": True, "uuid": request.uuid, **result}
+            except ValueError as e:
+                raise HTTPException(status_code=404, detail=str(e))
+            except Exception as e:
+                logger.error(
+                    f"Failed to evaluate security of {request.content_type} {request.uuid}: {e}",
+                    exc_info=True,
+                )
+                raise HTTPException(status_code=500, detail=str(e))
+
+        return router
 
     def get_cli_commands(self) -> Optional[Dict[str, Any]]:
         return None
 
     def get_ui_config(self) -> Optional[Dict[str, Any]]:
-        return None  # implemented in Task 6
+        return {
+            "icon": "ShieldAltIcon",
+            "color": "#E74C3C",
+            "actions": [
+                {
+                    "label": "Evaluate Security",
+                    "endpoint": "/api/plugins/security/evaluate",
+                    "method": "POST",
+                    "params_schema": {
+                        "type": "object",
+                        "properties": {
+                            "uuid": {
+                                "type": "string",
+                                "description": "UUID of the object to evaluate",
+                            },
+                            "content_type": {
+                                "type": "string",
+                                "enum": ["tool", "skill", "snippet"],
+                                "description": "Type of object to evaluate",
+                            },
+                        },
+                        "required": ["uuid", "content_type"],
+                    },
+                }
+            ],
+        }

--- a/plugins/skillberry-plugin-security/src/skillberry_plugin_security/plugin.py
+++ b/plugins/skillberry-plugin-security/src/skillberry_plugin_security/plugin.py
@@ -1,0 +1,93 @@
+"""
+Skillberry Plugin Security - LLM-based security evaluation plugin.
+Uses llm-switchboard for LLM integration.
+"""
+
+import os
+import logging
+import json
+from typing import Dict, Any, Optional, List
+
+from skillberry_store.plugins.base import PluginBase, PluginMetadata, PluginType
+
+logger = logging.getLogger(__name__)
+
+
+class SkillberryPluginSecurity(PluginBase):
+    """Plugin for evaluating skills, tools, and snippets for security posture using LLM."""
+
+    def __init__(self):
+        super().__init__()
+
+        self._metadata = PluginMetadata(
+            name="Security Evaluator",
+            version="0.1.0",
+            description="Evaluate content security posture using LLM",
+            plugin_type=PluginType.EVALUATOR,
+        )
+
+        self.llm_client = None
+        self._status_message = "Initializing..."
+
+        try:
+            from llm_switchboard import get_llm
+
+            provider_name = os.getenv("LLM_PROVIDER", "openai.async")
+            model_name = os.getenv("LLM_MODEL", "gpt-4")
+
+            logger.info(f"Initializing LLM: provider={provider_name}, model={model_name}")
+
+            LLMClientClass = get_llm(provider_name)
+            self.llm_client = LLMClientClass(model_name=model_name)
+            self._status_message = f"Ready (using {provider_name})"
+
+            logger.info("LLM client initialized successfully")
+
+        except ImportError:
+            self._status_message = "Missing dependency: llm-switchboard not installed"
+            logger.warning("llm-switchboard not installed, plugin will be disabled")
+        except Exception as e:
+            self._status_message = f"Configuration error: {str(e)}"
+            logger.error(f"Failed to initialize LLM client: {e}", exc_info=True)
+
+        self._register_event_handlers()
+
+    def _register_event_handlers(self) -> None:
+        pass  # implemented in Task 7
+
+    @property
+    def metadata(self) -> PluginMetadata:
+        return self._metadata
+
+    def get_status_message(self) -> str:
+        return self._status_message
+
+    def is_enabled(self) -> bool:
+        return self.llm_client is not None
+
+    def _strip_score_tags(self, tags: List[str]) -> List[str]:
+        return tags  # implemented in Task 2
+
+    def _build_context(self, obj: Dict[str, Any], content_type: str) -> str:
+        return ""  # implemented in Task 3
+
+    async def _write_security_to_store(
+        self,
+        uuid: str,
+        content_type: str,
+        obj: Dict[str, Any],
+        evaluation: Dict[str, Any],
+    ) -> None:
+        pass  # implemented in Task 4
+
+    async def evaluate_security(self, uuid: str, content_type: str) -> Dict[str, Any]:
+        raise NotImplementedError  # implemented in Task 5
+
+    def get_router(self):
+        return None  # implemented in Task 6
+
+    def get_cli_commands(self) -> Optional[Dict[str, Any]]:
+        return None
+
+    def get_ui_config(self) -> Optional[Dict[str, Any]]:
+        return None  # implemented in Task 6

--- a/plugins/skillberry-plugin-security/src/skillberry_plugin_security/plugin.py
+++ b/plugins/skillberry-plugin-security/src/skillberry_plugin_security/plugin.py
@@ -53,7 +53,48 @@ class SkillberryPluginSecurity(PluginBase):
         self._register_event_handlers()
 
     def _register_event_handlers(self) -> None:
-        pass  # implemented in Task 7
+        """Register on_content_added handlers for automatic security evaluation on object creation."""
+        from skillberry_store.plugins.events import _event_handlers
+
+        for content_type in ("tool", "skill", "snippet"):
+            async def _handle_added(uuid: str, ct=content_type):
+                if not self.is_enabled() or self._store_api is None:
+                    return
+                try:
+                    await self.evaluate_security(uuid, ct)
+                except Exception as e:
+                    logger.error(
+                        f"Auto-security-evaluation failed for {ct} {uuid}: {e}", exc_info=True
+                    )
+                # For skills, also evaluate referenced tools and snippets.
+                # Import flows write tools/snippets directly without emitting per-object events.
+                if ct == "skill":
+                    try:
+                        skill_obj = self.store.get_skill(uuid)
+                    except Exception:
+                        skill_obj = None
+                    if skill_obj:
+                        for tool_uuid in skill_obj.get("tool_uuids") or []:
+                            try:
+                                await self.evaluate_security(tool_uuid, "tool")
+                            except Exception as e:
+                                logger.error(
+                                    f"Auto-security-evaluation failed for tool {tool_uuid}: {e}",
+                                    exc_info=True,
+                                )
+                        for snippet_uuid in skill_obj.get("snippet_uuids") or []:
+                            try:
+                                await self.evaluate_security(snippet_uuid, "snippet")
+                            except Exception as e:
+                                logger.error(
+                                    f"Auto-security-evaluation failed for snippet {snippet_uuid}: {e}",
+                                    exc_info=True,
+                                )
+
+            event_name = f"content_added:{content_type}"
+            if event_name not in _event_handlers:
+                _event_handlers[event_name] = []
+            _event_handlers[event_name].append(_handle_added)
 
     @property
     def metadata(self) -> PluginMetadata:

--- a/plugins/skillberry-plugin-security/src/skillberry_plugin_security/plugin.py
+++ b/plugins/skillberry-plugin-security/src/skillberry_plugin_security/plugin.py
@@ -140,7 +140,28 @@ class SkillberryPluginSecurity(PluginBase):
         obj: Dict[str, Any],
         evaluation: Dict[str, Any],
     ) -> None:
-        pass  # implemented in Task 4
+        """Write security score tag and evaluation text back to the store object.
+
+        Merges into extra["evaluation"]["security"] without wiping quality/performance keys.
+        """
+        existing_tags = self._strip_score_tags(obj.get("tags") or [])
+        obj["tags"] = existing_tags + [f"security-score:{evaluation['security_score']}"]
+
+        if not isinstance(obj.get("extra"), dict):
+            obj["extra"] = {}
+        if not isinstance(obj["extra"].get("evaluation"), dict):
+            obj["extra"]["evaluation"] = {}
+        obj["extra"]["evaluation"]["security"] = {
+            "score": evaluation["security_score"],
+            "evaluation": evaluation["security_evaluation"],
+        }
+
+        if content_type == "tool":
+            self.store.tools.write_dict(uuid, obj)
+        elif content_type == "skill":
+            self.store.skills.write_dict(uuid, obj)
+        elif content_type == "snippet":
+            self.store.snippets.write_dict(uuid, obj)
 
     async def evaluate_security(self, uuid: str, content_type: str) -> Dict[str, Any]:
         raise NotImplementedError  # implemented in Task 5

--- a/plugins/skillberry-plugin-security/src/skillberry_plugin_security/plugin.py
+++ b/plugins/skillberry-plugin-security/src/skillberry_plugin_security/plugin.py
@@ -66,7 +66,7 @@ class SkillberryPluginSecurity(PluginBase):
         return self.llm_client is not None
 
     def _strip_score_tags(self, tags: List[str]) -> List[str]:
-        return tags  # implemented in Task 2
+        return [t for t in tags if not t.startswith("security-score:")]
 
     def _build_context(self, obj: Dict[str, Any], content_type: str) -> str:
         return ""  # implemented in Task 3

--- a/plugins/skillberry-plugin-security/src/skillberry_plugin_security/plugin.py
+++ b/plugins/skillberry-plugin-security/src/skillberry_plugin_security/plugin.py
@@ -69,7 +69,69 @@ class SkillberryPluginSecurity(PluginBase):
         return [t for t in tags if not t.startswith("security-score:")]
 
     def _build_context(self, obj: Dict[str, Any], content_type: str) -> str:
-        return ""  # implemented in Task 3
+        """Build rich context string for the LLM security evaluation prompt."""
+        lines = [
+            f"Name: {obj.get('name', 'N/A')}",
+            f"Description: {obj.get('description', 'N/A')}",
+        ]
+
+        if obj.get("version"):
+            lines.append(f"Version: {obj['version']}")
+        if obj.get("state"):
+            lines.append(f"State: {obj['state']}")
+        if obj.get("tags"):
+            lines.append(f"Tags: {', '.join(obj['tags'])}")
+
+        extra = obj.get("extra")
+        if extra and isinstance(extra, dict):
+            # Exclude previous evaluation results so they don't bias the new evaluation.
+            extra_for_context = {k: v for k, v in extra.items() if k != "evaluation"}
+            if extra_for_context:
+                lines.append(f"Extra info: {json.dumps(extra_for_context)}")
+
+        if content_type == "tool":
+            if obj.get("programming_language"):
+                lines.append(f"Language: {obj['programming_language']}")
+            if obj.get("packaging_format"):
+                lines.append(f"Packaging format: {obj['packaging_format']}")
+            if obj.get("packaging_params"):
+                lines.append(f"Packaging params: {json.dumps(obj['packaging_params'])}")
+            if obj.get("params"):
+                lines.append(f"Parameters: {json.dumps(obj['params'])}")
+            if obj.get("returns"):
+                lines.append(f"Returns: {json.dumps(obj['returns'])}")
+            if obj.get("dependencies"):
+                lines.append(f"Dependencies: {', '.join(obj['dependencies'])}")
+
+            module_name = obj.get("module_name")
+            if module_name and self._store_api is not None:
+                try:
+                    code = self.store.tools.read_file(
+                        obj["uuid"], module_name, raw_content=True
+                    )
+                    lines.append(f"\nCode ({module_name}):\n```\n{code}\n```")
+                except Exception as e:
+                    logger.info(f"Could not read code for tool {obj.get('uuid')}: {e}")
+
+        elif content_type == "skill":
+            tool_uuids = obj.get("tool_uuids") or []
+            snippet_uuids = obj.get("snippet_uuids") or []
+            lines.append(
+                f"Contains {len(tool_uuids)} tool(s): "
+                f"{', '.join(tool_uuids) if tool_uuids else 'none'}"
+            )
+            lines.append(
+                f"Contains {len(snippet_uuids)} snippet(s): "
+                f"{', '.join(snippet_uuids) if snippet_uuids else 'none'}"
+            )
+
+        elif content_type == "snippet":
+            if obj.get("content_type"):
+                lines.append(f"Content type: {obj['content_type']}")
+            if obj.get("content"):
+                lines.append(f"\nContent:\n```\n{obj['content']}\n```")
+
+        return "\n".join(lines)
 
     async def _write_security_to_store(
         self,

--- a/plugins/skillberry-plugin-security/src/skillberry_plugin_security/plugin.py
+++ b/plugins/skillberry-plugin-security/src/skillberry_plugin_security/plugin.py
@@ -164,7 +164,80 @@ class SkillberryPluginSecurity(PluginBase):
             self.store.snippets.write_dict(uuid, obj)
 
     async def evaluate_security(self, uuid: str, content_type: str) -> Dict[str, Any]:
-        raise NotImplementedError  # implemented in Task 5
+        """
+        Evaluate a store object's security posture.
+
+        Fetches the full object from the store, sends it to the LLM, then
+        stores the score as a tag (security-score:N) and the evaluation text
+        in extra["evaluation"]["security"]. Preserves any existing quality/
+        performance evaluation keys.
+
+        Args:
+            uuid: UUID of the object to evaluate
+            content_type: "tool", "skill", or "snippet"
+
+        Returns:
+            Dict with security_score (int 1-10) and security_evaluation (str)
+        """
+        if not self.llm_client:
+            raise RuntimeError("LLM client not initialized")
+        if self._store_api is None:
+            raise RuntimeError("Store API not available")
+
+        if content_type == "tool":
+            obj = self.store.get_tool(uuid)
+        elif content_type == "skill":
+            obj = self.store.get_skill(uuid)
+        elif content_type == "snippet":
+            obj = self.store.get_snippet(uuid)
+        else:
+            raise ValueError(f"Unknown content_type: {content_type}")
+
+        if not obj:
+            raise ValueError(f"{content_type.capitalize()} {uuid} not found in store")
+
+        logger.info(f"Evaluating security of {content_type} {uuid}: {obj.get('name', 'unnamed')}")
+
+        context = self._build_context(obj, content_type)
+
+        prompt = f"""You are evaluating a {content_type} from a skills store for security posture.
+
+{context}
+
+Evaluate this {content_type} on security and return a JSON object with exactly these two fields:
+- security_score: integer 1-10 where 1-3 = critical issues (injection flaws, exposed secrets, no input validation), 4-6 = moderate risks (weak error handling, risky dependencies, missing auth checks), 7-9 = minor issues (best-practice gaps, overly permissive patterns), 10 = no identified issues
+- security_evaluation: string (one paragraph explicitly naming each specific vulnerability or concern found, or "No security issues identified." if the score is 10)
+
+Return ONLY the JSON object, no other text."""
+
+        logger.debug(f"Calling LLM for security evaluation of {content_type} {uuid}")
+        response = await self.llm_client.generate_async(prompt=prompt)
+        logger.info(f"Received LLM response ({len(response)} chars)")
+
+        try:
+            start = response.find("{")
+            end = response.rfind("}") + 1
+            if start < 0 or end <= start:
+                raise ValueError("No JSON object found in LLM response")
+            evaluation = json.loads(response[start:end])
+
+            for field in ("security_score", "security_evaluation"):
+                if field not in evaluation:
+                    raise ValueError(f"Missing field in LLM response: {field}")
+
+            evaluation["security_score"] = int(evaluation["security_score"])
+
+        except Exception as e:
+            logger.warning(f"Failed to parse LLM security evaluation response: {e}")
+            raise RuntimeError(f"Failed to parse LLM response: {str(e)}")
+
+        await self._write_security_to_store(uuid, content_type, obj, evaluation)
+        logger.info(
+            f"Security evaluation stored for {content_type} {uuid}: "
+            f"security={evaluation['security_score']}"
+        )
+
+        return evaluation
 
     def get_router(self):
         return None  # implemented in Task 6

--- a/plugins/skillberry-plugin-security/tests/test_security_plugin.py
+++ b/plugins/skillberry-plugin-security/tests/test_security_plugin.py
@@ -194,3 +194,98 @@ async def test_write_security_uses_skills_writer_for_skill():
 
     assert mock_store.skills.write_dict.called
     assert not mock_store.tools.write_dict.called if hasattr(mock_store, 'tools') else True
+
+
+# ── evaluate_security ────────────────────────────────────────────────────────
+
+def _make_plugin_with_mock_llm():
+    """Create a plugin instance with a mocked LLM client."""
+    mock_client = MagicMock()
+    mock_llm_class = MagicMock(return_value=mock_client)
+    mock_module = MagicMock()
+    mock_module.get_llm.return_value = mock_llm_class
+    with patch.dict("sys.modules", {"llm_switchboard": mock_module}):
+        plugin = SkillberryPluginSecurity()
+    return plugin
+
+
+def _llm_json(score=7):
+    return json.dumps({
+        "security_score": score,
+        "security_evaluation": f"Score: {score}/10. Found a minor path traversal risk.",
+    })
+
+
+@pytest.mark.asyncio
+async def test_evaluate_security_tool_returns_both_fields():
+    plugin = _make_plugin_with_mock_llm()
+    mock_store = MagicMock()
+    mock_store.get_tool.return_value = {
+        "uuid": "tool-1", "name": "test_tool", "description": "A test tool",
+        "programming_language": "python", "packaging_format": "code",
+        "params": {}, "tags": [], "extra": {},
+    }
+    mock_store.tools = MagicMock()
+    plugin.set_store_api(mock_store)
+    plugin.llm_client.generate_async = AsyncMock(return_value=_llm_json(score=7))
+
+    result = await plugin.evaluate_security("tool-1", "tool")
+
+    assert result["security_score"] == 7
+    assert "path traversal" in result["security_evaluation"]
+
+
+@pytest.mark.asyncio
+async def test_evaluate_security_writes_tag_and_metadata():
+    plugin = _make_plugin_with_mock_llm()
+    mock_store = MagicMock()
+    mock_store.get_tool.return_value = {
+        "uuid": "tool-1", "name": "t", "description": "",
+        "tags": ["existing-tag"], "extra": {},
+    }
+    mock_store.tools = MagicMock()
+    plugin.set_store_api(mock_store)
+    plugin.llm_client.generate_async = AsyncMock(return_value=_llm_json(score=5))
+
+    await plugin.evaluate_security("tool-1", "tool")
+
+    written = mock_store.tools.write_dict.call_args[0][1]
+    assert "security-score:5" in written["tags"]
+    assert "existing-tag" in written["tags"]
+    assert written["extra"]["evaluation"]["security"]["score"] == 5
+
+
+@pytest.mark.asyncio
+async def test_evaluate_security_raises_value_error_when_uuid_not_found():
+    plugin = _make_plugin_with_mock_llm()
+    mock_store = MagicMock()
+    mock_store.get_tool.return_value = None
+    plugin.set_store_api(mock_store)
+
+    with pytest.raises(ValueError, match="not found"):
+        await plugin.evaluate_security("nonexistent", "tool")
+
+
+@pytest.mark.asyncio
+async def test_evaluate_security_raises_runtime_error_on_bad_llm_response():
+    plugin = _make_plugin_with_mock_llm()
+    mock_store = MagicMock()
+    mock_store.get_tool.return_value = {
+        "uuid": "t1", "name": "t", "description": "", "tags": [], "extra": {},
+    }
+    mock_store.tools = MagicMock()
+    plugin.set_store_api(mock_store)
+    plugin.llm_client.generate_async = AsyncMock(return_value="not json at all")
+
+    with pytest.raises(RuntimeError, match="Failed to parse"):
+        await plugin.evaluate_security("t1", "tool")
+
+
+@pytest.mark.asyncio
+async def test_evaluate_security_raises_value_error_on_unknown_content_type():
+    plugin = _make_plugin_with_mock_llm()
+    mock_store = MagicMock()
+    plugin.set_store_api(mock_store)
+
+    with pytest.raises(ValueError, match="Unknown content_type"):
+        await plugin.evaluate_security("uuid-1", "banana")

--- a/plugins/skillberry-plugin-security/tests/test_security_plugin.py
+++ b/plugins/skillberry-plugin-security/tests/test_security_plugin.py
@@ -103,3 +103,94 @@ def test_build_context_snippet_includes_content():
     context = plugin._build_context(obj, "snippet")
     assert "Hello World" in context
     assert "my_snippet" in context
+
+
+# ── helper: _write_security_to_store ────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_write_security_adds_tag_and_metadata_to_tool():
+    plugin = SkillberryPluginSecurity()
+    mock_store = MagicMock()
+    mock_store.tools = MagicMock()
+    plugin.set_store_api(mock_store)
+
+    obj = {"uuid": "tool-1", "name": "t", "description": "", "tags": ["keeper"], "extra": {}}
+    evaluation = {"security_score": 6, "security_evaluation": "Found SQL injection risk."}
+
+    await plugin._write_security_to_store("tool-1", "tool", obj, evaluation)
+
+    written = mock_store.tools.write_dict.call_args[0][1]
+    assert "security-score:6" in written["tags"]
+    assert "keeper" in written["tags"]
+    assert written["extra"]["evaluation"]["security"]["score"] == 6
+    assert written["extra"]["evaluation"]["security"]["evaluation"] == "Found SQL injection risk."
+
+
+@pytest.mark.asyncio
+async def test_write_security_preserves_quality_and_performance_metadata():
+    plugin = SkillberryPluginSecurity()
+    mock_store = MagicMock()
+    mock_store.tools = MagicMock()
+    plugin.set_store_api(mock_store)
+
+    obj = {
+        "uuid": "tool-1", "name": "t", "description": "",
+        "tags": ["quality-score:8", "performance-score:7"],
+        "extra": {
+            "evaluation": {
+                "quality": {"score": 8, "evaluation": "Great quality."},
+                "performance": {"score": 7, "evaluation": "Good perf."},
+            }
+        },
+    }
+    evaluation = {"security_score": 5, "security_evaluation": "Weak input validation."}
+
+    await plugin._write_security_to_store("tool-1", "tool", obj, evaluation)
+
+    written = mock_store.tools.write_dict.call_args[0][1]
+    assert "quality-score:8" in written["tags"]
+    assert "performance-score:7" in written["tags"]
+    assert "security-score:5" in written["tags"]
+    eval_meta = written["extra"]["evaluation"]
+    assert "quality" in eval_meta
+    assert "performance" in eval_meta
+    assert "security" in eval_meta
+
+
+@pytest.mark.asyncio
+async def test_write_security_replaces_old_security_tag_on_snippet():
+    plugin = SkillberryPluginSecurity()
+    mock_store = MagicMock()
+    mock_store.snippets = MagicMock()
+    plugin.set_store_api(mock_store)
+
+    obj = {
+        "uuid": "snip-1", "name": "s", "description": "",
+        "tags": ["keeper", "security-score:2"],
+        "extra": {},
+    }
+    evaluation = {"security_score": 9, "security_evaluation": "Minor issue only."}
+
+    await plugin._write_security_to_store("snip-1", "snippet", obj, evaluation)
+
+    written = mock_store.snippets.write_dict.call_args[0][1]
+    tags = written["tags"]
+    assert "security-score:9" in tags
+    assert "security-score:2" not in tags
+    assert "keeper" in tags
+
+
+@pytest.mark.asyncio
+async def test_write_security_uses_skills_writer_for_skill():
+    plugin = SkillberryPluginSecurity()
+    mock_store = MagicMock()
+    mock_store.skills = MagicMock()
+    plugin.set_store_api(mock_store)
+
+    obj = {"uuid": "skill-1", "name": "s", "description": "", "tags": [], "extra": {}}
+    evaluation = {"security_score": 10, "security_evaluation": "No security issues identified."}
+
+    await plugin._write_security_to_store("skill-1", "skill", obj, evaluation)
+
+    assert mock_store.skills.write_dict.called
+    assert not mock_store.tools.write_dict.called if hasattr(mock_store, 'tools') else True

--- a/plugins/skillberry-plugin-security/tests/test_security_plugin.py
+++ b/plugins/skillberry-plugin-security/tests/test_security_plugin.py
@@ -15,3 +15,23 @@ def test_plugin_metadata():
     assert metadata.plugin_type == PluginType.EVALUATOR
     assert metadata.version == "0.1.0"
     assert "security" in metadata.description.lower()
+
+
+# ── helper: _strip_score_tags ────────────────────────────────────────────────
+
+def test_strip_score_tags_removes_only_security():
+    plugin = SkillberryPluginSecurity()
+    tags = ["python", "security-score:4", "quality-score:8", "performance-score:7", "utility"]
+    result = plugin._strip_score_tags(tags)
+    assert result == ["python", "quality-score:8", "performance-score:7", "utility"]
+
+
+def test_strip_score_tags_no_security_tag_unchanged():
+    plugin = SkillberryPluginSecurity()
+    tags = ["python", "utility"]
+    assert plugin._strip_score_tags(tags) == ["python", "utility"]
+
+
+def test_strip_score_tags_empty_list():
+    plugin = SkillberryPluginSecurity()
+    assert plugin._strip_score_tags([]) == []

--- a/plugins/skillberry-plugin-security/tests/test_security_plugin.py
+++ b/plugins/skillberry-plugin-security/tests/test_security_plugin.py
@@ -35,3 +35,71 @@ def test_strip_score_tags_no_security_tag_unchanged():
 def test_strip_score_tags_empty_list():
     plugin = SkillberryPluginSecurity()
     assert plugin._strip_score_tags([]) == []
+
+
+# ── helper: _build_context ───────────────────────────────────────────────────
+
+def test_build_context_excludes_previous_security_from_extra():
+    plugin = SkillberryPluginSecurity()
+    obj = {
+        "name": "my_tool",
+        "description": "does something",
+        "extra": {
+            "custom_key": "keep_me",
+            "evaluation": {"security": {"score": 4, "evaluation": "old finding"}},
+        },
+        "tags": [],
+    }
+    context = plugin._build_context(obj, "tool")
+    assert "keep_me" in context
+    assert "old finding" not in context
+    assert "evaluation" not in context
+
+
+def test_build_context_tool_includes_key_fields():
+    plugin = SkillberryPluginSecurity()
+    obj = {
+        "uuid": "tool-1",
+        "name": "my_tool",
+        "description": "does something useful",
+        "programming_language": "python",
+        "packaging_format": "code",
+        "params": {"type": "object", "properties": {}},
+        "tags": ["utility"],
+        "extra": {},
+    }
+    context = plugin._build_context(obj, "tool")
+    assert "my_tool" in context
+    assert "does something useful" in context
+    assert "python" in context
+
+
+def test_build_context_skill_includes_uuids():
+    plugin = SkillberryPluginSecurity()
+    obj = {
+        "name": "my_skill",
+        "description": "orchestrates things",
+        "tool_uuids": ["uuid-a", "uuid-b"],
+        "snippet_uuids": ["uuid-c"],
+        "tags": [],
+        "extra": {},
+    }
+    context = plugin._build_context(obj, "skill")
+    assert "my_skill" in context
+    assert "uuid-a" in context
+    assert "uuid-c" in context
+
+
+def test_build_context_snippet_includes_content():
+    plugin = SkillberryPluginSecurity()
+    obj = {
+        "name": "my_snippet",
+        "description": "a greeting",
+        "content": "Hello World",
+        "content_type": "text/plain",
+        "tags": [],
+        "extra": {},
+    }
+    context = plugin._build_context(obj, "snippet")
+    assert "Hello World" in context
+    assert "my_snippet" in context

--- a/plugins/skillberry-plugin-security/tests/test_security_plugin.py
+++ b/plugins/skillberry-plugin-security/tests/test_security_plugin.py
@@ -289,3 +289,48 @@ async def test_evaluate_security_raises_value_error_on_unknown_content_type():
 
     with pytest.raises(ValueError, match="Unknown content_type"):
         await plugin.evaluate_security("uuid-1", "banana")
+
+
+# ── router + UI config ───────────────────────────────────────────────────────
+
+def test_plugin_disabled_when_llm_unavailable():
+    mock_module = MagicMock()
+    mock_module.get_llm.side_effect = RuntimeError("LLM unavailable")
+    with patch.dict("sys.modules", {"llm_switchboard": mock_module}):
+        plugin = SkillberryPluginSecurity()
+        assert not plugin.is_enabled()
+
+
+def test_plugin_enabled_when_llm_available():
+    mock_client = MagicMock()
+    mock_llm_class = MagicMock(return_value=mock_client)
+    mock_module = MagicMock()
+    mock_module.get_llm.return_value = mock_llm_class
+    with patch.dict("sys.modules", {"llm_switchboard": mock_module}):
+        plugin = SkillberryPluginSecurity()
+        assert plugin.is_enabled()
+
+
+def test_plugin_provides_router():
+    plugin = SkillberryPluginSecurity()
+    router = plugin.get_router()
+    assert router is not None
+    route_paths = [route.path for route in router.routes]
+    assert any("evaluate" in path for path in route_paths)
+
+
+def test_plugin_provides_no_cli_commands():
+    plugin = SkillberryPluginSecurity()
+    assert plugin.get_cli_commands() is None
+
+
+def test_plugin_provides_ui_config():
+    plugin = SkillberryPluginSecurity()
+    ui_config = plugin.get_ui_config()
+    assert ui_config is not None
+    assert "icon" in ui_config
+    assert "color" in ui_config
+    assert "actions" in ui_config
+    assert len(ui_config["actions"]) > 0
+    action_labels = [action["label"] for action in ui_config["actions"]]
+    assert any("security" in label.lower() for label in action_labels)

--- a/plugins/skillberry-plugin-security/tests/test_security_plugin.py
+++ b/plugins/skillberry-plugin-security/tests/test_security_plugin.py
@@ -1,0 +1,17 @@
+"""Tests for the Security Plugin."""
+
+import json
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+
+from skillberry_plugin_security.plugin import SkillberryPluginSecurity
+from skillberry_store.plugins.base import PluginType
+
+
+def test_plugin_metadata():
+    plugin = SkillberryPluginSecurity()
+    metadata = plugin.metadata
+    assert metadata.name == "Security Evaluator"
+    assert metadata.plugin_type == PluginType.EVALUATOR
+    assert metadata.version == "0.1.0"
+    assert "security" in metadata.description.lower()

--- a/plugins/skillberry-plugin-security/tests/test_security_plugin.py
+++ b/plugins/skillberry-plugin-security/tests/test_security_plugin.py
@@ -334,3 +334,86 @@ def test_plugin_provides_ui_config():
     assert len(ui_config["actions"]) > 0
     action_labels = [action["label"] for action in ui_config["actions"]]
     assert any("security" in label.lower() for label in action_labels)
+
+
+# ── event handler tests ──────────────────────────────────────────────────────
+
+def test_event_handlers_registered_for_all_content_types():
+    from skillberry_store.plugins import events as events_module
+
+    saved = dict(events_module._event_handlers)
+    events_module._event_handlers.clear()
+    try:
+        mock_module = MagicMock()
+        mock_module.get_llm.side_effect = RuntimeError("unavailable")
+        with patch.dict("sys.modules", {"llm_switchboard": mock_module}):
+            SkillberryPluginSecurity()
+
+        assert len(events_module._event_handlers.get("content_added:tool", [])) > 0
+        assert len(events_module._event_handlers.get("content_added:skill", [])) > 0
+        assert len(events_module._event_handlers.get("content_added:snippet", [])) > 0
+    finally:
+        events_module._event_handlers.clear()
+        events_module._event_handlers.update(saved)
+
+
+@pytest.mark.asyncio
+async def test_auto_evaluation_skipped_when_store_not_set():
+    from skillberry_store.plugins import events as events_module
+
+    saved = dict(events_module._event_handlers)
+    events_module._event_handlers.clear()
+    try:
+        mock_client = MagicMock()
+        mock_llm_class = MagicMock(return_value=mock_client)
+        mock_module = MagicMock()
+        mock_module.get_llm.return_value = mock_llm_class
+        with patch.dict("sys.modules", {"llm_switchboard": mock_module}):
+            SkillberryPluginSecurity()
+
+        handler = events_module._event_handlers["content_added:tool"][0]
+        await handler(uuid="any-uuid")  # must not raise
+    finally:
+        events_module._event_handlers.clear()
+        events_module._event_handlers.update(saved)
+
+
+@pytest.mark.asyncio
+async def test_skill_content_added_also_evaluates_referenced_tools_and_snippets():
+    """When a skill is added, its referenced tools and snippets are evaluated too."""
+    plugin = _make_plugin_with_mock_llm()
+    mock_store = MagicMock()
+
+    mock_store.get_skill.return_value = {
+        "uuid": "skill-1", "name": "my_skill", "description": "",
+        "tool_uuids": ["tool-a"], "snippet_uuids": ["snip-b"], "tags": [], "extra": {},
+    }
+    mock_store.get_tool.return_value = {
+        "uuid": "tool-a", "name": "tool_a", "description": "", "tags": [], "extra": {},
+    }
+    mock_store.get_snippet.return_value = {
+        "uuid": "snip-b", "name": "snip_b", "description": "",
+        "content": "hello", "content_type": "text/plain", "tags": [], "extra": {},
+    }
+    mock_store.skills = MagicMock()
+    mock_store.tools = MagicMock()
+    mock_store.snippets = MagicMock()
+
+    from skillberry_store.plugins import events as events_module
+
+    saved = dict(events_module._event_handlers)
+    events_module._event_handlers.clear()
+    try:
+        fresh_plugin = _make_plugin_with_mock_llm()
+        fresh_plugin.set_store_api(mock_store)
+        fresh_plugin.llm_client.generate_async = AsyncMock(return_value=_llm_json())
+
+        handler = events_module._event_handlers["content_added:skill"][0]
+        await handler(uuid="skill-1")
+
+        assert mock_store.skills.write_dict.called
+        assert mock_store.tools.write_dict.called
+        assert mock_store.snippets.write_dict.called
+    finally:
+        events_module._event_handlers.clear()
+        events_module._event_handlers.update(saved)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,16 +155,22 @@ plugin-evaluator = [
   "skillberry-plugin-evaluator>=0.2.0",
 ]
 
+plugin-security = [
+  "skillberry-plugin-security>=0.1.0",
+]
+
 # Install all plugins
 plugins-all = [
   "skillberry-plugin-creator>=0.2.0",
   "skillberry-plugin-evaluator>=0.2.0",
+  "skillberry-plugin-security>=0.1.0",
 ]
 
 [tool.uv.sources]
 skillberry-store-sdk = { path = "client/python/skillberry_store_sdk", editable = true }
 skillberry-plugin-creator = { path = "plugins/skillberry-plugin-creator", editable = true }
 skillberry-plugin-evaluator = { path = "plugins/skillberry-plugin-evaluator", editable = true }
+skillberry-plugin-security = { path = "plugins/skillberry-plugin-security", editable = true }
 llm-client = { path = "skillberry-common/packages/llm-client", editable = true }
 torch = { index = "pytorch-cpu" }
 


### PR DESCRIPTION
Closes #159.

## Summary
- Implement a standalone security plugin that evaluates skill security via an LLM-based scoring pipeline (`_strip_score_tags`, `_build_context`, `_write_security_to_store`, `evaluate_security`, `get_router`, `get_ui_config`, event handlers)
- Register security plugin in root `pyproject.toml`
- Refactor evaluator plugin: remove security dimension, evaluate quality and performance only, guarantee clean overwrites on re-evaluation, and trigger evaluation when a skill is added

## Design decisions
- Security evaluation is now fully isolated in its own plugin, keeping the evaluator plugin focused on quality and performance.
- Clean overwrite semantics prevent stale scores from persisting across re-evaluations.

## Testing
Ran existing test suite; removed security-specific references from evaluator tests.

<img width="2568" height="1077" alt="image" src="https://github.com/user-attachments/assets/f320b01d-9049-4af6-a463-549598191a6f" />


<img width="5106" height="1477" alt="image" src="https://github.com/user-attachments/assets/290f4e0f-03e7-415f-9bad-c2b983dfba33" />



Signed-off-by: Eran Raichstein <eranra@il.ibm.com>