### PR TITLE
feat(plugin): add anthropic-skill-generator plugin

### DIFF
--- a/docs/plugins-installation.md
+++ b/docs/plugins-installation.md
@@ -35,6 +35,7 @@ This installs:
 - skillberry-plugin-security (AI-powered security evaluation)
 - skillberry-plugin-dedupe (AI-powered duplicate skill detection)
 - skillberry-plugin-mcp-importer (import tools from any MCP SSE server)
+- skillberry-plugin-anthropic-skill-generator (generate Anthropic skills from descriptions using Claude Code)
 
 ### 3. Install Specific Plugins
 
@@ -60,9 +61,14 @@ pip install skillberry-store[plugin-dedupe]
 pip install skillberry-store[plugin-mcp-importer]
 ```
 
+#### Anthropic Skill Generator Plugin Only
+```bash
+pip install skillberry-store[plugin-anthropic-skill-generator]
+```
+
 #### Multiple Specific Plugins
 ```bash
-pip install skillberry-store[plugin-creator,plugin-evaluator,plugin-mcp-importer]
+pip install skillberry-store[plugin-creator,plugin-evaluator,plugin-mcp-importer,plugin-anthropic-skill-generator]
 ```
 
 ### 4. Adding Plugins Later
@@ -71,7 +77,7 @@ If you initially installed skillberry-store without plugins, you can add them la
 
 ```bash
 # Add all plugins to existing installation
-pip install skillberry-plugin-creator skillberry-plugin-evaluator skillberry-plugin-security skillberry-plugin-dedupe skillberry-plugin-mcp-importer
+pip install skillberry-plugin-creator skillberry-plugin-evaluator skillberry-plugin-security skillberry-plugin-dedupe skillberry-plugin-mcp-importer skillberry-plugin-anthropic-skill-generator
 
 # Or reinstall with plugins
 pip install --upgrade skillberry-store[plugins-all]
@@ -255,6 +261,91 @@ curl -X POST http://localhost:8000/plugins/mcp-importer/import-tools \
 - `400` — `mcp_url` is missing or does not start with `http://` / `https://`
 - `502` — Could not connect to the MCP server (unreachable, refused, or timed out)
 
+### Anthropic Skill Generator Plugin (`skillberry-plugin-anthropic-skill-generator`)
+
+**Purpose:** Generate complete Anthropic skills from natural language descriptions using Claude Code via runspace-agent.
+
+**Features:**
+- Generates complete Anthropic skills (SKILL.md, tools, documentation) from descriptions
+- Uses Claude Code AI agent for intelligent skill creation
+- Automatically imports generated skills into the store
+- Supports both local and container execution modes (container is default for safety)
+- Auto-loads credentials from `~/.claude/settings.json` if available
+- Includes skill-creator preinstalled skill for better generation quality
+
+**Configuration:**
+
+The plugin automatically loads credentials from `~/.claude/settings.json` if it exists:
+```json
+{
+  "apiKey": "sk-ant-...",
+  "model": "claude-opus-4-8",
+  "baseUrl": "https://api.anthropic.com"
+}
+```
+
+Or configure via environment variables:
+```bash
+# Option 1: Direct Anthropic API
+export ANTHROPIC_API_KEY="sk-ant-..."
+
+# Option 2: Proxy/Gateway
+export ANTHROPIC_BASE_URL="https://your-gateway.example.com"
+export ANTHROPIC_AUTH_TOKEN="your-token"
+export ANTHROPIC_MODEL="claude-opus-4-8"
+
+# Execution mode (default: container - requires Docker)
+export RUNSPACE_MODE="container"  # or "local" for development
+
+# Max conversation turns (default: 300)
+export RUNSPACE_MAX_TURNS="300"
+```
+
+**Requirements:**
+- Docker (for default container mode - recommended)
+- Anthropic API credentials (API key or proxy configuration)
+
+**API Endpoints:**
+- `POST /api/plugins/anthropic-skill-generator/generate-skill`
+
+**Request body:**
+```json
+{
+  "description": "A skill for processing PDF documents and extracting text",
+  "skill_name": "pdf-processor",
+  "tags": ["pdf", "document-processing"],
+  "max_turns": 50
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Skill 'pdf-processor' generated successfully.",
+  "skill_name": "pdf-processor",
+  "skill_uuid": "550e8400-e29b-41d4-a716-446655440000",
+  "tools_count": 3,
+  "snippets_count": 2
+}
+```
+
+**Example:**
+```bash
+curl -X POST http://localhost:8000/api/plugins/anthropic-skill-generator/generate-skill \
+  -H "Content-Type: application/json" \
+  -d '{
+    "description": "A skill for processing PDF documents and extracting text with OCR support",
+    "skill_name": "pdf-processor",
+    "tags": ["pdf", "ocr"]
+  }'
+```
+
+**Configuration Priority:**
+1. Request-specific parameters (highest)
+2. Environment variables
+3. `~/.claude/settings.json` (lowest - automatic)
+
 ## LLM Configuration
 
 Both plugins use `llm-switchboard` for LLM integration. Configuration is done via environment variables.
