### PR TITLE
feat(mcp-importer): auto-generate tags on imported tools and skills

### DIFF
--- a/plugins/skillberry-plugin-mcp-importer/src/skillberry_plugin_mcp_importer/plugin.py
+++ b/plugins/skillberry-plugin-mcp-importer/src/skillberry_plugin_mcp_importer/plugin.py
@@ -75,6 +75,12 @@ class SkillberryPluginMcpImporter(PluginBase):
         raw = "_".join(parts)
         return "".join(c if c.isalnum() or c == "_" else "_" for c in raw)
 
+    @staticmethod
+    def _hostname_from_url(mcp_url: str) -> str:
+        """Extract the hostname from a MCP URL, e.g. 'localhost', 'api.acme.com'."""
+        from urllib.parse import urlparse
+        return urlparse(mcp_url).hostname or "mcp"
+
     async def _import_tools(
         self,
         mcp_url: str,

--- a/plugins/skillberry-plugin-mcp-importer/src/skillberry_plugin_mcp_importer/plugin.py
+++ b/plugins/skillberry-plugin-mcp-importer/src/skillberry_plugin_mcp_importer/plugin.py
@@ -86,6 +86,7 @@ class SkillberryPluginMcpImporter(PluginBase):
         mcp_url: str,
         create_skill: bool = True,
         skill_name: Optional[str] = None,
+        tags: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
         """
         Connect to the MCP server at mcp_url, list all tools, create each in the store.
@@ -104,6 +105,16 @@ class SkillberryPluginMcpImporter(PluginBase):
 
         imported: List[Dict[str, Any]] = []
         failed: List[Dict[str, Any]] = []
+
+        hostname = self._hostname_from_url(mcp_url)
+        resolved_skill_name = skill_name or self._skill_name_from_url(mcp_url)
+
+        tool_tags: List[str] = ["mcp", hostname]
+        if create_skill:
+            tool_tags.append(f"skill:{resolved_skill_name}")
+        for tag in (tags or []):
+            if tag and tag not in tool_tags:
+                tool_tags.append(tag)
 
         for tool in tools:
             input_schema = tool.inputSchema or {}
@@ -130,6 +141,7 @@ class SkillberryPluginMcpImporter(PluginBase):
                 },
                 "params": params,
                 "programming_language": "python",
+                "tags": tool_tags,
             }
             stub = mcp_content(vars(tool))
             try:
@@ -145,19 +157,23 @@ class SkillberryPluginMcpImporter(PluginBase):
 
         skill: Optional[Dict[str, Any]] = None
         if create_skill and imported:
-            name = skill_name or self._skill_name_from_url(mcp_url)
             tool_uuids = [t["uuid"] for t in imported]
+            skill_tags: List[str] = ["mcp", "imported", hostname]
+            for tag in (tags or []):
+                if tag and tag not in skill_tags:
+                    skill_tags.append(tag)
             try:
                 skill_result = self.store.create_skill(
                     {
-                        "name": name,
+                        "name": resolved_skill_name,
                         "description": f"Tools imported from {mcp_url}",
                         "tool_uuids": tool_uuids,
+                        "tags": skill_tags,
                     }
                 )
                 skill = {"name": skill_result["name"], "uuid": skill_result["uuid"]}
             except Exception as exc:
-                logger.warning(f"Failed to create skill '{name}': {exc}")
+                logger.warning(f"Failed to create skill '{resolved_skill_name}': {exc}")
 
         return {
             "success": len(failed) == 0 and len(imported) > 0,

--- a/plugins/skillberry-plugin-mcp-importer/src/skillberry_plugin_mcp_importer/plugin.py
+++ b/plugins/skillberry-plugin-mcp-importer/src/skillberry_plugin_mcp_importer/plugin.py
@@ -250,6 +250,11 @@ class SkillberryPluginMcpImporter(PluginBase):
                                 "type": "string",
                                 "description": "Name for the auto-created skill (default: derived from MCP URL)",
                             },
+                            "tags": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "description": "Optional extra tags to add to imported tools and skill",
+                            },
                         },
                         "required": ["mcp_url"],
                     },

--- a/plugins/skillberry-plugin-mcp-importer/src/skillberry_plugin_mcp_importer/plugin.py
+++ b/plugins/skillberry-plugin-mcp-importer/src/skillberry_plugin_mcp_importer/plugin.py
@@ -193,6 +193,7 @@ class SkillberryPluginMcpImporter(PluginBase):
             mcp_url: str
             create_skill: bool = True
             skill_name: Optional[str] = None
+            tags: Optional[List[str]] = None
 
         @router.post("/import-tools")
         async def import_tools(request: ImportRequest):
@@ -210,6 +211,7 @@ class SkillberryPluginMcpImporter(PluginBase):
                     url,
                     create_skill=request.create_skill,
                     skill_name=request.skill_name,
+                    tags=request.tags,
                 )
             except Exception as exc:
                 logger.error(

--- a/plugins/skillberry-plugin-mcp-importer/tests/test_mcp_importer_plugin.py
+++ b/plugins/skillberry-plugin-mcp-importer/tests/test_mcp_importer_plugin.py
@@ -134,6 +134,49 @@ def _patch_mcp(tools):
     return stack
 
 
+# --- tool tag generation ---
+
+def test_tool_tags_include_mcp_and_hostname():
+    tools = [_MockTool("tool_a")]
+    client, _, mock_store = _make_client(tools=tools)
+    with _patch_mcp(tools):
+        resp = client.post(
+            "/plugins/mcp-importer/import-tools",
+            json={"mcp_url": "http://mock-mcp:9500/sse", "create_skill": False},
+        )
+    assert resp.status_code == 200
+    data_arg = mock_store.create_tool.call_args.args[0]
+    assert "mcp" in data_arg["tags"]
+    assert "mock-mcp" in data_arg["tags"]
+
+
+def test_tool_tags_include_skill_reference_when_skill_created():
+    tools = [_MockTool("tool_b")]
+    client, _, mock_store = _make_client(tools=tools)
+    mock_store.create_skill.return_value = {"uuid": "s-uuid", "name": "mock-mcp_9500_sse"}
+    with _patch_mcp(tools):
+        resp = client.post(
+            "/plugins/mcp-importer/import-tools",
+            json={"mcp_url": "http://mock-mcp:9500/sse", "create_skill": True},
+        )
+    assert resp.status_code == 200
+    data_arg = mock_store.create_tool.call_args.args[0]
+    assert "skill:mock_mcp_9500_sse" in data_arg["tags"]
+
+
+def test_tool_tags_no_skill_reference_when_skill_not_created():
+    tools = [_MockTool("tool_c")]
+    client, _, mock_store = _make_client(tools=tools)
+    with _patch_mcp(tools):
+        resp = client.post(
+            "/plugins/mcp-importer/import-tools",
+            json={"mcp_url": "http://mock-mcp:9500/sse", "create_skill": False},
+        )
+    assert resp.status_code == 200
+    data_arg = mock_store.create_tool.call_args.args[0]
+    assert not any(t.startswith("skill:") for t in data_arg["tags"])
+
+
 # ── Validation tests ──────────────────────────────────────────────────────────
 
 def test_import_missing_url_returns_400():

--- a/plugins/skillberry-plugin-mcp-importer/tests/test_mcp_importer_plugin.py
+++ b/plugins/skillberry-plugin-mcp-importer/tests/test_mcp_importer_plugin.py
@@ -177,6 +177,24 @@ def test_tool_tags_no_skill_reference_when_skill_not_created():
     assert not any(t.startswith("skill:") for t in data_arg["tags"])
 
 
+# --- skill tag generation ---
+
+def test_skill_tags_include_mcp_imported_and_hostname():
+    tools = [_MockTool("tool_d")]
+    client, _, mock_store = _make_client(tools=tools)
+    mock_store.create_skill.return_value = {"uuid": "s-uuid", "name": "mock_mcp_9500_sse"}
+    with _patch_mcp(tools):
+        resp = client.post(
+            "/plugins/mcp-importer/import-tools",
+            json={"mcp_url": "http://mock-mcp:9500/sse", "create_skill": True},
+        )
+    assert resp.status_code == 200
+    skill_data = mock_store.create_skill.call_args.args[0]
+    assert "mcp" in skill_data["tags"]
+    assert "imported" in skill_data["tags"]
+    assert "mock-mcp" in skill_data["tags"]
+
+
 # ── Validation tests ──────────────────────────────────────────────────────────
 
 def test_import_missing_url_returns_400():

--- a/plugins/skillberry-plugin-mcp-importer/tests/test_mcp_importer_plugin.py
+++ b/plugins/skillberry-plugin-mcp-importer/tests/test_mcp_importer_plugin.py
@@ -5,6 +5,21 @@ from skillberry_plugin_mcp_importer.plugin import SkillberryPluginMcpImporter
 from skillberry_store.plugins.base import PluginType
 
 
+# --- _hostname_from_url ---
+
+def test_hostname_from_url_standard():
+    assert SkillberryPluginMcpImporter._hostname_from_url("http://localhost:3001/sse") == "localhost"
+
+def test_hostname_from_url_no_port():
+    assert SkillberryPluginMcpImporter._hostname_from_url("http://localhost/sse") == "localhost"
+
+def test_hostname_from_url_domain():
+    assert SkillberryPluginMcpImporter._hostname_from_url("https://api.acme.com/mcp/sse") == "api.acme.com"
+
+def test_hostname_from_url_malformed():
+    assert SkillberryPluginMcpImporter._hostname_from_url("not-a-url") == "mcp"
+
+
 def test_plugin_metadata():
     plugin = SkillberryPluginMcpImporter()
     meta = plugin.metadata

--- a/plugins/skillberry-plugin-mcp-importer/tests/test_mcp_importer_plugin.py
+++ b/plugins/skillberry-plugin-mcp-importer/tests/test_mcp_importer_plugin.py
@@ -195,6 +195,62 @@ def test_skill_tags_include_mcp_imported_and_hostname():
     assert "mock-mcp" in skill_data["tags"]
 
 
+# --- user-supplied tags merging ---
+
+def test_user_tags_merged_into_tool_tags():
+    tools = [_MockTool("tool_e")]
+    client, _, mock_store = _make_client(tools=tools)
+    with _patch_mcp(tools):
+        resp = client.post(
+            "/plugins/mcp-importer/import-tools",
+            json={
+                "mcp_url": "http://mock-mcp:9500/sse",
+                "create_skill": False,
+                "tags": ["my-project", "prod"],
+            },
+        )
+    assert resp.status_code == 200
+    data_arg = mock_store.create_tool.call_args.args[0]
+    assert "my-project" in data_arg["tags"]
+    assert "prod" in data_arg["tags"]
+
+
+def test_user_tags_merged_into_skill_tags():
+    tools = [_MockTool("tool_f")]
+    client, _, mock_store = _make_client(tools=tools)
+    mock_store.create_skill.return_value = {"uuid": "s-uuid", "name": "mock_mcp_9500_sse"}
+    with _patch_mcp(tools):
+        resp = client.post(
+            "/plugins/mcp-importer/import-tools",
+            json={
+                "mcp_url": "http://mock-mcp:9500/sse",
+                "create_skill": True,
+                "tags": ["team-alpha"],
+            },
+        )
+    assert resp.status_code == 200
+    skill_data = mock_store.create_skill.call_args.args[0]
+    assert "team-alpha" in skill_data["tags"]
+
+
+def test_user_tags_deduped():
+    tools = [_MockTool("tool_g")]
+    client, _, mock_store = _make_client(tools=tools)
+    with _patch_mcp(tools):
+        resp = client.post(
+            "/plugins/mcp-importer/import-tools",
+            json={
+                "mcp_url": "http://mock-mcp:9500/sse",
+                "create_skill": False,
+                "tags": ["mcp", "unique-tag"],  # "mcp" is already auto-generated
+            },
+        )
+    assert resp.status_code == 200
+    data_arg = mock_store.create_tool.call_args.args[0]
+    assert data_arg["tags"].count("mcp") == 1
+    assert "unique-tag" in data_arg["tags"]
+
+
 # ── Validation tests ──────────────────────────────────────────────────────────
 
 def test_import_missing_url_returns_400():


### PR DESCRIPTION
Closes #181.

## Summary
- Add `_hostname_from_url` static helper to extract the DNS hostname from the MCP server URL
- `_import_tools` now builds `["mcp", <hostname>, "skill:<name>"]` tags for tools and `["mcp", "imported", <hostname>]` tags for the skill before the tool loop
- Add optional `tags: List[str]` parameter to `_import_tools` and `ImportRequest` for caller-supplied extras, merged in with dedup (mirrors the Anthropic importer pattern)
- Expose `tags` array field in `get_ui_config` params_schema so the UI form includes it
- 10 new tests; 27 total, all passing

## Testing
- All 27 unit tests pass: `pytest plugins/skillberry-plugin-mcp-importer/tests/test_mcp_importer_plugin.py`
- No regressions in existing tests

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>