### PR TITLE
feat: add kagenti-approver plugin and make dedupe+kagenti default

### DIFF
--- a/docs/plugins-installation.md
+++ b/docs/plugins-installation.md
@@ -8,7 +8,7 @@ The skillberry-store supports a flexible plugin architecture that allows extendi
 
 ### 1. Install Without Plugins (Minimal Installation)
 
-When you install skillberry-store without any extras, you get the core functionality only:
+When you install skillberry-store, two plugins are included by default:
 
 ```bash
 pip install skillberry-store
@@ -16,9 +16,14 @@ pip install skillberry-store
 
 This installs:
 - Core skillberry-store functionality
-- No plugins (plugins can be added later)
+- skillberry-plugin-dedupe (AI-powered duplicate skill detection) — **default**
+- skillberry-plugin-kagenti-approver (automatic kagenti-approved labeling) — **default**
 
-The store will start normally without any plugins. Plugin-related API endpoints will be available but will return empty lists.
+Both default plugins can be uninstalled individually if not needed:
+```bash
+pip uninstall skillberry-plugin-dedupe
+pip uninstall skillberry-plugin-kagenti-approver
+```
 
 ### 2. Install All Plugins
 
@@ -33,9 +38,10 @@ This installs:
 - skillberry-plugin-creator (AI-powered content creation)
 - skillberry-plugin-evaluator (AI-powered content evaluation and tagging)
 - skillberry-plugin-security (AI-powered security evaluation)
-- skillberry-plugin-dedupe (AI-powered duplicate skill detection)
+- skillberry-plugin-dedupe (AI-powered duplicate skill detection) — also a default plugin
 - skillberry-plugin-mcp-importer (import tools from any MCP SSE server)
 - skillberry-plugin-anthropic-skill-generator (generate Anthropic skills from descriptions using Claude Code)
+- skillberry-plugin-kagenti-approver (automatic kagenti-approved labeling) — also a default plugin
 
 ### 3. Install Specific Plugins
 

--- a/docs/plugins-installation.md
+++ b/docs/plugins-installation.md
@@ -66,6 +66,11 @@ pip install skillberry-store[plugin-mcp-importer]
 pip install skillberry-store[plugin-anthropic-skill-generator]
 ```
 
