### PR TITLE
feat: non-blocking plugin events and tag prefix filtering

### DIFF
--- a/src/skillberry_store/fast_api/skills_api.py
+++ b/src/skillberry_store/fast_api/skills_api.py
@@ -173,7 +173,7 @@ def register_skills_api(
             )
 
             # Emit event for plugin hooks
-            await emit_content_added("skill", skill.uuid)
+            emit_content_added("skill", skill.uuid)
 
             return {
                 "message": f"Skill '{skill.name}' created successfully.",
@@ -313,7 +313,7 @@ def register_skills_api(
             )
 
             # Emit event for plugin hooks
-            await emit_content_deleted("skill", skill_uuid)
+            emit_content_deleted("skill", skill_uuid)
 
             return {
                 "message": f"Skill with UUID or name '{uuid_or_name}' deleted successfully."
@@ -401,7 +401,7 @@ def register_skills_api(
             )
 
             # Emit event for plugin hooks
-            await emit_content_updated("skill", skill_uuid)
+            emit_content_updated("skill", skill_uuid)
 
             return {
                 "message": f"Skill with UUID or name '{uuid_or_name}' updated successfully."

--- a/src/skillberry_store/fast_api/snippets_api.py
+++ b/src/skillberry_store/fast_api/snippets_api.py
@@ -146,7 +146,7 @@ def register_snippets_api(
             logger.info(f"Snippet '{snippet.name}' created successfully")
 
             # Emit event for plugin hooks
-            await emit_content_added("snippet", snippet.uuid)
+            emit_content_added("snippet", snippet.uuid)
 
             return {
                 "message": f"Snippet '{snippet.name}' created successfully.",
@@ -283,7 +283,7 @@ def register_snippets_api(
             )
 
             # Emit event for plugin hooks
-            await emit_content_deleted("snippet", snippet_uuid)
+            emit_content_deleted("snippet", snippet_uuid)
 
             return {
                 "message": f"Snippet with UUID or name '{uuid_or_name}' deleted successfully."
@@ -371,7 +371,7 @@ def register_snippets_api(
             )
 
             # Emit event for plugin hooks
-            await emit_content_updated("snippet", snippet_uuid)
+            emit_content_updated("snippet", snippet_uuid)
 
             return {
                 "message": f"Snippet with UUID or name '{uuid_or_name}' updated successfully."

--- a/src/skillberry_store/fast_api/tools_api.py
+++ b/src/skillberry_store/fast_api/tools_api.py
@@ -255,7 +255,7 @@ def register_tools_api(
             )
 
             # Emit event for plugin hooks
-            await emit_content_added("tool", tool.uuid)
+            emit_content_added("tool", tool.uuid)
 
             return {
                 "message": f"Tool '{tool.name}' created successfully.",
@@ -478,7 +478,7 @@ def register_tools_api(
             logger.info(f"Tool with UUID or name '{uuid_or_name}' deleted successfully")
 
             # Emit event for plugin hooks
-            await emit_content_deleted("tool", tool_uuid)
+            emit_content_deleted("tool", tool_uuid)
 
             return {
                 "message": f"Tool with UUID or name '{uuid_or_name}' deleted successfully."
@@ -573,7 +573,7 @@ def register_tools_api(
             )
 
             # Emit event for plugin hooks
-            await emit_content_updated("tool", tool_uuid)
+            emit_content_updated("tool", tool_uuid)
 
             return {
                 "message": f"Tool with UUID or name '{uuid_or_name}' updated successfully."

--- a/src/skillberry_store/plugins/events.py
+++ b/src/skillberry_store/plugins/events.py
@@ -4,6 +4,7 @@ Plugins can register handlers for content lifecycle events (added, updated, dele
 The store emits these events when content changes occur.
 """
 
+import asyncio
 from typing import Callable, Dict, List
 import logging
 
@@ -12,16 +13,20 @@ logger = logging.getLogger(__name__)
 # Global registry of event handlers
 _event_handlers: Dict[str, List[Callable]] = {}
 
+# Holds strong references to background tasks so they are not garbage-collected
+# before they complete.
+_background_tasks: set = set()
+
 
 def on_content_added(content_type: str):
     """Decorator to register handler for content addition events.
-    
+
     Usage in plugin:
         @on_content_added("tool")
         async def handle_new_tool(uuid: str):
             # Process new tool
             pass
-    
+
     Args:
         content_type: Type of content (tool, skill, snippet, etc.)
     """
@@ -36,13 +41,13 @@ def on_content_added(content_type: str):
 
 def on_content_updated(content_type: str):
     """Decorator to register handler for content update events.
-    
+
     Usage in plugin:
         @on_content_updated("tool")
         async def handle_tool_update(uuid: str):
             # Process tool update
             pass
-    
+
     Args:
         content_type: Type of content (tool, skill, snippet, etc.)
     """
@@ -57,13 +62,13 @@ def on_content_updated(content_type: str):
 
 def on_content_deleted(content_type: str):
     """Decorator to register handler for content deletion events.
-    
+
     Usage in plugin:
         @on_content_deleted("tool")
         async def handle_tool_deletion(uuid: str):
             # Process tool deletion
             pass
-    
+
     Args:
         content_type: Type of content (tool, skill, snippet, etc.)
     """
@@ -76,52 +81,58 @@ def on_content_deleted(content_type: str):
     return decorator
 
 
-async def emit_event(event_name: str, **kwargs):
-    """Emit an event to all registered handlers.
-    
-    Called by store when content lifecycle events occur.
-    Handlers are called in registration order. If a handler fails,
-    the error is logged but other handlers continue to execute.
-    
+async def _run_handler(handler: Callable, **kwargs):
+    """Run a single handler, logging any exception without propagating it."""
+    try:
+        await handler(**kwargs)
+    except Exception as e:
+        logger.error(f"Event handler failed for handler {handler.__name__}: {e}", exc_info=True)
+
+
+def emit_event(event_name: str, **kwargs):
+    """Schedule all registered handlers for an event as background tasks.
+
+    Returns immediately. Handlers run concurrently on the running event loop.
+    If a handler raises, the error is logged and other handlers still run.
+
     Args:
         event_name: Name of the event (e.g., "content_added:tool")
         **kwargs: Arguments to pass to event handlers
     """
     handlers = _event_handlers.get(event_name, [])
     for handler in handlers:
-        try:
-            await handler(**kwargs)
-        except Exception as e:
-            logger.error(f"Event handler failed for {event_name}: {e}", exc_info=True)
+        task = asyncio.create_task(_run_handler(handler, **kwargs))
+        _background_tasks.add(task)
+        task.add_done_callback(_background_tasks.discard)
 
 
-async def emit_content_added(content_type: str, uuid: str):
+def emit_content_added(content_type: str, uuid: str):
     """Convenience function to emit content_added event.
-    
+
     Args:
         content_type: Type of content (tool, skill, snippet, etc.)
         uuid: UUID of the added content
     """
-    await emit_event(f"content_added:{content_type}", uuid=uuid)
+    emit_event(f"content_added:{content_type}", uuid=uuid)
 
 
-async def emit_content_updated(content_type: str, uuid: str):
+def emit_content_updated(content_type: str, uuid: str):
     """Convenience function to emit content_updated event.
-    
+
     Args:
         content_type: Type of content (tool, skill, snippet, etc.)
         uuid: UUID of the updated content
     """
-    await emit_event(f"content_updated:{content_type}", uuid=uuid)
+    emit_event(f"content_updated:{content_type}", uuid=uuid)
 
 
-async def emit_content_deleted(content_type: str, uuid: str):
+def emit_content_deleted(content_type: str, uuid: str):
     """Convenience function to emit content_deleted event.
-    
+
     Args:
         content_type: Type of content (tool, skill, snippet, etc.)
         uuid: UUID of the deleted content
     """
-    await emit_event(f"content_deleted:{content_type}", uuid=uuid)
+    emit_event(f"content_deleted:{content_type}", uuid=uuid)
 
 # Made with Bob

--- a/src/skillberry_store/tests/plugins/test_events.py
+++ b/src/skillberry_store/tests/plugins/test_events.py
@@ -1,22 +1,23 @@
 """Tests for plugin event system."""
 
+import asyncio
 import pytest
 
 
 @pytest.mark.asyncio
 async def test_event_handler_registration():
     """Test registering event handlers with decorators."""
-    from skillberry_store.plugins.events import on_content_added, _event_handlers
-    
-    # Clear any existing handlers
+    from skillberry_store.plugins.events import on_content_added, _event_handlers, _background_tasks
+
     _event_handlers.clear()
-    
+    _background_tasks.clear()
+
     handler_called = []
-    
+
     @on_content_added("tool")
     async def handle_tool_added(uuid: str):
         handler_called.append(uuid)
-    
+
     assert "content_added:tool" in _event_handlers
     assert len(_event_handlers["content_added:tool"]) == 1
 
@@ -24,42 +25,71 @@ async def test_event_handler_registration():
 @pytest.mark.asyncio
 async def test_emit_event_calls_handlers():
     """Test that emitting events calls registered handlers."""
-    from skillberry_store.plugins.events import on_content_added, emit_event, _event_handlers
-    
+    from skillberry_store.plugins.events import on_content_added, emit_event, _event_handlers, _background_tasks
+
     _event_handlers.clear()
-    
+    _background_tasks.clear()
+
     results = []
-    
+
     @on_content_added("tool")
     async def handler1(uuid: str):
         results.append(f"handler1:{uuid}")
-    
+
     @on_content_added("tool")
     async def handler2(uuid: str):
         results.append(f"handler2:{uuid}")
-    
-    await emit_event("content_added:tool", uuid="test-uuid-123")
-    
+
+    emit_event("content_added:tool", uuid="test-uuid-123")
+    await asyncio.sleep(0)
+
     assert len(results) == 2
     assert "handler1:test-uuid-123" in results
     assert "handler2:test-uuid-123" in results
 
 
 @pytest.mark.asyncio
+async def test_emit_event_is_non_blocking():
+    """Test that emit_event returns before handlers complete."""
+    from skillberry_store.plugins.events import on_content_added, emit_event, _event_handlers, _background_tasks
+
+    _event_handlers.clear()
+    _background_tasks.clear()
+
+    completed = []
+
+    @on_content_added("tool")
+    async def slow_handler(uuid: str):
+        await asyncio.sleep(0)
+        completed.append(uuid)
+
+    emit_event("content_added:tool", uuid="non-blocking-test")
+    # Handler has NOT completed yet — emit_event returned immediately
+    assert completed == []
+
+    # Yield to let the background task run
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    assert completed == ["non-blocking-test"]
+
+
+@pytest.mark.asyncio
 async def test_emit_content_added_convenience():
     """Test convenience function for emitting content_added events."""
-    from skillberry_store.plugins.events import on_content_added, emit_content_added, _event_handlers
-    
+    from skillberry_store.plugins.events import on_content_added, emit_content_added, _event_handlers, _background_tasks
+
     _event_handlers.clear()
-    
+    _background_tasks.clear()
+
     results = []
-    
+
     @on_content_added("skill")
     async def handle_skill(uuid: str):
         results.append(uuid)
-    
-    await emit_content_added("skill", "skill-uuid-456")
-    
+
+    emit_content_added("skill", "skill-uuid-456")
+    await asyncio.sleep(0)
+
     assert len(results) == 1
     assert results[0] == "skill-uuid-456"
 
@@ -67,18 +97,20 @@ async def test_emit_content_added_convenience():
 @pytest.mark.asyncio
 async def test_emit_content_updated():
     """Test content_updated event."""
-    from skillberry_store.plugins.events import on_content_updated, emit_content_updated, _event_handlers
-    
+    from skillberry_store.plugins.events import on_content_updated, emit_content_updated, _event_handlers, _background_tasks
+
     _event_handlers.clear()
-    
+    _background_tasks.clear()
+
     results = []
-    
+
     @on_content_updated("snippet")
     async def handle_update(uuid: str):
         results.append(f"updated:{uuid}")
-    
-    await emit_content_updated("snippet", "snippet-123")
-    
+
+    emit_content_updated("snippet", "snippet-123")
+    await asyncio.sleep(0)
+
     assert len(results) == 1
     assert results[0] == "updated:snippet-123"
 
@@ -86,18 +118,20 @@ async def test_emit_content_updated():
 @pytest.mark.asyncio
 async def test_emit_content_deleted():
     """Test content_deleted event."""
-    from skillberry_store.plugins.events import on_content_deleted, emit_content_deleted, _event_handlers
-    
+    from skillberry_store.plugins.events import on_content_deleted, emit_content_deleted, _event_handlers, _background_tasks
+
     _event_handlers.clear()
-    
+    _background_tasks.clear()
+
     results = []
-    
+
     @on_content_deleted("tool")
     async def handle_delete(uuid: str):
         results.append(f"deleted:{uuid}")
-    
-    await emit_content_deleted("tool", "tool-789")
-    
+
+    emit_content_deleted("tool", "tool-789")
+    await asyncio.sleep(0)
+
     assert len(results) == 1
     assert results[0] == "deleted:tool-789"
 
@@ -106,27 +140,30 @@ async def test_emit_content_deleted():
 async def test_multiple_content_types():
     """Test handlers for different content types don't interfere."""
     from skillberry_store.plugins.events import (
-        on_content_added, 
+        on_content_added,
         emit_content_added,
-        _event_handlers
+        _event_handlers,
+        _background_tasks,
     )
-    
+
     _event_handlers.clear()
-    
+    _background_tasks.clear()
+
     tool_results = []
     skill_results = []
-    
+
     @on_content_added("tool")
     async def handle_tool(uuid: str):
         tool_results.append(uuid)
-    
+
     @on_content_added("skill")
     async def handle_skill(uuid: str):
         skill_results.append(uuid)
-    
-    await emit_content_added("tool", "tool-1")
-    await emit_content_added("skill", "skill-1")
-    
+
+    emit_content_added("tool", "tool-1")
+    emit_content_added("skill", "skill-1")
+    await asyncio.sleep(0)
+
     assert tool_results == ["tool-1"]
     assert skill_results == ["skill-1"]
 
@@ -134,24 +171,24 @@ async def test_multiple_content_types():
 @pytest.mark.asyncio
 async def test_handler_error_doesnt_stop_other_handlers():
     """Test that if one handler fails, others still execute."""
-    from skillberry_store.plugins.events import on_content_added, emit_event, _event_handlers
-    
+    from skillberry_store.plugins.events import on_content_added, emit_event, _event_handlers, _background_tasks
+
     _event_handlers.clear()
-    
+    _background_tasks.clear()
+
     results = []
-    
+
     @on_content_added("tool")
     async def failing_handler(uuid: str):
         raise ValueError("Handler failed!")
-    
+
     @on_content_added("tool")
     async def working_handler(uuid: str):
         results.append(uuid)
-    
-    # Should not raise, but log error
-    await emit_event("content_added:tool", uuid="test-123")
-    
-    # Working handler should still execute
+
+    emit_event("content_added:tool", uuid="test-123")
+    await asyncio.sleep(0)
+
     assert len(results) == 1
     assert results[0] == "test-123"
 
@@ -159,30 +196,33 @@ async def test_handler_error_doesnt_stop_other_handlers():
 @pytest.mark.asyncio
 async def test_no_handlers_registered():
     """Test emitting event with no handlers doesn't error."""
-    from skillberry_store.plugins.events import emit_event, _event_handlers
-    
+    from skillberry_store.plugins.events import emit_event, _event_handlers, _background_tasks
+
     _event_handlers.clear()
-    
-    # Should not raise
-    await emit_event("content_added:nonexistent", uuid="test")
+    _background_tasks.clear()
+
+    emit_event("content_added:nonexistent", uuid="test")
+    await asyncio.sleep(0)
 
 
 @pytest.mark.asyncio
 async def test_handler_receives_correct_kwargs():
     """Test that handlers receive all kwargs passed to emit."""
-    from skillberry_store.plugins.events import on_content_added, emit_event, _event_handlers
-    
+    from skillberry_store.plugins.events import on_content_added, emit_event, _event_handlers, _background_tasks
+
     _event_handlers.clear()
-    
+    _background_tasks.clear()
+
     received_kwargs = {}
-    
+
     @on_content_added("tool")
     async def handler(uuid: str, extra_data: str = None):
         received_kwargs["uuid"] = uuid
         received_kwargs["extra_data"] = extra_data
-    
-    await emit_event("content_added:tool", uuid="test-uuid", extra_data="extra")
-    
+
+    emit_event("content_added:tool", uuid="test-uuid", extra_data="extra")
+    await asyncio.sleep(0)
+
     assert received_kwargs["uuid"] == "test-uuid"
     assert received_kwargs["extra_data"] == "extra"
 

--- a/src/skillberry_store/ui/src/components/TagFilter.tsx
+++ b/src/skillberry_store/ui/src/components/TagFilter.tsx
@@ -10,6 +10,7 @@ import {
   MenuToggleElement,
   Label,
   Button,
+  Divider,
 } from '@patternfly/react-core';
 import { getTagColor } from '../utils/tagColors';
 
@@ -23,6 +24,23 @@ interface TagFilterProps {
 export function TagFilter({ allTags, selectedTags, onTagsChange, placeholder = 'Filter by tags...' }: TagFilterProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
+
+  // Derive "quality-score:*" style prefix options from tags that contain ":"
+  const tagPrefixes = useMemo(() => {
+    const prefixes = new Set<string>();
+    allTags.forEach(tag => {
+      const colonIdx = tag.indexOf(':');
+      if (colonIdx > 0) prefixes.add(tag.slice(0, colonIdx + 1) + '*');
+    });
+    return Array.from(prefixes)
+      .filter(p => !selectedTags.includes(p))
+      .sort();
+  }, [allTags, selectedTags]);
+
+  const filteredPrefixes = useMemo(() => {
+    const lowerSearch = searchTerm.toLowerCase();
+    return tagPrefixes.filter(p => p.toLowerCase().includes(lowerSearch));
+  }, [tagPrefixes, searchTerm]);
 
   const filteredTags = useMemo(() => {
     const lowerSearch = searchTerm.toLowerCase();
@@ -47,6 +65,8 @@ export function TagFilter({ allTags, selectedTags, onTagsChange, placeholder = '
   const handleClearAll = () => {
     onTagsChange([]);
   };
+
+  const isEmpty = filteredPrefixes.length === 0 && filteredTags.length === 0;
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', minWidth: '250px' }}>
@@ -82,16 +102,28 @@ export function TagFilter({ allTags, selectedTags, onTagsChange, placeholder = '
                 outline: 'none',
               }}
             />
-            {filteredTags.length === 0 ? (
+            {isEmpty ? (
               <SelectOption isDisabled>
                 {searchTerm ? 'No tags found' : allTags.length === 0 ? 'No tags available' : 'All tags selected'}
               </SelectOption>
             ) : (
-              filteredTags.map((tag) => (
-                <SelectOption key={tag} value={tag}>
-                  {tag}
-                </SelectOption>
-              ))
+              <>
+                {filteredPrefixes.length > 0 && (
+                  <>
+                    {filteredPrefixes.map((p) => (
+                      <SelectOption key={p} value={p}>
+                        {p}
+                      </SelectOption>
+                    ))}
+                    {filteredTags.length > 0 && <Divider />}
+                  </>
+                )}
+                {filteredTags.map((tag) => (
+                  <SelectOption key={tag} value={tag}>
+                    {tag}
+                  </SelectOption>
+                ))}
+              </>
             )}
           </SelectList>
         </Select>

--- a/src/skillberry_store/ui/src/pages/SkillsPage.tsx
+++ b/src/skillberry_store/ui/src/pages/SkillsPage.tsx
@@ -4,6 +4,7 @@
 import { useState, useMemo } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { TagFilter } from '../components/TagFilter';
+import { tagMatchesFilter } from '../utils/tagUtils';
 import { NamespaceFilter } from '../components/NamespaceFilter';
 import { SearchBox, SearchMode } from '../components/SearchBox';
 import { exportSkills, importSkills, downloadJSON } from '../utils/exportImportHelpers';
@@ -407,7 +408,7 @@ export function SkillsPage() {
     if (filtered && selectedTags.length > 0) {
       filtered = filtered.filter(skill =>
         selectedTags.every(selectedTag =>
-          skill.tags?.includes(selectedTag)
+          tagMatchesFilter(skill.tags ?? [], selectedTag)
         )
       );
     }

--- a/src/skillberry_store/ui/src/pages/SnippetsPage.tsx
+++ b/src/skillberry_store/ui/src/pages/SnippetsPage.tsx
@@ -5,6 +5,7 @@ import { useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getTagColor } from '../utils/tagColors';
+import { tagMatchesFilter } from '../utils/tagUtils';
 import { TagFilter } from '../components/TagFilter';
 import { NamespaceFilter } from '../components/NamespaceFilter';
 import { SearchBox, SearchMode } from '../components/SearchBox';
@@ -274,7 +275,7 @@ export function SnippetsPage() {
     if (filtered && selectedTags.length > 0) {
       filtered = filtered.filter(snippet =>
         selectedTags.every(selectedTag =>
-          snippet.tags?.includes(selectedTag)
+          tagMatchesFilter(snippet.tags ?? [], selectedTag)
         )
       );
     }

--- a/src/skillberry_store/ui/src/pages/ToolsPage.tsx
+++ b/src/skillberry_store/ui/src/pages/ToolsPage.tsx
@@ -5,6 +5,7 @@ import { useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getTagColor } from '../utils/tagColors';
+import { tagMatchesFilter } from '../utils/tagUtils';
 import { TagFilter } from '../components/TagFilter';
 import { NamespaceFilter } from '../components/NamespaceFilter';
 import { SearchBox, SearchMode } from '../components/SearchBox';
@@ -242,7 +243,7 @@ export function ToolsPage() {
     if (filtered && selectedTags.length > 0) {
       filtered = filtered.filter(tool =>
         selectedTags.every(selectedTag =>
-          tool.tags?.includes(selectedTag)
+          tagMatchesFilter(tool.tags ?? [], selectedTag)
         )
       );
     }

--- a/src/skillberry_store/ui/src/pages/VMCPServersPage.tsx
+++ b/src/skillberry_store/ui/src/pages/VMCPServersPage.tsx
@@ -5,6 +5,7 @@ import { useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getTagColor } from '../utils/tagColors';
+import { tagMatchesFilter } from '../utils/tagUtils';
 import { TagFilter } from '../components/TagFilter';
 import { SearchBox, SearchMode } from '../components/SearchBox';
 import { exportVMCPServers, importVMCPServers, downloadJSON } from '../utils/exportImportHelpers';
@@ -304,7 +305,7 @@ export function VMCPServersPage() {
     if (filtered && selectedTags.length > 0) {
       filtered = filtered.filter(server =>
         selectedTags.every(selectedTag =>
-          server.tags?.includes(selectedTag)
+          tagMatchesFilter(server.tags ?? [], selectedTag)
         )
       );
     }

--- a/src/skillberry_store/ui/src/pages/VNFSServersPage.tsx
+++ b/src/skillberry_store/ui/src/pages/VNFSServersPage.tsx
@@ -5,6 +5,7 @@ import { useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getTagColor } from '../utils/tagColors';
+import { tagMatchesFilter } from '../utils/tagUtils';
 import { TagFilter } from '../components/TagFilter';
 import { SearchBox, SearchMode } from '../components/SearchBox';
 import { exportVNFSServers, importVNFSServers, downloadJSON } from '../utils/exportImportHelpers';
@@ -230,7 +231,7 @@ export function VNFSServersPage() {
       }
     }
     if (filtered && selectedTags.length > 0) {
-      filtered = filtered.filter(s => selectedTags.every(t => s.tags?.includes(t)));
+      filtered = filtered.filter(s => selectedTags.every(t => tagMatchesFilter(s.tags ?? [], t)));
     }
     if (filtered && activeSortIndex !== null) {
       filtered = [...filtered].sort((a, b) => {

--- a/src/skillberry_store/ui/src/utils/tagUtils.test.ts
+++ b/src/skillberry_store/ui/src/utils/tagUtils.test.ts
@@ -1,0 +1,52 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+
+import { describe, it, expect } from 'vitest';
+import { tagMatchesFilter } from './tagUtils';
+
+describe('tagMatchesFilter', () => {
+  describe('exact match (no wildcard)', () => {
+    it('returns true when tag is present', () => {
+      expect(tagMatchesFilter(['python', 'beta'], 'python')).toBe(true);
+    });
+
+    it('returns false when tag is absent', () => {
+      expect(tagMatchesFilter(['python', 'beta'], 'java')).toBe(false);
+    });
+
+    it('returns false on empty tag list', () => {
+      expect(tagMatchesFilter([], 'python')).toBe(false);
+    });
+
+    it('does not partially match plain tags', () => {
+      expect(tagMatchesFilter(['python'], 'pyth')).toBe(false);
+    });
+  });
+
+  describe('wildcard match (filter ends with :*)', () => {
+    it('matches a tag with the given prefix', () => {
+      expect(tagMatchesFilter(['quality-score:8'], 'quality-score:*')).toBe(true);
+    });
+
+    it('matches any value for the prefix', () => {
+      expect(tagMatchesFilter(['quality-score:1'], 'quality-score:*')).toBe(true);
+      expect(tagMatchesFilter(['quality-score:10'], 'quality-score:*')).toBe(true);
+    });
+
+    it('returns true if any tag in the list matches the prefix', () => {
+      expect(tagMatchesFilter(['python', 'quality-score:7', 'beta'], 'quality-score:*')).toBe(true);
+    });
+
+    it('returns false when no tag matches the prefix', () => {
+      expect(tagMatchesFilter(['performance-score:5', 'beta'], 'quality-score:*')).toBe(false);
+    });
+
+    it('does not match a tag that is exactly the prefix without a value', () => {
+      expect(tagMatchesFilter(['quality-score'], 'quality-score:*')).toBe(false);
+    });
+
+    it('returns false on empty tag list', () => {
+      expect(tagMatchesFilter([], 'quality-score:*')).toBe(false);
+    });
+  });
+});

--- a/src/skillberry_store/ui/src/utils/tagUtils.ts
+++ b/src/skillberry_store/ui/src/utils/tagUtils.ts
@@ -1,0 +1,15 @@
+// Copyright 2025 IBM Corp.
+// Licensed under the Apache License, Version 2.0
+
+/**
+ * Returns true if itemTags satisfies the filter.
+ * - Wildcard filter "quality-score:*" matches any tag starting with "quality-score:"
+ * - Plain filter "python" requires an exact tag match
+ */
+export function tagMatchesFilter(itemTags: string[], filter: string): boolean {
+  if (filter.endsWith(':*')) {
+    const prefix = filter.slice(0, -1); // "quality-score:"
+    return itemTags.some(t => t.startsWith(prefix));
+  }
+  return itemTags.includes(filter);
+}


### PR DESCRIPTION
Closes #163.

## Summary
- **Non-blocking plugin events:** `emit_event` now uses `asyncio.create_task` instead of `await`, scheduling handlers as background tasks so HTTP endpoints return immediately instead of blocking on LLM evaluation calls. A module-level `_background_tasks` set holds strong references to prevent GC. Six `await emit_content_*` call sites in the API layer drop their `await`.
- **Tag prefix filtering:** New `tagMatchesFilter` utility supports wildcard filters (e.g. `quality-score:*` matches all `quality-score:N` tags). `TagFilter.tsx` now auto-computes and displays prefix options above full tags in the dropdown with a divider. All five list pages (Tools, Skills, Snippets, VMCP Servers, VNFS Servers) use the shared utility.

## Testing
- Python: all 48 plugin tests pass
- TypeScript: `tagUtils.test.ts` — 10/10 pass; no new vitest failures introduced

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>