### PR TITLE
fix: restore default text color in syntax highlighter code blocks

### DIFF
--- a/src/skillberry_store/ui/src/styles/global.css
+++ b/src/skillberry_store/ui/src/styles/global.css
@@ -67,6 +67,11 @@ pre {
   overflow-x: auto;
 }
 
+/* Let syntax highlighter spans inherit token colors instead of the global dark override */
+pre span {
+  color: inherit;
+}
+
 code {
   font-family: 'Red Hat Mono', 'Courier New', monospace;
   font-size: 0.875rem;


### PR DESCRIPTION
Closes #175.

## Summary
- The global CSS rule `span { color: var(--pf-v5-global--Color--100) }` was overriding `vscDarkPlus` theme's inherited text color for unstyled code tokens
- Added `pre span { color: inherit }` so token spans fall back to the `<pre>` element's light theme color
- Colored syntax tokens (keywords, strings, etc.) are unaffected — inline styles always win over CSS rules
- Elements outside `<pre>` blocks (e.g. "Additional Information") are unaffected

## Testing
Verified in the skill detail page Tools Code and Snippets Content tabs — default text is now visible on the dark background.

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>