+#### Kagenti Approver Plugin Only
+```bash
+pip install skillberry-store[plugin-kagenti-approver]
+```
+
 #### Multiple Specific Plugins
 ```bash
 pip install skillberry-store[plugin-creator,plugin-evaluator,plugin-mcp-importer,plugin-anthropic-skill-generator]
@@ -345,6 +350,40 @@ curl -X POST http://localhost:8000/api/plugins/anthropic-skill-generator/generat
 1. Request-specific parameters (highest)
 2. Environment variables
 3. `~/.claude/settings.json` (lowest - automatic)
+
+### Kagenti Approver Plugin (`skillberry-plugin-kagenti-approver`)
+
+**Purpose:** Automatically label skills as `kagenti-approved` when their score tags satisfy configurable criteria.
+
+**Features:**
+- Reacts to `content_added:skill` and `content_updated:skill` events — no manual trigger needed
+- Adds `kagenti-approved` tag when all criteria in any OR-group are met
+- Removes `kagenti-approved` tag when criteria are no longer met (revocation on update)
+- No-op if approval state has not changed (avoids unnecessary writes)
+- No LLM or external dependencies
+
+**Configuration:**
+```bash
+# Optional — defaults to "security-score>=9,performance-score>=8" if not set
+export KAGENTI_CRITERIA="security-score>=9,performance-score>=8"
+```
+
+**Criteria syntax:**
+- `,` = AND (all conditions in a group must pass)
+- `|` = OR (any group passing is sufficient)
+- Supported operators: `>=`, `>`, `<=`, `<`, `=`, `!=`
+- Each condition: `{tag-prefix}{operator}{number}` (e.g. `security-score>=9`)
+
+**Examples:**
+```bash
+# Default: both scores required
+KAGENTI_CRITERIA="security-score>=9,performance-score>=8"
+
+# Either a perfect security score, or both scores at lower thresholds
+KAGENTI_CRITERIA="security-score>=10|security-score>=7,performance-score>=8"
+```
+
+**No API endpoints** — operates entirely in the background via event handlers.
 
 ## LLM Configuration
 

--- a/plugins/skillberry-plugin-kagenti-approver/pyproject.toml
+++ b/plugins/skillberry-plugin-kagenti-approver/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=45", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "skillberry-plugin-kagenti-approver"
+version = "0.1.0"
+description = "Skillberry Store plugin that labels skills as kagenti-approved based on score tags"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = []
+
+[project.entry-points."skillberry_store.plugins"]
+kagenti-approver = "skillberry_plugin_kagenti_approver.plugin:SkillberryPluginKagentiApprover"
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pytest-asyncio",
+]
+
+[tool.setuptools]
+packages = ["skillberry_plugin_kagenti_approver"]
+package-dir = {"" = "src"}

--- a/plugins/skillberry-plugin-kagenti-approver/src/skillberry_plugin_kagenti_approver/plugin.py
+++ b/plugins/skillberry-plugin-kagenti-approver/src/skillberry_plugin_kagenti_approver/plugin.py
@@ -10,7 +10,7 @@ from skillberry_store.plugins.base import PluginBase, PluginMetadata, PluginType
 logger = logging.getLogger(__name__)
 
 APPROVED_TAG = "kagenti-approved"
-DEFAULT_CRITERIA = "security-score>=9,performance-score>=8"
+DEFAULT_CRITERIA = "security-score>=9,performance-score>=8,quality-score>=8"
 
 _OPERATOR_RE = re.compile(r"^(.+?)(>=|>|<=|<|!=|=)(\S+)$")
 
@@ -149,7 +149,7 @@ class SkillberryPluginKagentiApprover(PluginBase):
         from skillberry_store.plugins.events import _event_handlers
 
         for event_name in ("content_added:skill", "content_updated:skill"):
-            async def _handle(uuid: str, _event=event_name):
+            async def _handle(uuid: str):
                 if self._store_api is None:
                     return
                 await self._evaluate_skill(uuid)

--- a/plugins/skillberry-plugin-kagenti-approver/src/skillberry_plugin_kagenti_approver/plugin.py
+++ b/plugins/skillberry-plugin-kagenti-approver/src/skillberry_plugin_kagenti_approver/plugin.py
@@ -1,0 +1,186 @@
+"""Kagenti Approver plugin — labels skills as kagenti-approved based on score-tag criteria."""
+
+import os
+import re
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+from skillberry_store.plugins.base import PluginBase, PluginMetadata, PluginType
+
+logger = logging.getLogger(__name__)
+
+APPROVED_TAG = "kagenti-approved"
+DEFAULT_CRITERIA = "security-score>=9,performance-score>=8"
+
+_OPERATOR_RE = re.compile(r"^(.+?)(>=|>|<=|<|!=|=)(\S+)$")
+
+
+def parse_criteria(criteria_str: str) -> List[List[Tuple[str, str, float]]]:
+    """Parse criteria string into OR-groups of AND-conditions.
+
+    Returns a list of OR-groups. Each OR-group is a list of (tag, operator, threshold) tuples.
+    OR-groups are separated by '|'; AND-conditions within a group are separated by ','.
+    Malformed or non-numeric conditions are skipped. Empty/all-malformed OR-groups are dropped.
+
+    Example:
+        "security-score>=9,performance-score>=8|security-score>=10"
+        -> [
+             [("security-score", ">=", 9.0), ("performance-score", ">=", 8.0)],
+             [("security-score", ">=", 10.0)],
+           ]
+    """
+    if not criteria_str.strip():
+        return []
+
+    result: List[List[Tuple[str, str, float]]] = []
+    for or_group_str in criteria_str.split("|"):
+        conditions: List[Tuple[str, str, float]] = []
+        for condition_str in or_group_str.split(","):
+            condition_str = condition_str.strip()
+            if not condition_str:
+                continue
+            match = _OPERATOR_RE.match(condition_str)
+            if not match:
+                logger.warning(f"Kagenti approver: skipping malformed condition: {condition_str!r}")
+                continue
+            tag, operator, threshold_str = match.group(1), match.group(2), match.group(3)
+            try:
+                threshold = float(threshold_str)
+            except ValueError:
+                logger.warning(
+                    f"Kagenti approver: skipping condition with non-numeric threshold: {condition_str!r}"
+                )
+                continue
+            conditions.append((tag.strip(), operator, threshold))
+        if conditions:
+            result.append(conditions)
+    return result
+
+
+def extract_scores(tags: List[str]) -> Dict[str, float]:
+    """Parse tags like 'security-score:9' into {'security-score': 9.0}.
+
+    Tags without a colon or with non-numeric values are ignored.
+    """
+    scores: Dict[str, float] = {}
+    for tag in tags:
+        if ":" not in tag:
+            continue
+        key, _, value_str = tag.partition(":")
+        if not value_str:
+            continue
+        try:
+            scores[key] = float(value_str)
+        except ValueError:
+            pass
+    return scores
+
+
+def evaluate_criteria(
+    or_groups: List[List[Tuple[str, str, float]]],
+    score_map: Dict[str, float],
+) -> bool:
+    """Return True if any OR-group has all its AND-conditions satisfied."""
+    if not or_groups:
+        return False
+    for group in or_groups:
+        if _group_passes(group, score_map):
+            return True
+    return False
+
+
+def _group_passes(
+    conditions: List[Tuple[str, str, float]],
+    score_map: Dict[str, float],
+) -> bool:
+    for tag, operator, threshold in conditions:
+        value = score_map.get(tag)
+        if value is None:
+            return False
+        if operator == ">=" and not (value >= threshold):
+            return False
+        elif operator == ">" and not (value > threshold):
+            return False
+        elif operator == "<=" and not (value <= threshold):
+            return False
+        elif operator == "<" and not (value < threshold):
+            return False
+        elif operator == "=" and not (value == threshold):
+            return False
+        elif operator == "!=" and not (value != threshold):
+            return False
+    return True
+
+
+class SkillberryPluginKagentiApprover(PluginBase):
+    """Plugin that labels skills as kagenti-approved when their score tags meet criteria."""
+
+    def __init__(self):
+        super().__init__()
+        self._metadata = PluginMetadata(
+            name="Kagenti Approver",
+            version="0.1.0",
+            description="Automatically label skills as kagenti-approved based on score-tag criteria",
+            plugin_type=PluginType.EVALUATOR,
+        )
+        self._register_event_handlers()
+
+    @property
+    def metadata(self) -> PluginMetadata:
+        return self._metadata
+
+    def is_enabled(self) -> bool:
+        return True
+
+    def get_router(self):
+        return None
+
+    def get_cli_commands(self) -> Optional[Dict[str, Any]]:
+        return None
+
+    def get_ui_config(self) -> Optional[Dict[str, Any]]:
+        return None
+
+    def _load_criteria(self) -> List[List[Tuple[str, str, float]]]:
+        raw = os.environ.get("KAGENTI_CRITERIA", DEFAULT_CRITERIA)
+        return parse_criteria(raw)
+
+    def _register_event_handlers(self) -> None:
+        from skillberry_store.plugins.events import _event_handlers
+
+        for event_name in ("content_added:skill", "content_updated:skill"):
+            async def _handle(uuid: str, _event=event_name):
+                if self._store_api is None:
+                    return
+                await self._evaluate_skill(uuid)
+
+            if event_name not in _event_handlers:
+                _event_handlers[event_name] = []
+            _event_handlers[event_name].append(_handle)
+
+    async def _evaluate_skill(self, uuid: str) -> None:
+        """Fetch skill, evaluate criteria, add or remove APPROVED_TAG.
+
+        - Criteria met + tag absent  → add APPROVED_TAG (union write via update_skill_tags)
+        - Criteria met + tag present → no-op (avoid unnecessary write)
+        - Criteria not met + tag present → remove APPROVED_TAG (full write via update_skill)
+        - Criteria not met + tag absent  → no-op
+        """
+        skill = self.store.get_skill(uuid)
+        if skill is None:
+            logger.warning(f"Kagenti approver: skill {uuid} not found, skipping")
+            return
+
+        tags: List[str] = list(skill.get("tags") or [])
+        score_map = extract_scores(tags)
+        or_groups = self._load_criteria()
+        approved = evaluate_criteria(or_groups, score_map)
+        has_tag = APPROVED_TAG in tags
+
+        if approved and not has_tag:
+            logger.info(f"Kagenti approver: approving skill {uuid}")
+            self.store.update_skill_tags(uuid, [APPROVED_TAG])
+        elif not approved and has_tag:
+            logger.info(f"Kagenti approver: revoking approval for skill {uuid}")
+            skill["tags"] = [t for t in tags if t != APPROVED_TAG]
+            self.store.update_skill(uuid, skill)

--- a/plugins/skillberry-plugin-kagenti-approver/tests/test_kagenti_approver_plugin.py
+++ b/plugins/skillberry-plugin-kagenti-approver/tests/test_kagenti_approver_plugin.py
@@ -1,0 +1,454 @@
+"""Tests for SkillberryPluginKagentiApprover."""
+import pytest
+from unittest.mock import MagicMock, patch
+
+from skillberry_plugin_kagenti_approver.plugin import (
+    parse_criteria,
+    evaluate_criteria,
+    extract_scores,
+    APPROVED_TAG,
+    DEFAULT_CRITERIA,
+)
+
+
+# ── parse_criteria ────────────────────────────────────────────────────────────
+
+def test_parse_criteria_default_produces_one_or_group_two_conditions():
+    groups = parse_criteria(DEFAULT_CRITERIA)
+    assert len(groups) == 1
+    assert len(groups[0]) == 2
+
+
+def test_parse_criteria_default_security_score():
+    groups = parse_criteria(DEFAULT_CRITERIA)
+    tag, op, threshold = groups[0][0]
+    assert tag == "security-score"
+    assert op == ">="
+    assert threshold == 9.0
+
+
+def test_parse_criteria_default_performance_score():
+    groups = parse_criteria(DEFAULT_CRITERIA)
+    tag, op, threshold = groups[0][1]
+    assert tag == "performance-score"
+    assert op == ">="
+    assert threshold == 8.0
+
+
+def test_parse_criteria_or_splits_into_two_groups():
+    groups = parse_criteria("security-score>=9|performance-score>=8")
+    assert len(groups) == 2
+    assert len(groups[0]) == 1
+    assert len(groups[1]) == 1
+
+
+def test_parse_criteria_or_group_has_correct_tags():
+    groups = parse_criteria("security-score>=9|performance-score>=8")
+    assert groups[0][0][0] == "security-score"
+    assert groups[1][0][0] == "performance-score"
+
+
+def test_parse_criteria_all_operators_parsed():
+    s = "a>=1,b>2,c<=3,d<4,e=5,f!=6"
+    groups = parse_criteria(s)
+    assert len(groups) == 1
+    conditions = groups[0]
+    assert len(conditions) == 6
+    ops = [c[1] for c in conditions]
+    assert set(ops) == {">=", ">", "<=", "<", "=", "!="}
+
+
+def test_parse_criteria_malformed_entry_is_skipped():
+    groups = parse_criteria("security-score>=9,not-a-condition,performance-score>=8")
+    # malformed middle entry skipped, valid ones kept
+    assert len(groups) == 1
+    assert len(groups[0]) == 2
+    tags = [c[0] for c in groups[0]]
+    assert "security-score" in tags
+    assert "performance-score" in tags
+
+
+def test_parse_criteria_non_numeric_threshold_is_skipped():
+    groups = parse_criteria("security-score>=nine,performance-score>=8")
+    assert len(groups) == 1
+    assert len(groups[0]) == 1
+    assert groups[0][0][0] == "performance-score"
+
+
+def test_parse_criteria_empty_string_returns_empty():
+    assert parse_criteria("") == []
+
+
+def test_parse_criteria_all_malformed_or_group_is_dropped():
+    # Both conditions malformed → OR group has no valid conditions → dropped
+    groups = parse_criteria("bad|security-score>=9")
+    # "bad" group is dropped (no valid conditions), "security-score>=9" survives
+    assert len(groups) == 1
+    assert groups[0][0][0] == "security-score"
+
+
+# ── extract_scores ────────────────────────────────────────────────────────────
+
+def test_extract_scores_parses_numeric_tags():
+    scores = extract_scores(["security-score:9", "performance-score:8"])
+    assert scores["security-score"] == 9.0
+    assert scores["performance-score"] == 8.0
+
+
+def test_extract_scores_ignores_non_numeric_value():
+    scores = extract_scores(["security-score:high", "performance-score:8"])
+    assert "security-score" not in scores
+    assert scores["performance-score"] == 8.0
+
+
+def test_extract_scores_ignores_tags_without_colon():
+    scores = extract_scores(["mcp", "imported", "kagenti-approved"])
+    assert scores == {}
+
+
+def test_extract_scores_handles_float_values():
+    scores = extract_scores(["quality-score:7.5"])
+    assert scores["quality-score"] == 7.5
+
+
+def test_extract_scores_empty_tags():
+    assert extract_scores([]) == {}
+
+
+def test_extract_scores_skips_colon_without_value():
+    scores = extract_scores(["security-score:"])
+    assert "security-score" not in scores
+
+
+# ── evaluate_criteria ─────────────────────────────────────────────────────────
+
+def test_evaluate_criteria_all_and_conditions_met():
+    groups = parse_criteria("security-score>=9,performance-score>=8")
+    scores = {"security-score": 9.0, "performance-score": 8.0}
+    assert evaluate_criteria(groups, scores) is True
+
+
+def test_evaluate_criteria_one_and_condition_fails():
+    groups = parse_criteria("security-score>=9,performance-score>=8")
+    scores = {"security-score": 9.0, "performance-score": 7.0}
+    assert evaluate_criteria(groups, scores) is False
+
+
+def test_evaluate_criteria_missing_tag_fails():
+    groups = parse_criteria("security-score>=9")
+    scores = {"performance-score": 9.0}
+    assert evaluate_criteria(groups, scores) is False
+
+
+def test_evaluate_criteria_or_first_group_passes():
+    groups = parse_criteria("security-score>=10|security-score>=9,performance-score>=8")
+    scores = {"security-score": 10.0}
+    assert evaluate_criteria(groups, scores) is True
+
+
+def test_evaluate_criteria_or_second_group_passes():
+    groups = parse_criteria("security-score>=10|security-score>=9,performance-score>=8")
+    scores = {"security-score": 9.0, "performance-score": 8.0}
+    assert evaluate_criteria(groups, scores) is True
+
+
+def test_evaluate_criteria_or_both_groups_fail():
+    groups = parse_criteria("security-score>=10|security-score>=9,performance-score>=8")
+    scores = {"security-score": 8.0, "performance-score": 8.0}
+    assert evaluate_criteria(groups, scores) is False
+
+
+def test_evaluate_criteria_operator_gt():
+    groups = parse_criteria("security-score>9")
+    assert evaluate_criteria(groups, {"security-score": 10.0}) is True
+    assert evaluate_criteria(groups, {"security-score": 9.0}) is False
+
+
+def test_evaluate_criteria_operator_lt():
+    groups = parse_criteria("security-score<5")
+    assert evaluate_criteria(groups, {"security-score": 4.0}) is True
+    assert evaluate_criteria(groups, {"security-score": 5.0}) is False
+
+
+def test_evaluate_criteria_operator_lte():
+    groups = parse_criteria("security-score<=5")
+    assert evaluate_criteria(groups, {"security-score": 5.0}) is True
+    assert evaluate_criteria(groups, {"security-score": 6.0}) is False
+
+
+def test_evaluate_criteria_operator_eq():
+    groups = parse_criteria("security-score=9")
+    assert evaluate_criteria(groups, {"security-score": 9.0}) is True
+    assert evaluate_criteria(groups, {"security-score": 8.0}) is False
+
+
+def test_evaluate_criteria_operator_neq():
+    groups = parse_criteria("security-score!=9")
+    assert evaluate_criteria(groups, {"security-score": 8.0}) is True
+    assert evaluate_criteria(groups, {"security-score": 9.0}) is False
+
+
+def test_evaluate_criteria_empty_groups_returns_false():
+    assert evaluate_criteria([], {"security-score": 9.0}) is False
+
+
+# ── plugin class ──────────────────────────────────────────────────────────────
+
+from skillberry_store.plugins.base import PluginType
+from skillberry_plugin_kagenti_approver.plugin import SkillberryPluginKagentiApprover
+
+
+def test_plugin_metadata_name():
+    plugin = SkillberryPluginKagentiApprover()
+    assert plugin.metadata.name == "Kagenti Approver"
+
+
+def test_plugin_metadata_type():
+    plugin = SkillberryPluginKagentiApprover()
+    assert plugin.metadata.plugin_type == PluginType.EVALUATOR
+
+
+def test_plugin_metadata_version():
+    plugin = SkillberryPluginKagentiApprover()
+    assert plugin.metadata.version == "0.1.0"
+
+
+def test_plugin_is_always_enabled():
+    plugin = SkillberryPluginKagentiApprover()
+    assert plugin.is_enabled() is True
+
+
+def test_plugin_get_router_returns_none():
+    plugin = SkillberryPluginKagentiApprover()
+    assert plugin.get_router() is None
+
+
+def test_plugin_get_cli_commands_returns_none():
+    plugin = SkillberryPluginKagentiApprover()
+    assert plugin.get_cli_commands() is None
+
+
+def test_plugin_get_ui_config_returns_none():
+    plugin = SkillberryPluginKagentiApprover()
+    assert plugin.get_ui_config() is None
+
+
+# ── _evaluate_skill ───────────────────────────────────────────────────────────
+
+def _make_plugin():
+    """Return a plugin with event handlers NOT registered (isolated)."""
+    from skillberry_store.plugins import events as events_module
+    saved = dict(events_module._event_handlers)
+    events_module._event_handlers.clear()
+    try:
+        p = SkillberryPluginKagentiApprover()
+    finally:
+        events_module._event_handlers.clear()
+        events_module._event_handlers.update(saved)
+    return p
+
+
+def _mock_store(skill=None):
+    store = MagicMock()
+    store.get_skill.return_value = skill
+    store.update_skill.return_value = True
+    store.update_skill_tags.return_value = True
+    return store
+
+
+@pytest.mark.asyncio
+async def test_evaluate_skill_approves_when_criteria_met():
+    plugin = _make_plugin()
+    skill = {"uuid": "s-1", "tags": ["security-score:9", "performance-score:8"], "name": "x"}
+    store = _mock_store(skill)
+    plugin.set_store_api(store)
+
+    await plugin._evaluate_skill("s-1")
+
+    store.update_skill_tags.assert_called_once_with("s-1", [APPROVED_TAG])
+
+
+@pytest.mark.asyncio
+async def test_evaluate_skill_does_not_approve_when_criteria_not_met():
+    plugin = _make_plugin()
+    skill = {"uuid": "s-1", "tags": ["security-score:7", "performance-score:8"], "name": "x"}
+    store = _mock_store(skill)
+    plugin.set_store_api(store)
+
+    await plugin._evaluate_skill("s-1")
+
+    store.update_skill_tags.assert_not_called()
+    store.update_skill.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_evaluate_skill_no_duplicate_tag_when_already_approved():
+    plugin = _make_plugin()
+    skill = {
+        "uuid": "s-1",
+        "tags": ["security-score:9", "performance-score:8", APPROVED_TAG],
+        "name": "x",
+    }
+    store = _mock_store(skill)
+    plugin.set_store_api(store)
+
+    await plugin._evaluate_skill("s-1")
+
+    # Tag already present — no write at all
+    store.update_skill_tags.assert_not_called()
+    store.update_skill.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_evaluate_skill_revokes_when_criteria_no_longer_met():
+    plugin = _make_plugin()
+    skill = {
+        "uuid": "s-1",
+        "tags": ["security-score:6", "performance-score:8", APPROVED_TAG],
+        "name": "x",
+    }
+    store = _mock_store(skill)
+    plugin.set_store_api(store)
+
+    await plugin._evaluate_skill("s-1")
+
+    store.update_skill.assert_called_once()
+    written_skill = store.update_skill.call_args[0][1]
+    assert APPROVED_TAG not in written_skill["tags"]
+
+
+@pytest.mark.asyncio
+async def test_evaluate_skill_revoke_preserves_other_tags():
+    plugin = _make_plugin()
+    skill = {
+        "uuid": "s-1",
+        "tags": ["security-score:6", "mcp", "imported", APPROVED_TAG],
+        "name": "x",
+    }
+    store = _mock_store(skill)
+    plugin.set_store_api(store)
+
+    await plugin._evaluate_skill("s-1")
+
+    written_skill = store.update_skill.call_args[0][1]
+    assert "mcp" in written_skill["tags"]
+    assert "imported" in written_skill["tags"]
+    assert APPROVED_TAG not in written_skill["tags"]
+
+
+@pytest.mark.asyncio
+async def test_evaluate_skill_no_op_when_criteria_fail_and_not_approved():
+    plugin = _make_plugin()
+    skill = {"uuid": "s-1", "tags": ["security-score:6", "mcp"], "name": "x"}
+    store = _mock_store(skill)
+    plugin.set_store_api(store)
+
+    await plugin._evaluate_skill("s-1")
+
+    store.update_skill_tags.assert_not_called()
+    store.update_skill.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_evaluate_skill_skill_not_found_no_crash():
+    plugin = _make_plugin()
+    store = _mock_store(skill=None)
+    plugin.set_store_api(store)
+
+    await plugin._evaluate_skill("missing-uuid")  # must not raise
+
+    store.update_skill_tags.assert_not_called()
+    store.update_skill.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_evaluate_skill_missing_score_tag_fails_criteria():
+    plugin = _make_plugin()
+    # Only has performance-score, no security-score
+    skill = {"uuid": "s-1", "tags": ["performance-score:9"], "name": "x"}
+    store = _mock_store(skill)
+    plugin.set_store_api(store)
+
+    await plugin._evaluate_skill("s-1")
+
+    store.update_skill_tags.assert_not_called()
+
+
+# ── event handler registration ────────────────────────────────────────────────
+
+def test_event_handlers_registered_for_skill_added_and_updated():
+    from skillberry_store.plugins import events as events_module
+    saved = dict(events_module._event_handlers)
+    events_module._event_handlers.clear()
+    try:
+        SkillberryPluginKagentiApprover()
+        assert len(events_module._event_handlers.get("content_added:skill", [])) > 0
+        assert len(events_module._event_handlers.get("content_updated:skill", [])) > 0
+    finally:
+        events_module._event_handlers.clear()
+        events_module._event_handlers.update(saved)
+
+
+def test_event_handlers_not_registered_for_tools_or_snippets():
+    from skillberry_store.plugins import events as events_module
+    saved = dict(events_module._event_handlers)
+    events_module._event_handlers.clear()
+    try:
+        SkillberryPluginKagentiApprover()
+        assert "content_added:tool" not in events_module._event_handlers
+        assert "content_added:snippet" not in events_module._event_handlers
+    finally:
+        events_module._event_handlers.clear()
+        events_module._event_handlers.update(saved)
+
+
+@pytest.mark.asyncio
+async def test_event_handler_no_op_when_store_not_set():
+    from skillberry_store.plugins import events as events_module
+    saved = dict(events_module._event_handlers)
+    events_module._event_handlers.clear()
+    try:
+        SkillberryPluginKagentiApprover()
+        handler = events_module._event_handlers["content_added:skill"][0]
+        await handler(uuid="any-uuid")  # must not raise
+    finally:
+        events_module._event_handlers.clear()
+        events_module._event_handlers.update(saved)
+
+
+# ── env var configuration ─────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_env_var_overrides_default_criteria(monkeypatch):
+    monkeypatch.setenv("KAGENTI_CRITERIA", "security-score>=10")
+    plugin = _make_plugin()
+    # Score 9 is not enough with the override (needs >=10)
+    skill = {"uuid": "s-1", "tags": ["security-score:9"], "name": "x"}
+    store = _mock_store(skill)
+    plugin.set_store_api(store)
+
+    await plugin._evaluate_skill("s-1")
+
+    store.update_skill_tags.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_env_var_override_approves_with_custom_threshold(monkeypatch):
+    monkeypatch.setenv("KAGENTI_CRITERIA", "security-score>=9")
+    plugin = _make_plugin()
+    skill = {"uuid": "s-1", "tags": ["security-score:9"], "name": "x"}
+    store = _mock_store(skill)
+    plugin.set_store_api(store)
+
+    await plugin._evaluate_skill("s-1")
+
+    store.update_skill_tags.assert_called_once_with("s-1", [APPROVED_TAG])
+
+
+def test_missing_env_var_falls_back_to_default(monkeypatch):
+    monkeypatch.delenv("KAGENTI_CRITERIA", raising=False)
+    plugin = _make_plugin()
+    groups = plugin._load_criteria()
+    # Default: security-score>=9,performance-score>=8 → 1 OR-group, 2 conditions
+    assert len(groups) == 1
+    assert len(groups[0]) == 2

--- a/plugins/skillberry-plugin-kagenti-approver/tests/test_kagenti_approver_plugin.py
+++ b/plugins/skillberry-plugin-kagenti-approver/tests/test_kagenti_approver_plugin.py
@@ -1,6 +1,6 @@
 """Tests for SkillberryPluginKagentiApprover."""
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from skillberry_plugin_kagenti_approver.plugin import (
     parse_criteria,
@@ -13,10 +13,10 @@ from skillberry_plugin_kagenti_approver.plugin import (
 
 # ── parse_criteria ────────────────────────────────────────────────────────────
 
-def test_parse_criteria_default_produces_one_or_group_two_conditions():
+def test_parse_criteria_default_produces_one_or_group_three_conditions():
     groups = parse_criteria(DEFAULT_CRITERIA)
     assert len(groups) == 1
-    assert len(groups[0]) == 2
+    assert len(groups[0]) == 3
 
 
 def test_parse_criteria_default_security_score():
@@ -259,7 +259,7 @@ def _mock_store(skill=None):
 @pytest.mark.asyncio
 async def test_evaluate_skill_approves_when_criteria_met():
     plugin = _make_plugin()
-    skill = {"uuid": "s-1", "tags": ["security-score:9", "performance-score:8"], "name": "x"}
+    skill = {"uuid": "s-1", "tags": ["security-score:9", "performance-score:8", "quality-score:8"], "name": "x"}
     store = _mock_store(skill)
     plugin.set_store_api(store)
 
@@ -286,7 +286,7 @@ async def test_evaluate_skill_no_duplicate_tag_when_already_approved():
     plugin = _make_plugin()
     skill = {
         "uuid": "s-1",
-        "tags": ["security-score:9", "performance-score:8", APPROVED_TAG],
+        "tags": ["security-score:9", "performance-score:8", "quality-score:8", APPROVED_TAG],
         "name": "x",
     }
     store = _mock_store(skill)
@@ -449,6 +449,6 @@ def test_missing_env_var_falls_back_to_default(monkeypatch):
     monkeypatch.delenv("KAGENTI_CRITERIA", raising=False)
     plugin = _make_plugin()
     groups = plugin._load_criteria()
-    # Default: security-score>=9,performance-score>=8 → 1 OR-group, 2 conditions
+    # Default: security-score>=9,performance-score>=8,quality-score>=8 → 1 OR-group, 3 conditions
     assert len(groups) == 1
-    assert len(groups[0]) == 2
+    assert len(groups[0]) == 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,6 +171,10 @@ plugin-anthropic-skill-generator = [
   "skillberry-plugin-anthropic-skill-generator>=0.1.0",
 ]
 
+plugin-kagenti-approver = [
+  "skillberry-plugin-kagenti-approver>=0.1.0",
+]
+
 # Install all plugins
 plugins-all = [
   "skillberry-plugin-creator>=0.2.0",
@@ -179,6 +183,7 @@ plugins-all = [
   "skillberry-plugin-dedupe>=0.1.0",
   "skillberry-plugin-mcp-importer>=0.1.0",
   "skillberry-plugin-anthropic-skill-generator>=0.1.0",
+  "skillberry-plugin-kagenti-approver>=0.1.0",
 ]
 
 test = [
@@ -193,6 +198,7 @@ skillberry-plugin-security = { path = "plugins/skillberry-plugin-security", edit
 skillberry-plugin-dedupe = { path = "plugins/skillberry-plugin-dedupe", editable = true }
 skillberry-plugin-mcp-importer = { path = "plugins/skillberry-plugin-mcp-importer", editable = true }
 skillberry-plugin-anthropic-skill-generator = { path = "plugins/skillberry-plugin-anthropic-skill-generator", editable = true }
+skillberry-plugin-kagenti-approver = { path = "plugins/skillberry-plugin-kagenti-approver", editable = true }
 llm-client = { path = "skillberry-common/packages/llm-client", editable = true }
 torch = { index = "pytorch-cpu" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,8 @@ dependencies = [
   "wsgidav>=4.3",
   "cheroot>=10.0",
   "shenanigaNFS @ git+https://github.com/JordanMilne/ShenanigaNFS.git",
+  "skillberry-plugin-dedupe>=0.1.0",
+  "skillberry-plugin-kagenti-approver>=0.1.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Closes #188.

## Summary
- New `skillberry-plugin-kagenti-approver` plugin that reacts to `content_added:skill` and `content_updated:skill` events and automatically adds or revokes the `kagenti-approved` tag based on configurable score-tag criteria
- Default criteria: `security-score>=9,performance-score>=8,quality-score>=8` (overridable via `KAGENTI_CRITERIA` env var)
- Criteria support AND (`,`), OR (`|`), and all six comparison operators (`>=`, `>`, `<=`, `<`, `=`, `!=`)
- `skillberry-plugin-dedupe` and `skillberry-plugin-kagenti-approver` promoted to core `dependencies` — installed by default with `pip install skillberry-store`, no extras bracket needed; both can still be uninstalled individually
- 49 tests, all passing; full suite (396 passed) unaffected

## Test Plan
- [ ] `python -m pytest plugins/skillberry-plugin-kagenti-approver/tests/ -q` → 49 passed
- [ ] Verify `kagenti-approved` tag appears on a skill with qualifying scores after add/update
- [ ] Verify tag is revoked when scores drop below threshold

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>