@@ -380,7 +471,7 @@ my-plugin = { path = "plugins/my-plugin", editable = true }
 
 ```bash
 # Uninstall all plugins
-pip uninstall -y skillberry-plugin-creator skillberry-plugin-evaluator skillberry-plugin-security skillberry-plugin-dedupe skillberry-plugin-mcp-importer
+pip uninstall -y skillberry-plugin-creator skillberry-plugin-evaluator skillberry-plugin-security skillberry-plugin-dedupe skillberry-plugin-mcp-importer skillberry-plugin-anthropic-skill-generator
 
 # Verify removal
 pip list | grep skillberry-plugin

--- a/plugins/skillberry-plugin-anthropic-skill-generator/.env.example
+++ b/plugins/skillberry-plugin-anthropic-skill-generator/.env.example
@@ -1,0 +1,87 @@
+the loy # Anthropic Skill Generator Plugin Configuration
+# Copy this file to .env and fill in your values
+
+# ============================================================================
+# REQUIRED: Anthropic API Authentication
+# ============================================================================
+# Choose ONE of the following authentication methods:
+
+# Option 1: Direct Anthropic API (Recommended)
+# Get your API key from: https://console.anthropic.com/
+ANTHROPIC_API_KEY=sk-ant-api03-...
+
+# Option 2: Proxy/Gateway Authentication
+# Use this if you're routing through an API gateway or proxy
+# ANTHROPIC_BASE_URL=https://your-gateway.example.com
+# ANTHROPIC_AUTH_TOKEN=your-auth-token
+# ANTHROPIC_MODEL=claude-opus-4-8
+
+# ============================================================================
+# OPTIONAL: Execution Configuration
+# ============================================================================
+
+# Execution mode: "local" (faster, less isolation) or "container" (safer, requires Docker)
+# Default: container (recommended for production)
+# Set to "local" only for development/testing when Docker is not available
+RUNSPACE_MODE=container
+
+# Maximum conversation turns for Claude Code
+# Higher values allow more refinement but take longer
+# Default: 300
+RUNSPACE_MAX_TURNS=300
+
+# Preinstalled skills to include (comma-separated)
+# Available: skill-creator, mcp-builder
+# Default: skill-creator (recommended for better skill generation)
+RUNSPACE_PREINSTALLED_SKILLS=skill-creator
+
+# ============================================================================
+# OPTIONAL: Docker Configuration (for container mode)
+# ============================================================================
+
+# If using container mode, ensure Docker is installed and running
+# The plugin will automatically build the runspace-agent image on first use
+
+# ============================================================================
+# OPTIONAL: Model Selection
+# ============================================================================
+
+# Specify which Claude model to use
+# Options: claude-opus-4-8, claude-3-5-sonnet-20241022, etc.
+# Default: Latest Claude model
+# ANTHROPIC_MODEL=claude-opus-4-8
+
+# ============================================================================
+# Configuration Priority
+# ============================================================================
+# The plugin uses credentials in this order (highest to lowest):
+# 1. Request-specific parameters (passed in API calls)
+# 2. Environment variables (this file)
+# 3. ~/.claude/settings.json (automatic)
+#
+# This means environment variables override the settings file.
+
+# ============================================================================
+# Usage Notes
+# ============================================================================
+#
+# 1. If you have ~/.claude/settings.json, just start Skillberry Store:
+#    skillberry-store
+#
+# 2. If using environment variables, source this file first:
+#    source .env
+#    skillberry-store
+#
+# 3. Verify plugin status (should show where credentials came from):
+#    curl http://localhost:8000/api/plugins/status
+#
+# 4. Test skill generation:
+#    curl -X POST http://localhost:8000/api/plugins/anthropic-generator/generate-skill \
+#      -H "Content-Type: application/json" \
+#      -d '{"description": "A skill for processing text files"}'
+#
+# 5. For container mode (default), ensure Docker is running:
+#    docker ps
+#
+# 6. Monitor logs for troubleshooting:
+#    tail -f /path/to/skillberry-store/logs/app.log

--- a/plugins/skillberry-plugin-anthropic-skill-generator/README.md
+++ b/plugins/skillberry-plugin-anthropic-skill-generator/README.md
@@ -1,0 +1,353 @@
+# Skillberry Plugin: Anthropic Skill Generator
+
+A Skillberry Store plugin that generates Anthropic skills from natural language descriptions using [runspace-agent](https://pypi.org/project/runspace-agent/0.1.0/).
+
+## Overview
+
+This plugin allows you to create complete Anthropic skills by simply providing a description. It uses the runspace-agent library with Claude Code to generate the skill structure (SKILL.md and associated files), then automatically imports the generated skill into the Skillberry Store.
+
+**Important:** This plugin requires Claude Code (Anthropic's AI agent) to generate skills. You must configure Anthropic API credentials for the plugin to work.
+
+## Features
+
+- **AI-Powered Generation**: Uses runspace-agent to create Anthropic skills from descriptions
+- **Automatic Import**: Generated skills are automatically imported into the store
+- **Tool & Snippet Support**: Handles both tools and snippets from generated skills
+- **Tagging**: Apply custom tags to generated skills for organization
+- **REST API**: Provides HTTP endpoints for skill generation
+- **UI Integration**: Includes UI configuration for seamless integration
+
+## Installation
+
+The plugin is automatically discovered by Skillberry Store when installed. To install:
+
+```bash
+cd plugins/skillberry-plugin-anthropic-skill-generator
+pip install -e .
+```
+
+### Dependencies
+
+- `runspace-agent==0.1.0` - AI agent for generating Anthropic skills
+- Python >= 3.10
+- **Docker (required)** - Container mode is the default for safe, isolated execution
+
+## Configuration
+
+### Automatic Configuration from Claude Settings
+
+**The plugin automatically loads credentials from `~/.claude/settings.json` if it exists!**
+
+If you already have Claude Code configured on your machine, the plugin will automatically use those settings. No additional configuration needed!
+
+Example `~/.claude/settings.json`:
+```json
+{
+  "apiKey": "sk-ant-...",
+  "model": "claude-opus-4-8",
+  "baseUrl": "https://api.anthropic.com",
+  "authToken": "optional-for-proxy"
+}
+```
+
+### Manual Configuration
+
+If you don't have `~/.claude/settings.json`, you can configure the plugin manually:
+
+#### Quick Start with .env.example
+
+The plugin includes a `.env.example` file with all configuration options documented:
+
+```bash
+cd plugins/skillberry-plugin-anthropic-skill-generator
+cp .env.example .env
+# Edit .env with your API credentials
+source .env
+```
+
+#### Required Environment Variables
+
+The plugin requires Anthropic API credentials to use Claude Code for skill generation. You must set **one** of the following authentication methods:
+
+#### Option 1: Direct Anthropic API (Recommended)
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."
+```
+
+#### Option 2: Proxy/Gateway Authentication
+
+If you're using an API proxy or gateway:
+
+```bash
+export ANTHROPIC_BASE_URL="https://your-gateway.example.com"
+export ANTHROPIC_AUTH_TOKEN="your-auth-token"
+export ANTHROPIC_MODEL="claude-opus-4-8"  # Optional, defaults to Claude's latest
+```
+
+### Configuration Priority
+
+The plugin uses the following priority order (highest to lowest):
+
+1. **Request-specific parameters** - Credentials passed in API requests
+2. **Environment variables** - `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL`, etc.
+3. **Claude settings file** - `~/.claude/settings.json` (automatic)
+
+This means you can override the settings file with environment variables, and override both with request-specific parameters.
+
+### Optional Environment Variables
+
+```bash
+# Execution mode (default: "container")
+# - "container": Runs in Docker container (safer, full isolation) - RECOMMENDED
+# - "local": Runs on host machine (faster, less isolation) - use only for development
+export RUNSPACE_MODE="container"
+
+# Maximum conversation turns for Claude Code (default: 300)
+export RUNSPACE_MAX_TURNS="300"
+
+# Custom skills to include (comma-separated)
+export RUNSPACE_PREINSTALLED_SKILLS="skill-creator,mcp-builder"
+```
+
+### Docker Setup (Required)
+
+Container mode is the default and provides full isolation. Install Docker:
+
+```bash
+# Verify Docker is running
+docker ps
+
+# The plugin will automatically build the runspace-agent:latest image on first use
+# This happens automatically when the plugin starts
+```
+
+**Note:** If Docker is not available, you can override to local mode by setting `RUNSPACE_MODE=local`, but this is **not recommended for production** as it provides less isolation.
+
+### Configuration Check
+
+After setting environment variables, verify the plugin status:
+
+```bash
+# Start Skillberry Store
+skillberry-store
+
+# Check plugin status via API
+curl http://localhost:8000/api/plugins/status
+```
+
+The plugin status should show "Ready (container mode) from ~/.claude/settings.json" if credentials are loaded from the settings file, or just "Ready (container mode)" if using environment variables.
+
+## Usage
+
+### Via REST API
+
+Generate a skill by sending a POST request:
+
+```bash
+curl -X POST http://localhost:8000/api/plugins/anthropic-skill-generator/generate-skill \
+  -H "Content-Type: application/json" \
+  -d '{
+    "description": "A skill for processing PDF documents and extracting text",
+    "skill_name": "pdf-processor",
+    "tags": ["pdf", "document-processing"]
+  }'
+```
+
+**Request Parameters:**
+- `description` (required): Natural language description of the skill to generate
+- `skill_name` (optional): Custom name for the skill
+- `tags` (optional): Array of tags to apply to the skill
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Skill 'pdf-processor' generated successfully.",
+  "skill_name": "pdf-processor",
+  "skill_uuid": "550e8400-e29b-41d4-a716-446655440000",
+  "tools_count": 3,
+  "snippets_count": 2
+}
+```
+
+### Via UI
+
+The plugin integrates with the Skillberry Store UI:
+
+1. Navigate to the Plugins section
+2. Find "Anthropic Skill Generator"
+3. Click "Generate Anthropic Skill"
+4. Enter your skill description
+5. Optionally provide a name and tags
+6. Click Generate
+
+### Environment Variables in Requests
+
+You can also override environment variables per request:
+
+```bash
+curl -X POST http://localhost:8000/api/plugins/anthropic-skill-generator/generate-skill \
+  -H "Content-Type: application/json" \
+  -d '{
+    "description": "A skill for processing PDF documents",
+    "skill_name": "pdf-processor",
+    "tags": ["pdf"],
+    "agent_env": {
+      "ANTHROPIC_API_KEY": "sk-ant-...",
+      "ANTHROPIC_MODEL": "claude-opus-4-8"
+    },
+    "max_turns": 50
+  }'
+```
+
+## How It Works
+
+1. **Description Input**: User provides a natural language description of the desired skill
+2. **Skill Generation**: runspace-agent creates the skill structure in a temporary directory
+3. **Import Process**: The Anthropic importer parses the generated files
+4. **Store Integration**: Tools and snippets are created in the Skillberry Store
+5. **Skill Creation**: A skill object is created linking all imported components
+
+## Plugin Status Messages
+
+The plugin reports its status based on configuration:
+
+- `"Ready (container mode)"` - Plugin is properly configured with valid credentials and Docker (default)
+- `"Ready (local mode)"` - Configured for local execution (development only)
+- `"Missing dependency: runspace-agent not installed"` - Install runspace-agent
+- `"Missing credentials: Set ANTHROPIC_API_KEY or ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN"` - Configure API access
+- `"Docker not available"` - Docker is required for container mode (default)
+- `"Configuration error: <details>"` - Check logs for specific error details
+
+## Development
+
+### Running Tests
+
+```bash
+cd plugins/skillberry-plugin-anthropic-skill-generator
+pytest tests/
+```
+
+### Plugin Structure
+
+```
+skillberry-plugin-anthropic-skill-generator/
+├── src/
+│   └── skillberry_plugin_anthropic_skill_generator/
+│       ├── __init__.py
+│       └── plugin.py
+├── tests/
+│   └── test_anthropic_skill_generator_plugin.py
+├── pyproject.toml
+└── README.md
+```
+
+## API Reference
+
+### SkillberryPluginAnthropicSkillGenerator
+
+Main plugin class that handles skill generation.
+
+#### Methods
+
+- `generate_skill(description, skill_name=None, tags=None)` - Generate and import an Anthropic skill
+- `is_enabled()` - Check if plugin is properly configured
+- `get_status_message()` - Get current plugin status
+
+## Troubleshooting
+
+### Plugin Not Appearing
+
+Ensure the plugin is installed:
+```bash
+pip list | grep skillberry-plugin-anthropic-skill-generator
+```
+
+### Plugin Shows "Missing credentials"
+
+Set the required environment variables before starting Skillberry Store:
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."
+skillberry-store
+```
+
+### Generation Fails with "Authentication error"
+
+Verify your API credentials:
+```bash
+# Test with curl
+curl https://api.anthropic.com/v1/messages \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "content-type: application/json" \
+  -d '{"model":"claude-3-5-sonnet-20241022","max_tokens":10,"messages":[{"role":"user","content":"Hi"}]}'
+```
+
+### Container Mode Fails (Default Mode)
+
+Ensure Docker is running:
+```bash
+docker ps
+# If this fails, start Docker daemon
+
+# On Linux
+sudo systemctl start docker
+
+# On macOS/Windows
+# Start Docker Desktop application
+```
+
+If Docker is not available and you need to run immediately, you can temporarily use local mode:
+```bash
+export RUNSPACE_MODE=local
+skillberry-store
+```
+
+**Warning:** Local mode is not recommended for production as it provides less isolation.
+
+### Generation Takes Too Long
+
+Reduce max_turns or switch to a faster model:
+```bash
+export RUNSPACE_MAX_TURNS="50"
+export ANTHROPIC_MODEL="claude-3-5-sonnet-20241022"
+```
+
+### Import Errors
+
+Check the logs for detailed error messages:
+```bash
+tail -f /path/to/skillberry-store/logs/app.log
+```
+
+### Skill Quality Issues
+
+The generated skill quality depends on:
+- **Description clarity**: Be specific about what the skill should do
+- **Model selection**: Opus models generally produce better results
+- **Max turns**: Higher values allow more refinement (but take longer)
+
+Example of a good description:
+```
+"Create a skill that extracts text from PDF files, supports both text-based and
+scanned PDFs using OCR, handles multi-page documents, and returns structured JSON
+with page numbers and extracted content."
+```
+
+## License
+
+Apache License 2.0
+
+## Contributing
+
+Contributions are welcome! Please ensure:
+- Code follows the existing plugin structure
+- Tests are included for new features
+- Documentation is updated accordingly
+
+## Support
+
+For issues and questions:
+- GitHub Issues: [skillberry-ai/skillberry-store](https://github.com/skillberry-ai/skillberry-store)
+- Documentation: [Skillberry Store Docs](https://github.com/skillberry-ai/skillberry-store/tree/main/docs)

--- a/plugins/skillberry-plugin-anthropic-skill-generator/pyproject.toml
+++ b/plugins/skillberry-plugin-anthropic-skill-generator/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["setuptools>=45", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "skillberry-plugin-anthropic-skill-generator"
+version = "0.1.0"
+description = "Skillberry Store plugin for generating Anthropic skills from descriptions using runspace-agent"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "runspace-agent[claude]==0.1.0",
+]
+
+[project.entry-points."skillberry_store.plugins"]
+anthropic-skill-generator = "skillberry_plugin_anthropic_skill_generator.plugin:SkillberryPluginAnthropicSkillGenerator"
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pytest-asyncio",
+]
+
+[tool.setuptools]
+packages = ["skillberry_plugin_anthropic_skill_generator"]
+package-dir = {"" = "src"}

--- a/plugins/skillberry-plugin-anthropic-skill-generator/src/skillberry_plugin_anthropic_skill_generator/__init__.py
+++ b/plugins/skillberry-plugin-anthropic-skill-generator/src/skillberry_plugin_anthropic_skill_generator/__init__.py
@@ -1,0 +1,7 @@
+"""Skillberry Plugin for generating Anthropic skills from descriptions."""
+
+from .plugin import SkillberryPluginAnthropicSkillGenerator
+
+__all__ = ["SkillberryPluginAnthropicSkillGenerator"]
+
+# Made with Bob

--- a/plugins/skillberry-plugin-anthropic-skill-generator/src/skillberry_plugin_anthropic_skill_generator/plugin.py
+++ b/plugins/skillberry-plugin-anthropic-skill-generator/src/skillberry_plugin_anthropic_skill_generator/plugin.py
@@ -1,0 +1,651 @@
+"""
+Skillberry Plugin Anthropic Skill Generator - generates Anthropic skills from descriptions.
+Uses runspace-agent to create skills and imports them into the store.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import tempfile
+import threading
+import time
+import uuid
+from typing import Dict, Any, Literal, Optional
+from pathlib import Path
+
+from skillberry_store.plugins.base import PluginBase, PluginMetadata, PluginType
+
+logger = logging.getLogger(__name__)
+
+
+class SkillberryPluginAnthropicSkillGenerator(PluginBase):
+    """Plugin for generating Anthropic skills from descriptions using runspace-agent."""
+
+    def __init__(self):
+        super().__init__()
+        
+        self._metadata = PluginMetadata(
+            name="Anthropic Skill Generator",
+            version="0.1.0",
+            description="Generate Anthropic skills from descriptions using runspace-agent",
+            plugin_type=PluginType.CREATOR,
+        )
+        
+        self._status_message = "Initializing..."
+        self._runspace_available = False
+        self._credentials_configured = False
+        self._execution_mode = os.getenv("RUNSPACE_MODE", "container")  # Default to container for safety
+        self._claude_settings = None
+        
+        # Try to load Claude settings from ~/.claude/settings.json
+        self._load_claude_settings()
+        
+        # Try to import runspace-agent
+        try:
+            import runspace_agent
+            self._runspace_available = True
+            logger.info("runspace-agent library available")
+            
+            # Check for Anthropic credentials (env vars or settings file)
+            self._credentials_configured = self._check_credentials()
+            
+            if self._credentials_configured:
+                mode_label = f" ({self._execution_mode} mode)" if self._execution_mode else ""
+                source = " from ~/.claude/settings.json" if self._claude_settings else ""
+                self._status_message = f"Ready{mode_label}{source}"
+                logger.info(f"Plugin ready with {self._execution_mode} execution mode")
+            else:
+                self._status_message = "Missing credentials: Set ANTHROPIC_API_KEY, configure ~/.claude/settings.json, or provide ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN"
+                logger.warning("Anthropic credentials not configured")
+                
+        except ImportError:
+            self._status_message = "Missing dependency: runspace-agent not installed"
+            logger.warning("runspace-agent not installed, plugin will be disabled")
+        except Exception as e:
+            self._status_message = f"Configuration error: {str(e)}"
+            logger.error(f"Failed to initialize runspace-agent: {e}", exc_info=True)
+    
+    def _load_claude_settings(self):
+        """Load Claude settings from ~/.claude/settings.json if it exists."""
+        settings_path = Path.home() / ".claude" / "settings.json"
+        
+        if settings_path.exists():
+            try:
+                with open(settings_path, 'r') as f:
+                    self._claude_settings = json.load(f)
+                logger.info(f"Loaded Claude settings from {settings_path}")
+            except Exception as e:
+                logger.warning(f"Failed to load Claude settings from {settings_path}: {e}")
+                self._claude_settings = None
+        else:
+            logger.debug(f"Claude settings file not found at {settings_path}")
+    
+    def _check_credentials(self) -> bool:
+        """Check if Anthropic credentials are configured."""
+        # Check for direct API key in environment
+        if os.getenv("ANTHROPIC_API_KEY"):
+            return True
+        
+        # Check for proxy/gateway configuration in environment
+        if os.getenv("ANTHROPIC_BASE_URL") and os.getenv("ANTHROPIC_AUTH_TOKEN"):
+            return True
+        
+        # Check for credentials in Claude settings file
+        if self._claude_settings:
+            # Check for API key in settings
+            if self._claude_settings.get("apiKey"):
+                return True
+            
+            # Check for proxy configuration in settings
+            if self._claude_settings.get("baseUrl") and self._claude_settings.get("authToken"):
+                return True
+        
+        return False
+    
+    def _build_claude_env(self, override_env: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+        """Build environment variables for Claude Code agent.
+        
+        Priority order (highest to lowest):
+        1. override_env (request-specific)
+        2. System environment variables
+        3. ~/.claude/settings.json
+        
+        Args:
+            override_env: Optional environment variables to override defaults
+            
+        Returns:
+            Dictionary of environment variables for Claude Code
+        """
+        env = {}
+        
+        # Start with Claude settings file (lowest priority)
+        if self._claude_settings:
+            if self._claude_settings.get("apiKey"):
+                env["ANTHROPIC_API_KEY"] = self._claude_settings["apiKey"]
+            
+            if self._claude_settings.get("baseUrl"):
+                env["ANTHROPIC_BASE_URL"] = self._claude_settings["baseUrl"]
+            
+            if self._claude_settings.get("authToken"):
+                env["ANTHROPIC_AUTH_TOKEN"] = self._claude_settings["authToken"]
+            
+            if self._claude_settings.get("model"):
+                env["ANTHROPIC_MODEL"] = self._claude_settings["model"]
+        
+        # Override with system environment variables (medium priority)
+        if os.getenv("ANTHROPIC_API_KEY"):
+            env["ANTHROPIC_API_KEY"] = os.getenv("ANTHROPIC_API_KEY")
+        
+        if os.getenv("ANTHROPIC_BASE_URL"):
+            env["ANTHROPIC_BASE_URL"] = os.getenv("ANTHROPIC_BASE_URL")
+        
+        if os.getenv("ANTHROPIC_AUTH_TOKEN"):
+            env["ANTHROPIC_AUTH_TOKEN"] = os.getenv("ANTHROPIC_AUTH_TOKEN")
+        
+        if os.getenv("ANTHROPIC_MODEL"):
+            env["ANTHROPIC_MODEL"] = os.getenv("ANTHROPIC_MODEL")
+        
+        # Override with request-specific values (highest priority)
+        if override_env:
+            env.update(override_env)
+        
+        return env
+
+    @property
+    def metadata(self) -> PluginMetadata:
+        """Return plugin metadata."""
+        return self._metadata
+    
+    def get_status_message(self) -> str:
+        """Return current plugin status."""
+        return self._status_message
+
+    def is_enabled(self) -> bool:
+        """Plugin is enabled if runspace-agent is available and credentials are configured."""
+        return self._runspace_available and self._credentials_configured
+
+    def _stream_docker_logs(self, workspace_root: Path, stop: threading.Event) -> None:
+        """Background thread: find the container mounting workspace_root and tail its logs."""
+        try:
+            import docker  # type: ignore[import-untyped]
+            client = docker.from_env()
+            container = None
+            # Wait up to 30 s for the container to appear
+            for _ in range(60):
+                if stop.is_set():
+                    return
+                time.sleep(0.5)
+                for c in client.containers.list():
+                    for mount in c.attrs.get("Mounts", []):
+                        if str(workspace_root) in mount.get("Source", ""):
+                            container = c
+                            break
+                    if container:
+                        break
+                if container:
+                    break
+
+            if not container:
+                logger.debug("Docker log streaming: container not found within timeout")
+                return
+
+            cid = container.short_id
+            logger.info(f"  [container:{cid}] Attaching to container logs...")
+            for chunk in container.logs(stream=True, follow=True, stderr=True, stdout=True):
+                if stop.is_set():
+                    break
+                line = chunk.decode("utf-8", errors="replace").rstrip()
+                if line:
+                    logger.info(f"  [container:{cid}] {line}")
+
+        except ImportError:
+            logger.debug("Docker SDK not available — install runspace-agent[container] for live logs")
+        except Exception as e:
+            logger.debug(f"Docker log streaming ended: {e}")
+
+    async def _stream_progress(
+        self,
+        mode: str,
+        workspace_root: Path,
+        run_task: "asyncio.Task[Any]",
+    ) -> None:
+        """Poll workspace for new files while agent runs; also stream Docker logs in container mode."""
+        editable = workspace_root / "agent_workspace" / "editable"
+        seen: set = set()
+
+        stop = threading.Event()
+        if mode == "container":
+            t = threading.Thread(
+                target=self._stream_docker_logs,
+                args=(workspace_root, stop),
+                daemon=True,
+            )
+            t.start()
+
+        try:
+            while not run_task.done():
+                await asyncio.sleep(5)
+                if not editable.exists():
+                    continue
+                current = {str(p) for p in editable.rglob("*") if p.is_file()}
+                for f in sorted(current - seen):
+                    rel = Path(f).relative_to(editable)
+                    logger.info(f"  [progress] created: {rel}")
+                seen = current
+        finally:
+            stop.set()
+
+    def _log_session_details(self, session_id: str) -> None:
+        """Log the summary and key conversation milestones from a completed session."""
+        try:
+            from runspace_agent.workspaces import session_workspace
+            workspace = session_workspace(session_id)
+
+            # Log human-readable summary if available
+            summary_path = workspace / "summary.md"
+            if summary_path.exists():
+                summary = summary_path.read_text(encoding="utf-8").strip()
+                logger.info(f"Session summary:\n{summary}")
+
+            # Parse conversation.json for key milestones
+            conv_path = workspace / "conversation.json"
+            if not conv_path.exists():
+                return
+
+            conv = json.loads(conv_path.read_text(encoding="utf-8"))
+            if not isinstance(conv, list):
+                return
+
+            logger.info(f"Agent conversation replay ({len(conv)} messages):")
+            for msg in conv:
+                t = msg.get("type", "")
+                data = msg.get("data", msg)
+
+                if t == "assistant":
+                    for block in (data.get("content") or []):
+                        if not isinstance(block, dict):
+                            continue
+                        if block.get("type") == "text":
+                            text = block["text"].strip().replace("\n", " ")
+                            if text:
+                                logger.info(f"  [agent] {text[:200]}")
+                        elif block.get("type") == "tool_use":
+                            inp = block.get("input", {})
+                            detail = (
+                                inp.get("command")
+                                or inp.get("file_path")
+                                or inp.get("path")
+                                or str(inp)[:80]
+                            )
+                            logger.info(f"  [tool]  {block['name']}: {str(detail)[:120]}")
+
+                elif t == "result":
+                    turns = data.get("num_turns", "?")
+                    cost = data.get("total_cost_usd")
+                    usage = data.get("usage", {})
+                    out_tok = usage.get("output_tokens", "?")
+                    cache_r = usage.get("cache_read_input_tokens", 0)
+                    cost_str = f" ${cost:.4f}" if cost is not None else ""
+                    logger.info(
+                        f"  [done]  {turns} turns, {out_tok} output tokens"
+                        f", {cache_r} cache-read tokens{cost_str}"
+                    )
+
+        except Exception as e:
+            logger.debug(f"Could not read session details for {session_id}: {e}")
+
+    async def generate_skill(
+        self,
+        description: str,
+        skill_name: Optional[str] = None,
+        tags: Optional[list] = None,
+        agent_env: Optional[Dict[str, str]] = None,
+        execution_mode: Optional[str] = None,
+        max_turns: Optional[int] = None
+    ) -> Dict[str, Any]:
+        """
+        Generate an Anthropic skill from a description using runspace-agent.
+        
+        Args:
+            description: Natural language description of the skill to create
+            skill_name: Optional name for the skill
+            tags: Optional list of tags to apply to the imported skill
+            agent_env: Optional environment variables for Claude Code (API keys, etc.)
+            execution_mode: Optional execution mode ("local" or "container")
+            max_turns: Optional maximum conversation turns for Claude Code
+            
+        Returns:
+            Dict with skill details (uuid, name, tools, etc.)
+        """
+        if not self._runspace_available:
+            raise RuntimeError("runspace-agent not available")
+        
+        if not self._credentials_configured and not agent_env:
+            raise RuntimeError(
+                "Anthropic credentials not configured. Set ANTHROPIC_API_KEY or provide agent_env"
+            )
+        
+        if not self.store:
+            raise RuntimeError("Store API not available")
+        
+        logger.info(f"Generating Anthropic skill from description: {description[:100]}...")
+        
+        # Import required modules
+        from runspace_agent import RunspaceSession, run_agent
+        from claude_code_sdk import ClaudeCodeOptions
+
+        # Build environment for Claude Code
+        claude_env = self._build_claude_env(agent_env)
+
+        # Configure Claude Code options.
+        # Use agent_options (not a pre-built agent) so both local and container
+        # modes can read the env vars from the session — container mode reads
+        # session.agent_options.env to inject credentials into the Docker container.
+        options = ClaudeCodeOptions(
+            env=claude_env,
+            max_turns=max_turns or int(os.getenv("RUNSPACE_MAX_TURNS", "300")),
+        )
+        
+        # Determine execution mode
+        raw_mode = execution_mode or self._execution_mode
+        mode: Literal["local", "container"] = "container" if raw_mode == "container" else "local"
+        
+        # Create a temporary directory for the generated skill
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            skill_dir = temp_path / "generated_skill"
+            skill_dir.mkdir(exist_ok=True)
+            context_dir = temp_path / "context"
+            context_dir.mkdir(exist_ok=True)
+            
+            logger.info(f"Creating skill in temporary directory: {skill_dir}")
+            
+            # Create a prompt for skill generation
+            prompt = f"""Create a new Anthropic skill based on this description:
+
+{description}
+
+Generate a complete skill with:
+1. A SKILL.md file with proper frontmatter (name, description)
+2. Any necessary tool implementations
+3. Documentation and examples
+4. Follow Anthropic skill best practices
+
+The skill should be production-ready and well-documented."""
+
+            if skill_name:
+                prompt += f"\n\nUse '{skill_name}' as the skill name."
+            
+            # Generate the skill using runspace-agent
+            try:
+                # Pre-generate session_id so we know the workspace path before
+                # run_agent starts — needed for concurrent progress streaming.
+                session_id = uuid.uuid4().hex[:12]
+                from runspace_agent.workspaces import session_workspace
+                workspace_root = session_workspace(session_id)
+
+                # Create a session — pass agent_options (not a pre-built agent) so
+                # both local and container backends can read credentials from it.
+                session = RunspaceSession(
+                    editable_dir=skill_dir,
+                    context_dir=context_dir,
+                    prompt=prompt,
+                    agent_options=options,
+                    preinstalled_skills=["skill-creator"],
+                    mode=mode,
+                )
+
+                logger.info(
+                    f"Running agent in {mode} mode "
+                    f"(session {session_id})"
+                    + (" — container will stream logs below..." if mode == "container"
+                       else " — watching workspace for progress...")
+                )
+                t0 = time.monotonic()
+
+                # Run agent and stream progress concurrently
+                run_task = asyncio.create_task(
+                    run_agent(session, session_id=session_id)
+                )
+                progress_task = asyncio.create_task(
+                    self._stream_progress(mode, workspace_root, run_task)
+                )
+                try:
+                    result = await run_task
+                finally:
+                    progress_task.cancel()
+                    try:
+                        await progress_task
+                    except asyncio.CancelledError:
+                        pass
+
+                elapsed = time.monotonic() - t0
+
+                if not result.success:
+                    logger.error(
+                        f"Agent failed after {elapsed:.1f}s: "
+                        f"{result.agent_result.error or 'Unknown error'}"
+                    )
+                    raise RuntimeError(f"Agent failed: {result.agent_result.error or 'Unknown error'}")
+
+                logger.info(
+                    f"Agent completed successfully in {elapsed:.1f}s "
+                    f"(session {result.session_id}, "
+                    f"{result.agent_result.total_tokens} tokens"
+                    + (f", ${result.agent_result.total_cost_usd:.4f}" if result.agent_result.total_cost_usd else "")
+                    + ")"
+                )
+                self._log_session_details(result.session_id)
+                
+            except Exception as e:
+                logger.error(f"Failed to generate skill with runspace-agent: {e}", exc_info=True)
+                raise RuntimeError(f"Skill generation failed: {str(e)}")
+            
+            # Import the generated skill into the store using the Anthropic importer
+            try:
+                from skillberry_store.tools.anthropic.importer import import_from_anthropic_skill
+                from runspace_agent.workspaces import session_workspace
+
+                # Container mode does not sync files back to session.editable_dir —
+                # generated files live in the runspace session workspace instead.
+                # Local mode does sync back, so skill_dir is correct there.
+                if mode == "container":
+                    import_dir = session_workspace(result.session_id) / "agent_workspace" / "editable"
+                else:
+                    import_dir = skill_dir
+
+                logger.info(f"Importing generated skill from {import_dir}...")
+
+                # Import from the folder
+                skill_name_result, skill_description, tools, snippets, ignored_files = (
+                    import_from_anthropic_skill(
+                        source_type="folder",
+                        source_data=str(import_dir),
+                        snippet_mode="file",
+                        treat_all_as_documents=False
+                    )
+                )
+                
+                logger.info(
+                    f"Imported skill '{skill_name_result}': "
+                    f"{len(tools)} tools, {len(snippets)} snippets, "
+                    f"{len(ignored_files)} ignored files"
+                )
+                
+                # Create tools in the store
+                tool_uuids = []
+                for tool in tools:
+                    try:
+                        tool_tags = list(getattr(tool, "tags", None) or [])
+                        if tags:
+                            tool_tags.extend(t for t in tags if t not in tool_tags)
+                        tool_data = {
+                            "name": tool.name,
+                            "description": tool.description or "",
+                            "programming_language": tool.programming_language or "python",
+                            "params": tool.params or {},
+                            "returns": tool.returns or {},
+                            "tags": tool_tags,
+                        }
+
+                        module_bytes = tool.module_content.encode() if tool.module_content else b""
+                        module_filename = tool.source_file_name or f"{tool.name}.py"
+                        created_tool = self.store.create_tool(
+                            tool_data,
+                            module_content=module_bytes,
+                            module_filename=module_filename,
+                        )
+                        tool_uuids.append(created_tool["uuid"])
+                        logger.info(f"Created tool: {tool.name} ({created_tool['uuid']})")
+                        
+                    except Exception as e:
+                        logger.error(f"Failed to create tool {tool.name}: {e}", exc_info=True)
+                
+                # Create snippets in the store
+                snippet_uuids = []
+                for snippet in snippets:
+                    try:
+                        snippet_tags = list(getattr(snippet, "tags", None) or [])
+                        if tags:
+                            snippet_tags.extend(t for t in tags if t not in snippet_tags)
+                        snippet_data = {
+                            "name": snippet.name,
+                            "content": snippet.content,
+                            "tags": snippet_tags,
+                            "description": snippet.description or "",
+                            "version": getattr(snippet, "version", "1.0.0"),
+                        }
+                        
+                        created_snippet = self.store.create_snippet(snippet_data)
+                        snippet_uuids.append(created_snippet["uuid"])
+                        logger.info(f"Created snippet: {snippet.name} ({created_snippet['uuid']})")
+                        
+                    except Exception as e:
+                        logger.error(f"Failed to create snippet {snippet.name}: {e}", exc_info=True)
+                
+                # Create the skill in the store
+                final_skill_name = skill_name or skill_name_result
+                skill_tags = ["anthropic", "generated"]
+                if tags:
+                    skill_tags.extend(tags)
+                
+                skill_data = {
+                    "name": final_skill_name,
+                    "description": skill_description,
+                    "tool_uuids": tool_uuids,
+                    "tags": skill_tags,
+                }
+                
+                created_skill = self.store.create_skill(skill_data)
+                logger.info(f"Skill created with UUID: {created_skill.get('uuid')}")
+                
+                return {
+                    "success": True,
+                    "skill": created_skill,
+                    "tools_count": len(tool_uuids),
+                    "snippets_count": len(snippet_uuids),
+                    "ignored_files": ignored_files,
+                }
+                
+            except Exception as e:
+                logger.error(f"Failed to import generated skill: {e}", exc_info=True)
+                raise RuntimeError(f"Skill import failed: {str(e)}")
+
+    def get_router(self):
+        """Register plugin routes."""
+        from fastapi import APIRouter, HTTPException
+        from pydantic import BaseModel
+        from typing import List, Optional
+        
+        router = APIRouter()
+        
+        class GenerateSkillRequest(BaseModel):
+            description: str
+            skill_name: Optional[str] = None
+            tags: Optional[List[str]] = None
+            agent_env: Optional[Dict[str, str]] = None
+            execution_mode: Optional[str] = None
+            max_turns: Optional[int] = None
+        
+        @router.post("/generate-skill")
+        async def generate_skill_endpoint(request: GenerateSkillRequest):
+            """Generate an Anthropic skill from a description."""
+            if not self.is_enabled():
+                raise HTTPException(status_code=503, detail=self._status_message)
+            
+            try:
+                result = await self.generate_skill(
+                    description=request.description,
+                    skill_name=request.skill_name,
+                    tags=request.tags,
+                    agent_env=request.agent_env,
+                    execution_mode=request.execution_mode,
+                    max_turns=request.max_turns
+                )
+                return {
+                    "success": True,
+                    "message": f"Skill '{result['skill']['name']}' generated successfully.",
+                    "skill_name": result["skill"]["name"],
+                    "skill_uuid": result["skill"]["uuid"],
+                    "tools_count": result["tools_count"],
+                    "snippets_count": result["snippets_count"],
+                }
+            except Exception as e:
+                logger.error(f"Failed to generate skill: {e}", exc_info=True)
+                raise HTTPException(status_code=500, detail=str(e))
+        
+        return router
+    
+    def get_cli_commands(self) -> Optional[Dict[str, Any]]:
+        """No CLI commands for this plugin."""
+        return None
+    
+    def get_ui_config(self) -> Optional[Dict[str, Any]]:
+        """Return UI configuration for the plugin."""
+        return {
+            "icon": "WandIcon",
+            "color": "#8B5CF6",
+            "actions": [
+                {
+                    "label": "Generate Anthropic Skill",
+                    "endpoint": "/api/plugins/anthropic-skill-generator/generate-skill",
+                    "method": "POST",
+                    "params_schema": {
+                        "type": "object",
+                        "properties": {
+                            "description": {
+                                "type": "string",
+                                "description": "Description of the Anthropic skill to generate"
+                            },
+                            "skill_name": {
+                                "type": "string",
+                                "description": "Optional name for the skill"
+                            },
+                            "tags": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "description": "Optional tags to apply to the skill"
+                            },
+                            "agent_env": {
+                                "type": "object",
+                                "description": "Optional environment variables for Claude Code (e.g., ANTHROPIC_API_KEY)"
+                            },
+                            "execution_mode": {
+                                "type": "string",
+                                "enum": ["container", "local"],
+                                "default": "container",
+                                "description": "Execution mode: 'local' (faster) or 'container' (safer, requires Docker)"
+                            },
+                            "max_turns": {
+                                "type": "integer",
+                                "description": "Maximum conversation turns for Claude Code (default: 300)"
+                            }
+                        },
+                        "required": ["description"]
+                    }
+                }
+            ]
+        }
+
+# Made with Bob

--- a/plugins/skillberry-plugin-anthropic-skill-generator/src/skillberry_plugin_anthropic_skill_generator/plugin.py
+++ b/plugins/skillberry-plugin-anthropic-skill-generator/src/skillberry_plugin_anthropic_skill_generator/plugin.py
@@ -18,6 +18,75 @@ from skillberry_store.plugins.base import PluginBase, PluginMetadata, PluginType
 
 logger = logging.getLogger(__name__)
 
+try:
+    import runspace_agent
+    from runspace_agent import RunspaceSession, run_agent
+    from runspace_agent.workspaces import session_workspace
+except ImportError:
+    runspace_agent = None
+    RunspaceSession = None
+    run_agent = None
+    session_workspace = None
+
+try:
+    from skillberry_store.tools.anthropic.importer import import_from_anthropic_skill
+except ImportError:
+    import_from_anthropic_skill = None
+
+
+async def create_skill(prompt, skill_dir, context_dir, options, mode, plugin_instance):
+    """Create and execute a runspace-agent session to generate a skill.
+
+    Module-level so tests can patch it without reaching the real runspace layer.
+    Returns the RunspaceSession result (with .session_id attribute).
+    """
+    gen_session_id = uuid.uuid4().hex[:12]
+    workspace_root = session_workspace(gen_session_id)
+
+    session = RunspaceSession(
+        editable_dir=skill_dir,
+        context_dir=context_dir,
+        prompt=prompt,
+        agent_options=options,
+        preinstalled_skills=["skill-creator"],
+        mode=mode,
+    )
+
+    logger.info(
+        f"Running agent in {mode} mode (session {gen_session_id})"
+        + (" — container will stream logs below..." if mode == "container"
+           else " — watching workspace for progress...")
+    )
+
+    t0 = time.monotonic()
+    run_task = asyncio.create_task(run_agent(session, session_id=gen_session_id))
+    progress_task = asyncio.create_task(
+        plugin_instance._stream_progress(mode, workspace_root, run_task)
+    )
+    try:
+        result = await run_task
+    finally:
+        progress_task.cancel()
+        try:
+            await progress_task
+        except asyncio.CancelledError:
+            pass
+    elapsed = time.monotonic() - t0
+    if not result.success:
+        logger.error(
+            f"Agent failed after {elapsed:.1f}s: "
+            f"{result.agent_result.error or 'Unknown error'}"
+        )
+        raise RuntimeError(f"Agent failed: {result.agent_result.error or 'Unknown error'}")
+    logger.info(
+        f"Agent completed successfully in {elapsed:.1f}s "
+        f"(session {result.session_id}, "
+        f"{result.agent_result.total_tokens} tokens"
+        + (f", ${result.agent_result.total_cost_usd:.4f}" if result.agent_result.total_cost_usd else "")
+        + ")"
+    )
+    return result
+
 
 class SkillberryPluginAnthropicSkillGenerator(PluginBase):
     """Plugin for generating Anthropic skills from descriptions using runspace-agent."""
@@ -41,30 +110,30 @@ class SkillberryPluginAnthropicSkillGenerator(PluginBase):
         # Try to load Claude settings from ~/.claude/settings.json
         self._load_claude_settings()
         
-        # Try to import runspace-agent
-        try:
-            import runspace_agent
-            self._runspace_available = True
-            logger.info("runspace-agent library available")
-            
-            # Check for Anthropic credentials (env vars or settings file)
-            self._credentials_configured = self._check_credentials()
-            
-            if self._credentials_configured:
-                mode_label = f" ({self._execution_mode} mode)" if self._execution_mode else ""
-                source = " from ~/.claude/settings.json" if self._claude_settings else ""
-                self._status_message = f"Ready{mode_label}{source}"
-                logger.info(f"Plugin ready with {self._execution_mode} execution mode")
-            else:
-                self._status_message = "Missing credentials: Set ANTHROPIC_API_KEY, configure ~/.claude/settings.json, or provide ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN"
-                logger.warning("Anthropic credentials not configured")
-                
-        except ImportError:
+        # Check if runspace-agent is available (module-level import)
+        if runspace_agent is not None:
+            try:
+                self._runspace_available = True
+                logger.info("runspace-agent library available")
+
+                # Check for Anthropic credentials (env vars or settings file)
+                self._credentials_configured = self._check_credentials()
+
+                if self._credentials_configured:
+                    mode_label = f" ({self._execution_mode} mode)" if self._execution_mode else ""
+                    source = " from ~/.claude/settings.json" if self._claude_settings else ""
+                    self._status_message = f"Ready{mode_label}{source}"
+                    logger.info(f"Plugin ready with {self._execution_mode} execution mode")
+                else:
+                    self._status_message = "Missing credentials: Set ANTHROPIC_API_KEY, configure ~/.claude/settings.json, or provide ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN"
+                    logger.warning("Anthropic credentials not configured")
+
+            except Exception as e:
+                self._status_message = f"Configuration error: {str(e)}"
+                logger.error(f"Failed to initialize runspace-agent: {e}", exc_info=True)
+        else:
             self._status_message = "Missing dependency: runspace-agent not installed"
             logger.warning("runspace-agent not installed, plugin will be disabled")
-        except Exception as e:
-            self._status_message = f"Configuration error: {str(e)}"
-            logger.error(f"Failed to initialize runspace-agent: {e}", exc_info=True)
     
     def _load_claude_settings(self):
         """Load Claude settings from ~/.claude/settings.json if it exists."""
@@ -320,19 +389,17 @@ class SkillberryPluginAnthropicSkillGenerator(PluginBase):
         """
         if not self._runspace_available:
             raise RuntimeError("runspace-agent not available")
-        
+
+        if self._store_api is None:
+            raise RuntimeError("Store API not available")
+
         if not self._credentials_configured and not agent_env:
             raise RuntimeError(
                 "Anthropic credentials not configured. Set ANTHROPIC_API_KEY or provide agent_env"
             )
-        
-        if not self.store:
-            raise RuntimeError("Store API not available")
-        
+
         logger.info(f"Generating Anthropic skill from description: {description[:100]}...")
-        
-        # Import required modules
-        from runspace_agent import RunspaceSession, run_agent
+
         from claude_code_sdk import ClaudeCodeOptions
 
         # Build environment for Claude Code
@@ -379,74 +446,15 @@ The skill should be production-ready and well-documented."""
             
             # Generate the skill using runspace-agent
             try:
-                # Pre-generate session_id so we know the workspace path before
-                # run_agent starts — needed for concurrent progress streaming.
-                session_id = uuid.uuid4().hex[:12]
-                from runspace_agent.workspaces import session_workspace
-                workspace_root = session_workspace(session_id)
-
-                # Create a session — pass agent_options (not a pre-built agent) so
-                # both local and container backends can read credentials from it.
-                session = RunspaceSession(
-                    editable_dir=skill_dir,
-                    context_dir=context_dir,
-                    prompt=prompt,
-                    agent_options=options,
-                    preinstalled_skills=["skill-creator"],
-                    mode=mode,
-                )
-
-                logger.info(
-                    f"Running agent in {mode} mode "
-                    f"(session {session_id})"
-                    + (" — container will stream logs below..." if mode == "container"
-                       else " — watching workspace for progress...")
-                )
-                t0 = time.monotonic()
-
-                # Run agent and stream progress concurrently
-                run_task = asyncio.create_task(
-                    run_agent(session, session_id=session_id)
-                )
-                progress_task = asyncio.create_task(
-                    self._stream_progress(mode, workspace_root, run_task)
-                )
-                try:
-                    result = await run_task
-                finally:
-                    progress_task.cancel()
-                    try:
-                        await progress_task
-                    except asyncio.CancelledError:
-                        pass
-
-                elapsed = time.monotonic() - t0
-
-                if not result.success:
-                    logger.error(
-                        f"Agent failed after {elapsed:.1f}s: "
-                        f"{result.agent_result.error or 'Unknown error'}"
-                    )
-                    raise RuntimeError(f"Agent failed: {result.agent_result.error or 'Unknown error'}")
-
-                logger.info(
-                    f"Agent completed successfully in {elapsed:.1f}s "
-                    f"(session {result.session_id}, "
-                    f"{result.agent_result.total_tokens} tokens"
-                    + (f", ${result.agent_result.total_cost_usd:.4f}" if result.agent_result.total_cost_usd else "")
-                    + ")"
-                )
+                result = await create_skill(prompt, skill_dir, context_dir, options, mode, self)
                 self._log_session_details(result.session_id)
-                
+
             except Exception as e:
                 logger.error(f"Failed to generate skill with runspace-agent: {e}", exc_info=True)
                 raise RuntimeError(f"Skill generation failed: {str(e)}")
             
             # Import the generated skill into the store using the Anthropic importer
             try:
-                from skillberry_store.tools.anthropic.importer import import_from_anthropic_skill
-                from runspace_agent.workspaces import session_workspace
-
                 # Container mode does not sync files back to session.editable_dir —
                 # generated files live in the runspace session workspace instead.
                 # Local mode does sync back, so skill_dir is correct there.

--- a/plugins/skillberry-plugin-anthropic-skill-generator/tests/__init__.py
+++ b/plugins/skillberry-plugin-anthropic-skill-generator/tests/__init__.py
@@ -1,0 +1,3 @@
+"""Tests for the Anthropic Skill Generator plugin."""
+
+# Made with Bob

--- a/plugins/skillberry-plugin-anthropic-skill-generator/tests/__init__.py
+++ b/plugins/skillberry-plugin-anthropic-skill-generator/tests/__init__.py
@@ -1,3 +1,0 @@
-"""Tests for the Anthropic Skill Generator plugin."""
-
-# Made with Bob

--- a/plugins/skillberry-plugin-anthropic-skill-generator/tests/test_anthropic_skill_generator_plugin.py
+++ b/plugins/skillberry-plugin-anthropic-skill-generator/tests/test_anthropic_skill_generator_plugin.py
@@ -1,7 +1,7 @@
 """Tests for the Anthropic Skill Generator plugin."""
 
 import pytest
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import AsyncMock, Mock, patch, MagicMock
 from pathlib import Path
 
 from skillberry_plugin_anthropic_skill_generator.plugin import SkillberryPluginAnthropicSkillGenerator
@@ -38,7 +38,7 @@ def test_plugin_metadata(plugin):
 
 def test_plugin_initialization_without_runspace():
     """Test plugin initialization when runspace-agent is not available."""
-    with patch("skillberry_plugin_anthropic_skill_generator.plugin.runspace_agent", side_effect=ImportError):
+    with patch("skillberry_plugin_anthropic_skill_generator.plugin.runspace_agent", None):
         plugin = SkillberryPluginAnthropicSkillGenerator()
         assert not plugin.is_enabled()
         assert "not installed" in plugin.get_status_message()
@@ -46,10 +46,9 @@ def test_plugin_initialization_without_runspace():
 
 def test_plugin_initialization_with_runspace():
     """Test plugin initialization when runspace-agent is available."""
-    with patch("skillberry_plugin_anthropic_skill_generator.plugin.runspace_agent"):
+    with patch("skillberry_plugin_anthropic_skill_generator.plugin.runspace_agent", MagicMock()):
         plugin = SkillberryPluginAnthropicSkillGenerator()
-        # Note: This will still fail if runspace-agent is not actually installed
-        # In a real environment with runspace-agent, this should pass
+        assert plugin._runspace_available
 
 
 def test_get_router(plugin):
@@ -98,7 +97,8 @@ async def test_generate_skill_without_runspace(plugin, mock_store):
 async def test_generate_skill_without_store(plugin):
     """Test that generate_skill raises error when store is not available."""
     plugin._runspace_available = True
-    
+    plugin._credentials_configured = True
+
     with pytest.raises(RuntimeError, match="Store API not available"):
         await plugin.generate_skill("Test skill description")
 
@@ -108,11 +108,12 @@ async def test_generate_skill_success(plugin, mock_store):
     """Test successful skill generation."""
     plugin.set_store_api(mock_store)
     plugin._runspace_available = True
-    
-    # Mock the runspace-agent create_skill function
-    mock_create_skill = Mock(return_value={"status": "success"})
-    
-    # Mock the import_from_anthropic_skill function
+    plugin._credentials_configured = True
+
+    mock_result = MagicMock()
+    mock_result.session_id = "test-session-id"
+    mock_create_skill = AsyncMock(return_value=mock_result)
+
     mock_tool = Mock()
     mock_tool.name = "test_tool"
     mock_tool.description = "Test tool"
@@ -120,13 +121,17 @@ async def test_generate_skill_success(plugin, mock_store):
     mock_tool.params = {}
     mock_tool.returns = {}
     mock_tool.content = "def test(): pass"
-    
+    mock_tool.module_content = "def test(): pass"
+    mock_tool.source_file_name = "test_tool.py"
+    mock_tool.tags = None
+
     mock_snippet = Mock()
     mock_snippet.name = "test_snippet"
     mock_snippet.content = "Test content"
     mock_snippet.language = "text"
     mock_snippet.description = "Test snippet"
-    
+    mock_snippet.tags = None
+
     mock_import = Mock(return_value=(
         "test_skill",
         "Test skill description",
@@ -134,7 +139,7 @@ async def test_generate_skill_success(plugin, mock_store):
         [mock_snippet],
         []
     ))
-    
+
     with patch("skillberry_plugin_anthropic_skill_generator.plugin.create_skill", mock_create_skill):
         with patch("skillberry_plugin_anthropic_skill_generator.plugin.import_from_anthropic_skill", mock_import):
             result = await plugin.generate_skill(
@@ -142,14 +147,12 @@ async def test_generate_skill_success(plugin, mock_store):
                 skill_name="test_skill",
                 tags=["test"]
             )
-    
-    # Verify the result
+
     assert result["success"] is True
     assert result["skill"]["uuid"] == "skill-uuid-789"
     assert result["tools_count"] == 1
     assert result["snippets_count"] == 1
-    
-    # Verify store methods were called
+
     mock_store.create_tool.assert_called_once()
     mock_store.create_snippet.assert_called_once()
     mock_store.create_skill.assert_called_once()
@@ -160,10 +163,10 @@ async def test_generate_skill_with_generation_error(plugin, mock_store):
     """Test skill generation when runspace-agent fails."""
     plugin.set_store_api(mock_store)
     plugin._runspace_available = True
-    
-    # Mock create_skill to raise an exception
-    mock_create_skill = Mock(side_effect=Exception("Generation failed"))
-    
+    plugin._credentials_configured = True
+
+    mock_create_skill = AsyncMock(side_effect=Exception("Generation failed"))
+
     with patch("skillberry_plugin_anthropic_skill_generator.plugin.create_skill", mock_create_skill):
         with pytest.raises(RuntimeError, match="Skill generation failed"):
             await plugin.generate_skill("Test skill description")
@@ -174,13 +177,14 @@ async def test_generate_skill_with_import_error(plugin, mock_store):
     """Test skill generation when import fails."""
     plugin.set_store_api(mock_store)
     plugin._runspace_available = True
-    
-    # Mock create_skill to succeed
-    mock_create_skill = Mock(return_value={"status": "success"})
-    
-    # Mock import to fail
+    plugin._credentials_configured = True
+
+    mock_result = MagicMock()
+    mock_result.session_id = "test-session-id"
+    mock_create_skill = AsyncMock(return_value=mock_result)
+
     mock_import = Mock(side_effect=Exception("Import failed"))
-    
+
     with patch("skillberry_plugin_anthropic_skill_generator.plugin.create_skill", mock_create_skill):
         with patch("skillberry_plugin_anthropic_skill_generator.plugin.import_from_anthropic_skill", mock_import):
             with pytest.raises(RuntimeError, match="Skill import failed"):

--- a/plugins/skillberry-plugin-anthropic-skill-generator/tests/test_anthropic_skill_generator_plugin.py
+++ b/plugins/skillberry-plugin-anthropic-skill-generator/tests/test_anthropic_skill_generator_plugin.py
@@ -1,0 +1,200 @@
+"""Tests for the Anthropic Skill Generator plugin."""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from pathlib import Path
+
+from skillberry_plugin_anthropic_skill_generator.plugin import SkillberryPluginAnthropicSkillGenerator
+
+
+@pytest.fixture
+def plugin():
+    """Create a plugin instance for testing."""
+    return SkillberryPluginAnthropicSkillGenerator()
+
+
+@pytest.fixture
+def mock_store():
+    """Create a mock store API."""
+    store = Mock()
+    store.create_tool = Mock(return_value={"uuid": "tool-uuid-123", "name": "test_tool"})
+    store.create_snippet = Mock(return_value={"uuid": "snippet-uuid-456", "name": "test_snippet"})
+    store.create_skill = Mock(return_value={
+        "uuid": "skill-uuid-789",
+        "name": "test_skill",
+        "description": "Test skill description"
+    })
+    return store
+
+
+def test_plugin_metadata(plugin):
+    """Test plugin metadata is correctly set."""
+    metadata = plugin.metadata
+    assert metadata.name == "Anthropic Skill Generator"
+    assert metadata.version == "0.1.0"
+    assert "runspace-agent" in metadata.description.lower()
+    assert metadata.plugin_type.value == "creator"
+
+
+def test_plugin_initialization_without_runspace():
+    """Test plugin initialization when runspace-agent is not available."""
+    with patch("skillberry_plugin_anthropic_skill_generator.plugin.runspace_agent", side_effect=ImportError):
+        plugin = SkillberryPluginAnthropicSkillGenerator()
+        assert not plugin.is_enabled()
+        assert "not installed" in plugin.get_status_message()
+
+
+def test_plugin_initialization_with_runspace():
+    """Test plugin initialization when runspace-agent is available."""
+    with patch("skillberry_plugin_anthropic_skill_generator.plugin.runspace_agent"):
+        plugin = SkillberryPluginAnthropicSkillGenerator()
+        # Note: This will still fail if runspace-agent is not actually installed
+        # In a real environment with runspace-agent, this should pass
+
+
+def test_get_router(plugin):
+    """Test that plugin provides a router."""
+    router = plugin.get_router()
+    assert router is not None
+    # Check that the router has the expected endpoint
+    routes = [route.path for route in router.routes]
+    assert "/generate-skill" in routes
+
+
+def test_get_cli_commands(plugin):
+    """Test that plugin returns None for CLI commands."""
+    commands = plugin.get_cli_commands()
+    assert commands is None
+
+
+def test_get_ui_config(plugin):
+    """Test that plugin provides UI configuration."""
+    ui_config = plugin.get_ui_config()
+    assert ui_config is not None
+    assert "icon" in ui_config
+    assert "color" in ui_config
+    assert "actions" in ui_config
+    assert len(ui_config["actions"]) > 0
+    
+    # Check the action configuration
+    action = ui_config["actions"][0]
+    assert action["label"] == "Generate Anthropic Skill"
+    assert action["endpoint"] == "/api/plugins/anthropic-skill-generator/generate-skill"
+    assert action["method"] == "POST"
+    assert "params_schema" in action
+
+
+@pytest.mark.asyncio
+async def test_generate_skill_without_runspace(plugin, mock_store):
+    """Test that generate_skill raises error when runspace is not available."""
+    plugin.set_store_api(mock_store)
+    plugin._runspace_available = False
+    
+    with pytest.raises(RuntimeError, match="runspace-agent not available"):
+        await plugin.generate_skill("Test skill description")
+
+
+@pytest.mark.asyncio
+async def test_generate_skill_without_store(plugin):
+    """Test that generate_skill raises error when store is not available."""
+    plugin._runspace_available = True
+    
+    with pytest.raises(RuntimeError, match="Store API not available"):
+        await plugin.generate_skill("Test skill description")
+
+
+@pytest.mark.asyncio
+async def test_generate_skill_success(plugin, mock_store):
+    """Test successful skill generation."""
+    plugin.set_store_api(mock_store)
+    plugin._runspace_available = True
+    
+    # Mock the runspace-agent create_skill function
+    mock_create_skill = Mock(return_value={"status": "success"})
+    
+    # Mock the import_from_anthropic_skill function
+    mock_tool = Mock()
+    mock_tool.name = "test_tool"
+    mock_tool.description = "Test tool"
+    mock_tool.programming_language = "python"
+    mock_tool.params = {}
+    mock_tool.returns = {}
+    mock_tool.content = "def test(): pass"
+    
+    mock_snippet = Mock()
+    mock_snippet.name = "test_snippet"
+    mock_snippet.content = "Test content"
+    mock_snippet.language = "text"
+    mock_snippet.description = "Test snippet"
+    
+    mock_import = Mock(return_value=(
+        "test_skill",
+        "Test skill description",
+        [mock_tool],
+        [mock_snippet],
+        []
+    ))
+    
+    with patch("skillberry_plugin_anthropic_skill_generator.plugin.create_skill", mock_create_skill):
+        with patch("skillberry_plugin_anthropic_skill_generator.plugin.import_from_anthropic_skill", mock_import):
+            result = await plugin.generate_skill(
+                description="Create a test skill",
+                skill_name="test_skill",
+                tags=["test"]
+            )
+    
+    # Verify the result
+    assert result["success"] is True
+    assert result["skill"]["uuid"] == "skill-uuid-789"
+    assert result["tools_count"] == 1
+    assert result["snippets_count"] == 1
+    
+    # Verify store methods were called
+    mock_store.create_tool.assert_called_once()
+    mock_store.create_snippet.assert_called_once()
+    mock_store.create_skill.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_generate_skill_with_generation_error(plugin, mock_store):
+    """Test skill generation when runspace-agent fails."""
+    plugin.set_store_api(mock_store)
+    plugin._runspace_available = True
+    
+    # Mock create_skill to raise an exception
+    mock_create_skill = Mock(side_effect=Exception("Generation failed"))
+    
+    with patch("skillberry_plugin_anthropic_skill_generator.plugin.create_skill", mock_create_skill):
+        with pytest.raises(RuntimeError, match="Skill generation failed"):
+            await plugin.generate_skill("Test skill description")
+
+
+@pytest.mark.asyncio
+async def test_generate_skill_with_import_error(plugin, mock_store):
+    """Test skill generation when import fails."""
+    plugin.set_store_api(mock_store)
+    plugin._runspace_available = True
+    
+    # Mock create_skill to succeed
+    mock_create_skill = Mock(return_value={"status": "success"})
+    
+    # Mock import to fail
+    mock_import = Mock(side_effect=Exception("Import failed"))
+    
+    with patch("skillberry_plugin_anthropic_skill_generator.plugin.create_skill", mock_create_skill):
+        with patch("skillberry_plugin_anthropic_skill_generator.plugin.import_from_anthropic_skill", mock_import):
+            with pytest.raises(RuntimeError, match="Skill import failed"):
+                await plugin.generate_skill("Test skill description")
+
+
+def test_router_endpoint_disabled(plugin):
+    """Test that router endpoint returns 503 when plugin is disabled."""
+    plugin._runspace_available = False
+    router = plugin.get_router()
+    
+    # This would require actually calling the FastAPI endpoint
+    # In a real test, you'd use TestClient from fastapi.testclient
+    # For now, we just verify the router exists
+    assert router is not None
+
+# Made with Bob

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,10 @@ plugin-mcp-importer = [
   "skillberry-plugin-mcp-importer>=0.1.0",
 ]
 
+plugin-anthropic-skill-generator = [
+  "skillberry-plugin-anthropic-skill-generator>=0.1.0",
+]
+
 # Install all plugins
 plugins-all = [
   "skillberry-plugin-creator>=0.2.0",
@@ -174,6 +178,7 @@ plugins-all = [
   "skillberry-plugin-security>=0.1.0",
   "skillberry-plugin-dedupe>=0.1.0",
   "skillberry-plugin-mcp-importer>=0.1.0",
+  "skillberry-plugin-anthropic-skill-generator>=0.1.0",
 ]
 
 test = [
@@ -187,6 +192,7 @@ skillberry-plugin-evaluator = { path = "plugins/skillberry-plugin-evaluator", ed
 skillberry-plugin-security = { path = "plugins/skillberry-plugin-security", editable = true }
 skillberry-plugin-dedupe = { path = "plugins/skillberry-plugin-dedupe", editable = true }
 skillberry-plugin-mcp-importer = { path = "plugins/skillberry-plugin-mcp-importer", editable = true }
+skillberry-plugin-anthropic-skill-generator = { path = "plugins/skillberry-plugin-anthropic-skill-generator", editable = true }
 llm-client = { path = "skillberry-common/packages/llm-client", editable = true }
 torch = { index = "pytorch-cpu" }
 

--- a/src/skillberry_store/fast_api/skills_api.py
+++ b/src/skillberry_store/fast_api/skills_api.py
@@ -187,8 +187,12 @@ def register_skills_api(
     )
     async def delete_skill(
         uuid_or_name: str,
-        delete_tools: bool = Query(False, description="Delete tools not shared with other skills"),
-        delete_snippets: bool = Query(False, description="Delete snippets not shared with other skills"),
+        delete_tools: bool = Query(
+            False, description="Delete tools not shared with other skills"
+        ),
+        delete_snippets: bool = Query(
+            False, description="Delete snippets not shared with other skills"
+        ),
     ):
         logger.info(f"Request to delete skill: {uuid_or_name}")
         delete_skill_counter.inc()
@@ -214,7 +218,9 @@ def register_skills_api(
                                 tools_service.delete(tool_uuid)
                                 deleted_tools.append(tool_uuid)
                             except Exception as e:
-                                logger.warning(f"Could not cascade-delete tool {tool_uuid}: {e}")
+                                logger.warning(
+                                    f"Could not cascade-delete tool {tool_uuid}: {e}"
+                                )
 
                 if delete_snippets:
                     for snippet_uuid in skill.get("snippet_uuids") or []:
@@ -223,7 +229,9 @@ def register_skills_api(
                                 snippets_service.delete(snippet_uuid)
                                 deleted_snippets.append(snippet_uuid)
                             except Exception as e:
-                                logger.warning(f"Could not cascade-delete snippet {snippet_uuid}: {e}")
+                                logger.warning(
+                                    f"Could not cascade-delete snippet {snippet_uuid}: {e}"
+                                )
 
             service.delete(uuid_or_name)
             emit_content_deleted("skill", skill_uuid)

--- a/src/skillberry_store/fast_api/skills_api.py
+++ b/src/skillberry_store/fast_api/skills_api.py
@@ -33,6 +33,8 @@ from skillberry_store.tools.configure import (
 from skillberry_store.fast_api.search_filters import apply_search_filters
 from skillberry_store.utils.utils import normalize_uuid, generate_or_validate_uuid
 from skillberry_store.services.skills_service import SkillsService
+from skillberry_store.services.tools_service import ToolsService
+from skillberry_store.services.snippets_service import SnippetsService
 
 if TYPE_CHECKING:
     from skillberry_store.modules.description import Description
@@ -86,6 +88,9 @@ def register_skills_api(
     skill_handler = service.handler
     tools_handler = service.tools_handler
     snippets_handler = service.snippets_handler
+    # descriptions=None: description file cleanup is skipped for cascade-deleted items (best-effort)
+    tools_service = ToolsService(handler=tools_handler)
+    snippets_service = SnippetsService(handler=snippets_handler)
 
     def populate_skill_objects(skill_dict):
         """Populate full tool and snippet objects from UUIDs."""
@@ -180,16 +185,52 @@ def register_skills_api(
         tags=[tags],
         openapi_extra={"x-cli-name": "delete-skill"},
     )
-    async def delete_skill(uuid_or_name: str):
+    async def delete_skill(
+        uuid_or_name: str,
+        delete_tools: bool = Query(False, description="Delete tools not shared with other skills"),
+        delete_snippets: bool = Query(False, description="Delete snippets not shared with other skills"),
+    ):
         logger.info(f"Request to delete skill: {uuid_or_name}")
         delete_skill_counter.inc()
         try:
             skill = service.get(uuid_or_name)
             skill_uuid = skill["uuid"]
+            deleted_tools: list = []
+            deleted_snippets: list = []
+
+            if delete_tools or delete_snippets:
+                all_skills = service.handler.list_all_dicts()
+                shared_tool_uuids: set = set()
+                shared_snippet_uuids: set = set()
+                for s in all_skills:
+                    if s.get("uuid") != skill_uuid:
+                        shared_tool_uuids.update(s.get("tool_uuids") or [])
+                        shared_snippet_uuids.update(s.get("snippet_uuids") or [])
+
+                if delete_tools:
+                    for tool_uuid in skill.get("tool_uuids") or []:
+                        if tool_uuid not in shared_tool_uuids:
+                            try:
+                                tools_service.delete(tool_uuid)
+                                deleted_tools.append(tool_uuid)
+                            except Exception as e:
+                                logger.warning(f"Could not cascade-delete tool {tool_uuid}: {e}")
+
+                if delete_snippets:
+                    for snippet_uuid in skill.get("snippet_uuids") or []:
+                        if snippet_uuid not in shared_snippet_uuids:
+                            try:
+                                snippets_service.delete(snippet_uuid)
+                                deleted_snippets.append(snippet_uuid)
+                            except Exception as e:
+                                logger.warning(f"Could not cascade-delete snippet {snippet_uuid}: {e}")
+
             service.delete(uuid_or_name)
             emit_content_deleted("skill", skill_uuid)
             return {
-                "message": f"Skill with UUID or name '{uuid_or_name}' deleted successfully."
+                "message": f"Skill with UUID or name '{uuid_or_name}' deleted successfully.",
+                "deleted_tools": deleted_tools,
+                "deleted_snippets": deleted_snippets,
             }
         except KeyError as e:
             raise HTTPException(status_code=404, detail=str(e))

--- a/src/skillberry_store/services/skills_service.py
+++ b/src/skillberry_store/services/skills_service.py
@@ -91,14 +91,25 @@ class SkillsService:
     def get(self, uuid_or_name: str) -> Dict[str, Any]:
         uuid = self._resolve_uuid(uuid_or_name)
         skill = self._safe_read(uuid, uuid_or_name)
-        return self.populate_objects(skill)
+        try:
+            return self.populate_objects(skill)
+        except RuntimeError as e:
+            logger.warning(str(e))
+            skill.setdefault("tools", [])
+            skill.setdefault("snippets", [])
+            return skill
 
     def list_all(self, filters: Optional[Dict] = None) -> List[Dict[str, Any]]:
         items = self.handler.list_all_dicts()
         if filters:
             items = [i for i in items if all(i.get(k) == v for k, v in filters.items())]
         for item in items:
-            self.populate_objects(item)
+            try:
+                self.populate_objects(item)
+            except RuntimeError as e:
+                logger.warning(str(e))
+                item.setdefault("tools", [])
+                item.setdefault("snippets", [])
         items.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
         return items
 

--- a/src/skillberry_store/tests/services/test_skills_service.py
+++ b/src/skillberry_store/tests/services/test_skills_service.py
@@ -53,6 +53,24 @@ def test_list_all_returns_sorted_and_populated():
     assert len(result) == 1
 
 
+def test_list_all_tolerates_skill_with_missing_tool():
+    th = MagicMock()
+    th.read_dicts.side_effect = RuntimeError("Skill 'get_time' references missing tools: 404: Tool not found")
+    sh = MagicMock()
+    sh.read_dicts.return_value = []
+    h = _handler()
+    h.list_all_dicts.return_value = [
+        {"name": "get_time", "modified_at": "2024-02-01", "tool_uuids": ["missing-uuid"], "snippet_uuids": []},
+        {"name": "other", "modified_at": "2024-01-01", "tool_uuids": [], "snippet_uuids": []},
+    ]
+    svc = SkillsService(h, tools_handler=th, snippets_handler=sh)
+    result = svc.list_all()
+    assert len(result) == 2
+    broken = next(r for r in result if r["name"] == "get_time")
+    assert broken["tools"] == []
+    assert broken["snippets"] == []
+
+
 def test_delete_updates_cache_then_deletes():
     h = _handler()
     svc = SkillsService(h, tools_handler=MagicMock(), snippets_handler=MagicMock())

--- a/src/skillberry_store/tests/test_cascade_delete.py
+++ b/src/skillberry_store/tests/test_cascade_delete.py
@@ -1,0 +1,95 @@
+from unittest.mock import MagicMock, patch
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from skillberry_store.fast_api.skills_api import register_skills_api
+
+
+def _make_client(skill, all_skills, mock_tools_svc, mock_snippets_svc):
+    """Register a test app with fully mocked services."""
+    app = FastAPI()
+    svc = MagicMock()
+    svc.get.return_value = skill
+    svc.delete.return_value = None
+    svc.handler.list_all_dicts.return_value = all_skills
+    svc.tools_handler = MagicMock()
+    svc.snippets_handler = MagicMock()
+    with patch("skillberry_store.fast_api.skills_api.ToolsService", return_value=mock_tools_svc), \
+         patch("skillberry_store.fast_api.skills_api.SnippetsService", return_value=mock_snippets_svc):
+        register_skills_api(app, service=svc)
+    return TestClient(app), svc
+
+
+def test_cascade_delete_exclusive_tool_is_deleted():
+    skill = {"uuid": "sk1", "name": "myskill", "tool_uuids": ["t1"], "snippet_uuids": []}
+    other = {"uuid": "sk2", "tool_uuids": [], "snippet_uuids": []}
+    mock_tools, mock_snippets = MagicMock(), MagicMock()
+    client, _ = _make_client(skill, [skill, other], mock_tools, mock_snippets)
+
+    resp = client.delete("/skills/sk1?delete_tools=true")
+
+    assert resp.status_code == 200
+    mock_tools.delete.assert_called_once_with("t1")
+    mock_snippets.delete.assert_not_called()
+
+
+def test_cascade_delete_shared_tool_is_skipped():
+    skill = {"uuid": "sk1", "name": "myskill", "tool_uuids": ["t1"], "snippet_uuids": []}
+    other = {"uuid": "sk2", "tool_uuids": ["t1"], "snippet_uuids": []}
+    mock_tools, mock_snippets = MagicMock(), MagicMock()
+    client, _ = _make_client(skill, [skill, other], mock_tools, mock_snippets)
+
+    resp = client.delete("/skills/sk1?delete_tools=true")
+
+    assert resp.status_code == 200
+    mock_tools.delete.assert_not_called()
+
+
+def test_cascade_delete_exclusive_snippet_is_deleted():
+    skill = {"uuid": "sk1", "name": "myskill", "tool_uuids": [], "snippet_uuids": ["sn1"]}
+    other = {"uuid": "sk2", "tool_uuids": [], "snippet_uuids": []}
+    mock_tools, mock_snippets = MagicMock(), MagicMock()
+    client, _ = _make_client(skill, [skill, other], mock_tools, mock_snippets)
+
+    resp = client.delete("/skills/sk1?delete_snippets=true")
+
+    assert resp.status_code == 200
+    mock_snippets.delete.assert_called_once_with("sn1")
+    mock_tools.delete.assert_not_called()
+
+
+def test_no_flags_skips_cascade():
+    skill = {"uuid": "sk1", "name": "myskill", "tool_uuids": ["t1"], "snippet_uuids": ["sn1"]}
+    mock_tools, mock_snippets = MagicMock(), MagicMock()
+    client, _ = _make_client(skill, [skill], mock_tools, mock_snippets)
+
+    resp = client.delete("/skills/sk1")
+
+    assert resp.status_code == 200
+    mock_tools.delete.assert_not_called()
+    mock_snippets.delete.assert_not_called()
+
+
+def test_response_includes_deleted_lists():
+    skill = {"uuid": "sk1", "name": "myskill", "tool_uuids": ["t1"], "snippet_uuids": ["sn1"]}
+    other = {"uuid": "sk2", "tool_uuids": [], "snippet_uuids": []}
+    mock_tools, mock_snippets = MagicMock(), MagicMock()
+    client, _ = _make_client(skill, [skill, other], mock_tools, mock_snippets)
+
+    resp = client.delete("/skills/sk1?delete_tools=true&delete_snippets=true")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["deleted_tools"] == ["t1"]
+    assert data["deleted_snippets"] == ["sn1"]
+
+
+def test_cascade_tool_failure_does_not_abort_skill_delete():
+    skill = {"uuid": "sk1", "name": "myskill", "tool_uuids": ["t1"], "snippet_uuids": []}
+    mock_tools, mock_snippets = MagicMock(), MagicMock()
+    mock_tools.delete.side_effect = Exception("storage error")
+    client, svc = _make_client(skill, [skill], mock_tools, mock_snippets)
+
+    resp = client.delete("/skills/sk1?delete_tools=true")
+
+    assert resp.status_code == 200
+    svc.delete.assert_called_once()  # skill still deleted

--- a/src/skillberry_store/ui/src/components/PluginActionForm.tsx
+++ b/src/skillberry_store/ui/src/components/PluginActionForm.tsx
@@ -12,6 +12,8 @@ import {
   Checkbox,
   Button,
   Alert,
+  FormSelect,
+  FormSelectOption,
 } from '@patternfly/react-core';
 import type { PluginAction, PluginActionResult } from '@/types';
 
@@ -39,8 +41,21 @@ export function PluginActionForm({
     setError(null);
     setResult(null);
 
+    // Coerce array-typed fields from comma-separated strings to string[]
+    const coercedData: Record<string, any> = { ...formData };
+    if (action.params_schema.properties) {
+      for (const [key, schema] of Object.entries(action.params_schema.properties) as [string, any][]) {
+        if (schema.type === 'array' && typeof coercedData[key] === 'string') {
+          coercedData[key] = coercedData[key]
+            .split(',')
+            .map((s: string) => s.trim())
+            .filter(Boolean);
+        }
+      }
+    }
+
     try {
-      const response = await onSubmit(formData);
+      const response = await onSubmit(coercedData);
       setResult(response);
       
       if (response.success) {
@@ -119,7 +134,38 @@ export function PluginActionForm({
       );
     }
 
+    // Enum → native select
+    if (propertySchema.enum) {
+      return (
+        <FormGroup
+          key={propertyName}
+          label={propertyName}
+          isRequired={isRequired}
+          fieldId={propertyName}
+        >
+          {propertySchema.description && (
+            <div style={{ fontSize: '0.875rem', color: '#6A6E73', marginBottom: '0.25rem' }}>
+              {propertySchema.description}
+            </div>
+          )}
+          <FormSelect
+            id={propertyName}
+            value={value as string}
+            onChange={(_event, newValue) => handleChange(newValue)}
+          >
+            {propertySchema.enum.map((option: string) => (
+              <FormSelectOption key={option} value={option} label={option} />
+            ))}
+          </FormSelect>
+        </FormGroup>
+      );
+    }
+
     // Default to text input
+    const isArray = propertySchema.type === 'array';
+    const description = isArray
+      ? `${propertySchema.description || ''} (comma-separated)`.trim()
+      : propertySchema.description;
     return (
       <FormGroup
         key={propertyName}
@@ -127,9 +173,9 @@ export function PluginActionForm({
         isRequired={isRequired}
         fieldId={propertyName}
       >
-        {propertySchema.description && (
+        {description && (
           <div style={{ fontSize: '0.875rem', color: '#6A6E73', marginBottom: '0.25rem' }}>
-            {propertySchema.description}
+            {description}
           </div>
         )}
         <TextInput

--- a/src/skillberry_store/ui/src/pages/SkillDetailPage.cascade-delete.test.tsx
+++ b/src/skillberry_store/ui/src/pages/SkillDetailPage.cascade-delete.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { SkillDetailPage } from './SkillDetailPage';
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useParams: () => ({ uuid: 'sk1' }), useNavigate: () => vi.fn() };
+});
+
+const mockDelete = vi.hoisted(() => vi.fn().mockResolvedValue({ message: 'ok' }));
+
+vi.mock('@/services/api', () => ({
+  skillsApi: {
+    get: vi.fn().mockResolvedValue({
+      uuid: 'sk1', name: 'myskill', description: 'desc',
+      tools: [{ uuid: 't1', name: 'tool1' }],
+      snippets: [],
+      tags: [], version: '', extra: {},
+    }),
+    delete: mockDelete,
+    search: vi.fn().mockResolvedValue([]),
+  },
+  toolsApi: { list: vi.fn().mockResolvedValue([]) },
+  snippetsApi: { list: vi.fn().mockResolvedValue([]) },
+}));
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <BrowserRouter>
+      <QueryClientProvider client={qc}>
+        <SkillDetailPage />
+      </QueryClientProvider>
+    </BrowserRouter>
+  );
+}
+
+describe('SkillDetailPage cascade delete modal', () => {
+  beforeEach(() => { mockDelete.mockClear(); });
+
+  async function openModal() {
+    renderPage();
+    // The Delete button is only rendered after skill data loads — wait for it
+    const deleteBtn = await screen.findByRole('button', { name: /^delete$/i });
+    await userEvent.click(deleteBtn);
+    return screen.findByRole('dialog');
+  }
+
+  it('shows both checkboxes checked by default', async () => {
+    const modal = await openModal();
+    expect(within(modal).getByRole('checkbox', { name: /delete associated tools/i })).toBeChecked();
+    expect(within(modal).getByRole('checkbox', { name: /delete associated snippets/i })).toBeChecked();
+  });
+
+  it('shows the shared-skills note', async () => {
+    const modal = await openModal();
+    expect(within(modal).getByText(/shared with other skills will not be deleted/i)).toBeInTheDocument();
+  });
+
+  it('calls skillsApi.delete with both flags when confirmed', async () => {
+    const modal = await openModal();
+    await userEvent.click(within(modal).getByRole('button', { name: /^delete$/i }));
+    await waitFor(() => {
+      expect(mockDelete).toHaveBeenCalledWith('sk1', { deleteTools: true, deleteSnippets: true });
+    });
+  });
+
+  it('calls skillsApi.delete with deleteTools: false when that checkbox is unchecked', async () => {
+    const modal = await openModal();
+    await userEvent.click(within(modal).getByRole('checkbox', { name: /delete associated tools/i }));
+    await userEvent.click(within(modal).getByRole('button', { name: /^delete$/i }));
+    await waitFor(() => {
+      expect(mockDelete).toHaveBeenCalledWith('sk1', { deleteTools: false, deleteSnippets: true });
+    });
+  });
+});

--- a/src/skillberry_store/ui/src/pages/SkillDetailPage.tsx
+++ b/src/skillberry_store/ui/src/pages/SkillDetailPage.tsx
@@ -40,6 +40,7 @@ import {
   MenuToggleElement,
   TreeView,
   TreeViewDataItem,
+  Checkbox,
 } from '@patternfly/react-core';
 import { EditIcon, TrashIcon, FolderIcon, FileIcon, FileCodeIcon, ExportIcon } from '@patternfly/react-icons';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
@@ -55,6 +56,8 @@ export function SkillDetailPage() {
 
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [deleteTools, setDeleteTools] = useState(true);
+  const [deleteSnippets, setDeleteSnippets] = useState(true);
   const [activeTabKey, setActiveTabKey] = useState<string | number>(0);
   const [editedSkill, setEditedSkill] = useState({
     name: '',
@@ -134,7 +137,7 @@ export function SkillDetailPage() {
 
   // Delete mutation
   const deleteMutation = useMutation({
-    mutationFn: () => skillsApi.delete(skill?.uuid!),
+    mutationFn: () => skillsApi.delete(skill?.uuid!, { deleteTools, deleteSnippets }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['skills'] });
       navigate('/skills');
@@ -1089,7 +1092,7 @@ export function SkillDetailPage() {
         variant={ModalVariant.small}
         title="Delete Skill"
         isOpen={isDeleteModalOpen}
-        onClose={() => setIsDeleteModalOpen(false)}
+        onClose={() => { setIsDeleteModalOpen(false); setDeleteTools(true); setDeleteSnippets(true); }}
         actions={[
           <Button
             key="delete"
@@ -1111,6 +1114,24 @@ export function SkillDetailPage() {
         <Text>
           Are you sure you want to delete the skill "{skill?.name}"? This action cannot be undone.
         </Text>
+        <div style={{ marginTop: '1rem' }}>
+          <Checkbox
+            id="delete-tools-checkbox"
+            label="Delete associated tools"
+            isChecked={deleteTools}
+            onChange={(_e, checked) => setDeleteTools(checked)}
+          />
+          <Checkbox
+            id="delete-snippets-checkbox"
+            label="Delete associated snippets"
+            isChecked={deleteSnippets}
+            onChange={(_e, checked) => setDeleteSnippets(checked)}
+            style={{ marginTop: '0.5rem' }}
+          />
+          <Text component="small" style={{ color: '#6a6e73', marginTop: '0.5rem', display: 'block' }}>
+            Tools or snippets shared with other skills will not be deleted.
+          </Text>
+        </div>
       </Modal>
     </>
   );

--- a/src/skillberry_store/ui/src/pages/SkillsPage.cascade-delete.test.tsx
+++ b/src/skillberry_store/ui/src/pages/SkillsPage.cascade-delete.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { SkillsPage } from './SkillsPage';
+
+const mockDelete = vi.hoisted(() => vi.fn().mockResolvedValue({ message: 'ok' }));
+
+vi.mock('@/services/api', () => ({
+  skillsApi: {
+    list: vi.fn().mockResolvedValue([
+      { uuid: 'sk1', name: 'skill-one', description: 'desc', tools: [], snippets: [], tags: [] },
+    ]),
+    delete: mockDelete,
+    search: vi.fn().mockResolvedValue([]),
+  },
+  toolsApi: { list: vi.fn().mockResolvedValue([]) },
+  snippetsApi: { list: vi.fn().mockResolvedValue([]) },
+}));
+
+vi.mock('../components/AnthropicSkillImporter', () => ({
+  AnthropicSkillImporter: () => null,
+}));
+
+vi.mock('../components/SkillCardView', () => ({
+  SkillCardView: ({ onSelectSkill }: { onSelectSkill: (name: string, selected: boolean) => void }) => (
+    <button data-testid="select-skill" onClick={() => onSelectSkill('skill-one', true)}>
+      skill-one
+    </button>
+  ),
+}));
+
+vi.mock('../components/SkillListView', () => ({ SkillListView: () => null }));
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <BrowserRouter>
+      <QueryClientProvider client={qc}>
+        <SkillsPage />
+      </QueryClientProvider>
+    </BrowserRouter>
+  );
+}
+
+describe('SkillsPage cascade delete modal', () => {
+  beforeEach(() => { mockDelete.mockClear(); });
+
+  async function openDeleteModal() {
+    renderPage();
+    await userEvent.click(await screen.findByTestId('select-skill'));
+    await userEvent.click(screen.getByRole('button', { name: 'Delete (1)' }));
+    return screen.findByRole('dialog');
+  }
+
+  it('shows both checkboxes checked by default', async () => {
+    const modal = await openDeleteModal();
+    expect(within(modal).getByRole('checkbox', { name: /delete associated tools/i })).toBeChecked();
+    expect(within(modal).getByRole('checkbox', { name: /delete associated snippets/i })).toBeChecked();
+  });
+
+  it('shows the shared-skills note', async () => {
+    const modal = await openDeleteModal();
+    expect(within(modal).getByText(/shared with other skills will not be deleted/i)).toBeInTheDocument();
+  });
+
+  it('calls skillsApi.delete with both flags when confirmed', async () => {
+    const modal = await openDeleteModal();
+    await userEvent.click(within(modal).getByRole('button', { name: /^delete$/i }));
+    await waitFor(() => {
+      expect(mockDelete).toHaveBeenCalledWith('skill-one', { deleteTools: true, deleteSnippets: true });
+    });
+  });
+});

--- a/src/skillberry_store/ui/src/pages/SkillsPage.tsx
+++ b/src/skillberry_store/ui/src/pages/SkillsPage.tsx
@@ -35,6 +35,7 @@ import {
   MenuToggleElement,
   ToggleGroup,
   ToggleGroupItem,
+  Checkbox,
 } from '@patternfly/react-core';
 import type { ThProps } from '@patternfly/react-table';
 import { PlusIcon, CodeIcon, SearchIcon, TrashIcon, ExportIcon, ImportIcon, UploadIcon, ThLargeIcon, ListIcon } from '@patternfly/react-icons';
@@ -66,6 +67,8 @@ export function SkillsPage() {
   const [createError, setCreateError] = useState('');
   const [selectedSkills, setSelectedSkills] = useState<string[]>([]);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [deleteTools, setDeleteTools] = useState(true);
+  const [deleteSnippets, setDeleteSnippets] = useState(true);
   const [isImportModalOpen, setIsImportModalOpen] = useState(false);
   const [importFile, setImportFile] = useState<File | null>(null);
   const [importError, setImportError] = useState('');
@@ -135,7 +138,7 @@ export function SkillsPage() {
   // Delete skills mutation
   const deleteMutation = useMutation({
     mutationFn: async (names: string[]) => {
-      await Promise.all(names.map(name => skillsApi.delete(name)));
+      await Promise.all(names.map(name => skillsApi.delete(name, { deleteTools, deleteSnippets })));
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['skills'] });
@@ -902,7 +905,7 @@ export function SkillsPage() {
         variant={ModalVariant.small}
         title="Delete Skills"
         isOpen={isDeleteModalOpen}
-        onClose={() => setIsDeleteModalOpen(false)}
+        onClose={() => { setIsDeleteModalOpen(false); setDeleteTools(true); setDeleteSnippets(true); }}
         actions={[
           <Button
             key="delete"
@@ -930,6 +933,24 @@ export function SkillsPage() {
             <li key={name}>{name}</li>
           ))}
         </ul>
+        <div style={{ marginTop: '1rem' }}>
+          <Checkbox
+            id="bulk-delete-tools-checkbox"
+            label="Delete associated tools"
+            isChecked={deleteTools}
+            onChange={(_e, checked) => setDeleteTools(checked)}
+          />
+          <Checkbox
+            id="bulk-delete-snippets-checkbox"
+            label="Delete associated snippets"
+            isChecked={deleteSnippets}
+            onChange={(_e, checked) => setDeleteSnippets(checked)}
+            style={{ marginTop: '0.5rem' }}
+          />
+          <Text component="small" style={{ color: '#6a6e73', marginTop: '0.5rem', display: 'block' }}>
+            Tools or snippets shared with other skills will not be deleted.
+          </Text>
+        </div>
       </Modal>
 
       {/* Import Modal */}

--- a/src/skillberry_store/ui/src/services/api.ts
+++ b/src/skillberry_store/ui/src/services/api.ts
@@ -152,8 +152,15 @@ export const skillsApi = {
     return handleResponse<{ message: string }>(response);
   },
 
-  delete: async (name: string): Promise<{ message: string }> => {
-    const response = await fetch(`${API_BASE}/skills/${name}`, {
+  delete: async (
+    name: string,
+    options?: { deleteTools?: boolean; deleteSnippets?: boolean }
+  ): Promise<{ message: string }> => {
+    const params = new URLSearchParams();
+    if (options?.deleteTools) params.set('delete_tools', 'true');
+    if (options?.deleteSnippets) params.set('delete_snippets', 'true');
+    const query = params.toString() ? `?${params}` : '';
+    const response = await fetch(`${API_BASE}/skills/${name}${query}`, {
       method: 'DELETE',
     });
     return handleResponse<{ message: string }>(response);

--- a/src/skillberry_store/ui/src/services/api.ts
+++ b/src/skillberry_store/ui/src/services/api.ts
@@ -30,7 +30,13 @@ async function handleResponse<T>(response: Response): Promise<T> {
     const error = await response.json().catch(() => ({
       detail: response.statusText,
     }));
-    throw new ApiError(error.detail || 'An error occurred', response.status);
+    const detail = error.detail;
+    const message = Array.isArray(detail)
+      ? detail.map((e: any) => e.msg || JSON.stringify(e)).join('; ')
+      : typeof detail === 'string'
+        ? detail
+        : JSON.stringify(detail);
+    throw new ApiError(message || 'An error occurred', response.status);
   }
   return response.json();
 }


### PR DESCRIPTION
Closes #184.

## Summary
- New plugin `skillberry-plugin-anthropic-skill-generator` — generates complete Anthropic skills from natural language descriptions using Claude Code via runspace-agent
- Credentials loaded from `~/.claude/settings.json`, env vars, or per-request `agent_env` param (priority order: request > env > settings file); passed via `session.agent_options` so both local and container modes receive them
- Defaults to `container` execution mode; `execution_mode` exposed as an enum select in the UI
- Live progress: Docker container logs streamed via background thread (finds container by workspace volume mount); workspace `editable/` polled every 5s for new files
- Post-run: conversation replay logged from `conversation.json` (tool calls, agent text, cost/token summary)
- Fixes `ParsedTool.module_content` / `ParsedSnippet` attribute mapping when importing generated skills

## UI fixes (PluginActionForm)
- `array`-typed schema fields split on comma before submission (fixes 422 on `tags`)
- `enum` fields render as `FormSelect` with schema default pre-selected
- Pydantic 422 `detail` arrays rendered as readable strings instead of `[object Object]`

## Testing
Tested end-to-end in container mode: skill generation, tool/snippet import, progress logging, and error display.

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>