### PR TITLE
fix: defer Docker client init to prevent MCP tool execution failure

### DIFF
--- a/src/skillberry_store/modules/file_executor.py
+++ b/src/skillberry_store/modules/file_executor.py
@@ -234,15 +234,6 @@ class FileExecutor:
             logger.error(f"Error parsing manifest: {e}")
             raise HTTPException(status_code=400, detail=f"Error parsing manifest: {e}")
 
-        if not self.execute_python_locally:
-            try:
-                self.client = docker.from_env()
-            except ImportError:
-                raise HTTPException(
-                    status_code=500,
-                    detail=f"Docker SDK for Python not found. Please install the Docker SDK for Python.",
-                )
-
     async def execute_file(self, parameters: Dict[str, Any], env_id=None) -> dict:
         """
         Executes dynamically based on manifest and parameters.
@@ -543,6 +534,19 @@ class FileExecutor:
         Executes a Python file using docker
         """
         logger.info(f"Executing python code using a Docker container")
+
+        try:
+            self.client = docker.from_env()
+        except ImportError:
+            raise HTTPException(
+                status_code=500,
+                detail="Docker SDK for Python not found. Please install the Docker SDK for Python.",
+            )
+        except Exception as e:
+            raise HTTPException(
+                status_code=500,
+                detail=f"Docker is not available: {e}. Ensure Docker is running or set EXECUTE_PYTHON_LOCALLY=true.",
+            )
 
         try:
             (


### PR DESCRIPTION
Closes #179

## Summary
- `FileExecutor.__init__` was calling `docker.from_env()` for all tools, including MCP-packaged ones that never use Docker
- When Docker daemon is unavailable, this raised an uncaught `DockerException` and aborted MCP tool execution before the SSE connection was attempted
- Moved `docker.from_env()` into `execute_python_file_using_docker()` where it is actually needed; also broadened the caught exception type to cover `DockerException` with a helpful error message

## Test plan
- [ ] Import tools from a remote MCP SSE server with Docker daemon not running
- [ ] Execute an imported MCP tool — should succeed and reach the MCP server
- [ ] Execute a code-packaged tool without Docker — should fail with a clear message suggesting `EXECUTE_PYTHON_LOCALLY=true`
- [ ] Execute a code-packaged tool with Docker running — should behave as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)