### PR TITLE
feat: add Skill Optimizer plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,11 @@ pip install skillberry-store[plugin-evaluator]
 # Dedupe plugin only (AI-powered duplicate skill detection)
 pip install skillberry-store[plugin-dedupe]
 
+# Skill Optimizer plugin only (optimize existing skills using Claude Code)
+pip install skillberry-store[plugin-skill-optimizer]
+
 # Multiple specific plugins
-pip install skillberry-store[plugin-creator,plugin-evaluator,plugin-dedupe]
+pip install skillberry-store[plugin-creator,plugin-evaluator,plugin-skill-optimizer]
 ```
 
 For detailed plugin installation options and configuration, see the [Plugin Installation Guide](docs/plugins-installation.md).

--- a/docs/plugins-installation.md
+++ b/docs/plugins-installation.md
@@ -41,6 +41,7 @@ This installs:
 - skillberry-plugin-dedupe (AI-powered duplicate skill detection) — also a default plugin
 - skillberry-plugin-mcp-importer (import tools from any MCP SSE server)
 - skillberry-plugin-anthropic-skill-generator (generate Anthropic skills from descriptions using Claude Code)
+- skillberry-plugin-skill-optimizer (optimize existing skills using Claude Code via runspace-agent)
 - skillberry-plugin-kagenti-approver (automatic kagenti-approved labeling) — also a default plugin
 
 ### 3. Install Specific Plugins
@@ -72,6 +73,11 @@ pip install skillberry-store[plugin-mcp-importer]
 pip install skillberry-store[plugin-anthropic-skill-generator]
 ```
 
+#### Skill Optimizer Plugin Only
+```bash
+pip install skillberry-store[plugin-skill-optimizer]
+```
+
 #### Kagenti Approver Plugin Only
 ```bash
 pip install skillberry-store[plugin-kagenti-approver]
@@ -79,7 +85,7 @@ pip install skillberry-store[plugin-kagenti-approver]
 
 #### Multiple Specific Plugins
 ```bash
-pip install skillberry-store[plugin-creator,plugin-evaluator,plugin-mcp-importer,plugin-anthropic-skill-generator]
+pip install skillberry-store[plugin-creator,plugin-evaluator,plugin-mcp-importer,plugin-anthropic-skill-generator,plugin-skill-optimizer]
 ```
 
 ### 4. Adding Plugins Later
@@ -88,7 +94,7 @@ If you initially installed skillberry-store without plugins, you can add them la
 
 ```bash
 # Add all plugins to existing installation
-pip install skillberry-plugin-creator skillberry-plugin-evaluator skillberry-plugin-security skillberry-plugin-dedupe skillberry-plugin-mcp-importer skillberry-plugin-anthropic-skill-generator
+pip install skillberry-plugin-creator skillberry-plugin-evaluator skillberry-plugin-security skillberry-plugin-dedupe skillberry-plugin-mcp-importer skillberry-plugin-anthropic-skill-generator skillberry-plugin-skill-optimizer
 
 # Or reinstall with plugins
 pip install --upgrade skillberry-store[plugins-all]
@@ -357,6 +363,101 @@ curl -X POST http://localhost:8000/api/plugins/anthropic-skill-generator/generat
 2. Environment variables
 3. `~/.claude/settings.json` (lowest - automatic)
 
+### Skill Optimizer Plugin (`skillberry-plugin-skill-optimizer`)
+
+**Purpose:** Optimize existing skills in the store using a RunSpace-powered Claude Code session.
+
+**Features:**
+- Exports a selected skill to a temporary directory in Anthropic format
+- Stages optional context: skill metadata, execution trajectories, additional context folder
+- Runs a RunSpace optimization session (Claude Code in container or local mode)
+- Imports the optimized result as a new skill with `<name>_optimized` naming
+- Attaches full optimization metadata (rationale, tools/snippets changed, issues addressed) to the new skill's `extra` field
+- Bundled knowledge base guides the agent on skill format, best practices, description optimization, snippet quality, tool quality, and trajectory-based analysis
+
+**Configuration:**
+
+The plugin automatically loads credentials from `~/.claude/settings.json` if it exists:
+```json
+{
+  "apiKey": "sk-ant-...",
+  "model": "claude-opus-4-8",
+  "baseUrl": "https://api.anthropic.com"
+}
+```
+
+Or configure via environment variables:
+```bash
+# Option 1: Direct Anthropic API
+export ANTHROPIC_API_KEY="sk-ant-..."
+
+# Option 2: Proxy/Gateway
+export ANTHROPIC_BASE_URL="https://your-gateway.example.com"
+export ANTHROPIC_AUTH_TOKEN="your-token"
+export ANTHROPIC_MODEL="claude-opus-4-8"
+
+# Execution mode (default: container - requires Docker)
+export RUNSPACE_MODE="container"  # or "local" for development
+
+# Max conversation turns (default: 300)
+export RUNSPACE_MAX_TURNS="300"
+```
+
+**Requirements:**
+- Docker (for default container mode — recommended)
+- Anthropic API credentials (API key or proxy configuration)
+
+**API Endpoints:**
+- `POST /api/plugins/skill-optimizer/optimize-skill`
+
+**Request body:**
+```json
+{
+  "skill_uuid": "550e8400-e29b-41d4-a716-446655440000",
+  "output_skill_name": "my-skill-v2",
+  "include_metadata": true,
+  "trajectories_dir": "/path/to/trajectories",
+  "additional_context_dir": "/path/to/context",
+  "execution_mode": "container",
+  "max_turns": 100
+}
+```
+
+Only `skill_uuid` is required. All other fields are optional.
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Skill 'my-skill_optimized' optimized successfully.",
+  "skill_name": "my-skill_optimized",
+  "skill_uuid": "661f9511-f30c-52e5-b827-557766551111",
+  "tools_count": 3,
+  "snippets_count": 1,
+  "optimization_rationale": "Improved tool descriptions and added input validation."
+}
+```
+
+**Output naming:**
+- Default: `<original_name>_optimized`
+- If name taken: `<original_name>_optimized(1)`, `(2)`, ...
+- Override with `output_skill_name`
+
+**Example:**
+```bash
+curl -X POST http://localhost:8000/api/plugins/skill-optimizer/optimize-skill \
+  -H "Content-Type: application/json" \
+  -d '{
+    "skill_uuid": "550e8400-e29b-41d4-a716-446655440000",
+    "include_metadata": true
+  }'
+```
+
+**Configuration Priority:**
+1. Request-specific parameters (highest)
+2. Environment variables
+3. `~/.claude/settings.json` (lowest — automatic)
+
 ### Kagenti Approver Plugin (`skillberry-plugin-kagenti-approver`)
 
 **Purpose:** Automatically label skills as `kagenti-approved` when their score tags satisfy configurable criteria.
@@ -516,7 +617,7 @@ my-plugin = { path = "plugins/my-plugin", editable = true }
 
 ```bash
 # Uninstall all plugins
-pip uninstall -y skillberry-plugin-creator skillberry-plugin-evaluator skillberry-plugin-security skillberry-plugin-dedupe skillberry-plugin-mcp-importer skillberry-plugin-anthropic-skill-generator
+pip uninstall -y skillberry-plugin-creator skillberry-plugin-evaluator skillberry-plugin-security skillberry-plugin-dedupe skillberry-plugin-mcp-importer skillberry-plugin-anthropic-skill-generator skillberry-plugin-skill-optimizer
 
 # Verify removal
 pip list | grep skillberry-plugin

--- a/plugins/skillberry-plugin-skill-optimizer/.env.example
+++ b/plugins/skillberry-plugin-skill-optimizer/.env.example
@@ -1,0 +1,11 @@
+# Anthropic credentials (one of the following):
+ANTHROPIC_API_KEY=your_api_key_here
+# OR proxy/gateway:
+# ANTHROPIC_BASE_URL=https://your-proxy.example.com
+# ANTHROPIC_AUTH_TOKEN=your_auth_token
+
+# Execution mode: "container" (default, requires Docker) or "local" (faster, dev only)
+RUNSPACE_MODE=container
+
+# Max conversation turns for Claude Code (default: 300)
+# RUNSPACE_MAX_TURNS=300

--- a/plugins/skillberry-plugin-skill-optimizer/README.md
+++ b/plugins/skillberry-plugin-skill-optimizer/README.md
@@ -1,0 +1,61 @@
+# Skillberry Plugin: Skill Optimizer
+
+Optimizes existing Skillberry skills using a RunSpace-powered Claude Code session.
+
+## What it does
+
+1. Exports the selected skill to a temporary directory in Anthropic format
+2. Stages optional context (skill metadata, execution trajectories, additional context)
+3. Runs a RunSpace optimization session (Claude Code in container or local mode)
+4. Imports the optimized result as a new skill in the store
+5. Attaches full optimization metadata (rationale, changes, issues addressed) to the new skill
+
+## Configuration
+
+Copy `.env.example` to `.env` and fill in credentials:
+
+```bash
+ANTHROPIC_API_KEY=your_key_here
+# or
+ANTHROPIC_BASE_URL=https://your-proxy.example.com
+ANTHROPIC_AUTH_TOKEN=your_token
+```
+
+Or configure `~/.claude/settings.json` (auto-detected).
+
+## Execution modes
+
+- `container` (default): Claude Code runs in a Docker container. Requires Docker.
+- `local`: Claude Code runs on the host machine. Faster, for development only.
+
+Set via `RUNSPACE_MODE` environment variable.
+
+## API
+
+`POST /api/plugins/skill-optimizer/optimize-skill`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `skill_uuid` | string | yes | UUID of the skill to optimize |
+| `output_skill_name` | string | no | Override the auto-generated name |
+| `include_metadata` | bool | no (default: true) | Include skill tags/extra in context |
+| `trajectories_dir` | string | no | Path to execution trajectories folder |
+| `additional_context_dir` | string | no | Path to additional context folder |
+| `execution_mode` | string | no | `"container"` or `"local"` |
+| `max_turns` | int | no | Max conversation turns (default: 300) |
+
+## Output skill naming
+
+- Default: `<original_name>_optimized`
+- If taken: `<original_name>_optimized(1)`, `(2)`, ...
+- Override with `output_skill_name`
+
+## Optimization metadata
+
+After optimization, the new skill's extra metadata contains an `optimization` key with:
+- `optimization_rationale`: what was changed and why
+- `issues_addressed`: failure modes fixed
+- `tools_added / tools_modified / tools_removed`: tool changes
+- `snippets_added / snippets_modified / snippets_removed`: snippet changes
+- `source_skill_uuid`: UUID of the original skill
+- `source_skill_name`: name of the original skill

--- a/plugins/skillberry-plugin-skill-optimizer/pyproject.toml
+++ b/plugins/skillberry-plugin-skill-optimizer/pyproject.toml
@@ -24,5 +24,8 @@ skill-optimizer = "skillberry_plugin_skill_optimizer.plugin:SkillberryPluginSkil
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.package-data]
+skillberry_plugin_skill_optimizer = ["knowledge/*.md"]
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/plugins/skillberry-plugin-skill-optimizer/pyproject.toml
+++ b/plugins/skillberry-plugin-skill-optimizer/pyproject.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 description = "Optimize existing Skillberry skills using RunSpace-powered Claude Code"
 requires-python = ">=3.10"
 dependencies = [
+    "skillberry-store",
     "runspace-agent[claude]==0.1.0",
 ]
 
@@ -20,9 +21,8 @@ dev = [
 [project.entry-points."skillberry_store.plugins"]
 skill-optimizer = "skillberry_plugin_skill_optimizer.plugin:SkillberryPluginSkillOptimizer"
 
-[tool.setuptools]
-packages = ["skillberry_plugin_skill_optimizer"]
-package-dir = {"" = "src"}
+[tool.setuptools.packages.find]
+where = ["src"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/plugins/skillberry-plugin-skill-optimizer/pyproject.toml
+++ b/plugins/skillberry-plugin-skill-optimizer/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = ["setuptools>=45", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "skillberry-plugin-skill-optimizer"
+version = "0.1.0"
+description = "Optimize existing Skillberry skills using RunSpace-powered Claude Code"
+requires-python = ">=3.10"
+dependencies = [
+    "runspace-agent[claude]==0.1.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "pytest-asyncio>=0.21",
+]
+
+[project.entry-points."skillberry_store.plugins"]
+skill-optimizer = "skillberry_plugin_skill_optimizer.plugin:SkillberryPluginSkillOptimizer"
+
+[tool.setuptools]
+packages = ["skillberry_plugin_skill_optimizer"]
+package-dir = {"" = "src"}
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/__init__.py
+++ b/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/__init__.py
@@ -1,0 +1,3 @@
+from skillberry_plugin_skill_optimizer.plugin import SkillberryPluginSkillOptimizer
+
+__all__ = ["SkillberryPluginSkillOptimizer"]

--- a/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/knowledge/01-skillberry-store-format.md
+++ b/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/knowledge/01-skillberry-store-format.md
@@ -1,0 +1,187 @@
+# SkillBerry Store — Skill Format Specification
+
+This file defines the exact format required for a skill that will be imported into
+the SkillBerry Store. **Every rule here is enforced by the importer — violations
+will cause import failure or silent data corruption.**
+
+---
+
+## Directory Structure
+
+A skill exported from the SkillBerry Store looks like this on disk:
+
+```
+<skill-name>/
+├── SKILL.md          # Required: frontmatter + instructions body
+├── scripts/          # Optional: Python tool modules (.py files)
+├── references/       # Optional: documentation snippets
+├── assets/           # Optional: templates, data files
+└── ...               # Any other non-Python files become snippets
+```
+
+---
+
+## SKILL.md Format
+
+### Frontmatter
+
+`SKILL.md` MUST begin with a `---`-delimited YAML frontmatter block. Only two
+fields are recognised by the SkillBerry Store importer:
+
+| Field         | Required | Constraints                                                      |
+|---------------|----------|------------------------------------------------------------------|
+| `name`        | Yes      | Kebab-case, max 64 characters. Lowercase letters, numbers, hyphens only. Must not start or end with a hyphen. No consecutive hyphens. |
+| `description` | Yes      | Max 1024 characters. Non-empty. Describes what the skill does and when to use it. |
+
+**Do NOT add any other fields to the frontmatter.** Extra fields are silently
+ignored but pollute the skill definition.
+
+Minimal example:
+```yaml
+---
+name: my-skill
+description: Extracts structured data from invoices. Use when working with PDF or image invoices.
+---
+```
+
+### `name` field rules
+
+- 1–64 characters
+- Only `a-z`, `0-9`, and `-`
+- Must not start or end with `-`
+- Must not contain `--`
+- Must match the parent directory name
+- If you made meaningful changes, update `name` to hint at the improvement
+  (e.g. `invoice-parser-guardrails`). Keep it short — 2–4 words.
+
+### `description` field rules
+
+- 1–1024 characters (hard limit enforced by importer)
+- Should describe **what the skill does AND when to use it**
+- Use imperative phrasing: "Use this skill when…" or "Extracts… when the user…"
+- Include specific keywords that help agents recognise relevant tasks
+- Err on the side of being specific about scope boundaries
+
+**Good example:**
+```yaml
+description: >
+  Extracts text, tables, and form fields from PDF files. Use when working with
+  PDF documents, invoices, contracts, or scanned forms — even if the user
+  doesn't explicitly say "PDF."
+```
+
+**Poor example:**
+```yaml
+description: Helps with PDFs.
+```
+
+### Body content
+
+The Markdown body (everything after the closing `---`) becomes a **snippet** in
+the SkillBerry Store. It contains the instructions the agent follows. There are
+no format restrictions, but effective bodies include:
+
+- Step-by-step instructions (numbered lists)
+- Gotchas (non-obvious edge cases the agent will get wrong without guidance)
+- Working examples of inputs and outputs
+- Checklists for multi-step workflows
+
+Keep the body under 500 lines. Move detailed reference material to separate files
+in `references/` and tell the agent exactly when to load them.
+
+---
+
+## How the SkillBerry Importer Classifies Files
+
+The importer classifies every file in the skill directory by **extension**,
+not by directory name.
+
+### Python files (`.py`) → Tools
+
+Every `.py` file is AST-parsed. Each **top-level `def`** becomes a separate tool:
+
+- Function name → tool name
+- Docstring → tool description
+- Type annotations + docstring `Args:` section → parameter schema
+
+A `.py` file with **no functions** becomes one tool named after the file.
+
+**Critical rules for Python files:**
+
+1. Each `.py` file must be **self-contained**: only stdlib imports plus injected
+   helpers. The store executes each file as a flat script — there is no
+   module/package system.
+2. **Relative and cross-file imports are FORBIDDEN:**
+   ```python
+   # NEVER do this — breaks at runtime
+   from scripts.helpers import call_api
+   import scripts.utils
+   ```
+3. Runtime helpers (e.g. `call_api`, `store_result`) are **injected into the
+   execution scope** by the store before your code runs. Call them directly —
+   do NOT import them.
+4. Each function should have a clear docstring describing what it does, its
+   parameters, and its return value. This becomes the tool's description in the
+   store and is what agents use to decide whether to call the tool.
+
+**Good tool function:**
+```python
+def extract_invoice_total(invoice_text: str) -> float:
+    """Extract the total amount due from invoice text.
+
+    Args:
+        invoice_text: Raw text content of an invoice document.
+
+    Returns:
+        The total amount due as a float.
+    """
+    # implementation
+```
+
+### Non-Python files → Snippets
+
+All non-Python files (`.md`, `.txt`, `.json`, `.yaml`, `.csv`, etc.) become
+**read-only reference snippets** in the store. This includes:
+
+- The `SKILL.md` body (the instructions)
+- Any files in `references/`, `assets/`, or other subdirectories
+- Configuration files, templates, schemas
+
+---
+
+## Preserve Structure (Critical)
+
+When optimizing a skill, you are editing the skill **in place** — the same
+directory will be re-imported after you finish. Follow these rules:
+
+- **Do NOT rename, move, or delete existing files.** Renaming changes tool/snippet
+  identity and breaks the import/export round-trip.
+- **Do NOT create subdirectories** that don't already exist, unless you are
+  adding reference material the agent can load on demand.
+- **Do NOT leave temporary files** in the directory — everything gets imported.
+- **Do NOT add `__init__.py`** or any Python packaging files.
+- Keep `SKILL.md` at the **top level** of the skill directory at all times.
+
+---
+
+## Skill Name — Updating After Optimization
+
+If you made meaningful improvements, update the `name` field in `SKILL.md`
+frontmatter to a new kebab-case name that concisely describes what changed:
+
+- `invoice-parser` → `invoice-parser-guardrails`
+- `data-analyst` → `data-analyst-chart-fix`
+
+Rules:
+- Max 64 characters — keep it short (2–4 words)
+- Only change the **value** inside `SKILL.md` (and in `required_outputs.json`)
+- **Do NOT** rename the directory, create a new subdirectory, or move `SKILL.md`
+
+---
+
+## Required Output Contract
+
+The optimization session produces a `required_outputs.json` file in the skill
+directory. You MUST fill in every field before finishing. The optimizer reads
+this to record what changed and attach it to the new skill's metadata in the
+store. See the main prompt for the template and field definitions.

--- a/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/knowledge/02-skill-best-practices.md
+++ b/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/knowledge/02-skill-best-practices.md
@@ -1,0 +1,241 @@
+# Best Practices for Writing and Optimizing Skills
+
+Source: agentskills.io — adapted for the SkillBerry Store context.
+
+---
+
+## Start from Real Expertise
+
+A common failure mode: using an LLM to generate a skill without domain-specific
+context. The result is vague, generic instructions ("handle errors appropriately",
+"follow best practices") rather than the specific patterns, edge cases, and
+conventions that make a skill valuable.
+
+**When optimizing, look for:**
+- Generic advice that could be replaced with specific, concrete instructions
+- Missing edge cases that real runs would surface
+- Over-broad instructions that cause the agent to pursue unproductive paths
+
+---
+
+## Spending Context Wisely
+
+The skill's `SKILL.md` body loads into the agent's context window alongside
+conversation history, system context, and other active skills. Every token
+competes for the agent's attention.
+
+### Add what the agent lacks, omit what it knows
+
+Focus on what the agent *wouldn't* know without the skill: project-specific
+conventions, domain procedures, non-obvious edge cases, specific APIs or tools.
+You don't need to explain what a PDF is or how HTTP works.
+
+**Too verbose — agent already knows this:**
+```markdown
+## Extract PDF text
+
+PDF (Portable Document Format) files are a common file format that contains
+text, images, and other content. To extract text from a PDF, you'll need to
+use a library. pdfplumber is recommended because it handles most cases well.
+```
+
+**Better — jumps straight to what the agent wouldn't know:**
+```markdown
+## Extract PDF text
+
+Use pdfplumber for text extraction. For scanned documents, fall back to
+pdf2image with pytesseract.
+```
+
+Ask about each piece of content: "Would the agent get this wrong without this
+instruction?" If the answer is no, cut it.
+
+### Keep SKILL.md under 500 lines
+
+Move detailed reference material to separate files. Tell the agent *when* to
+load each file — "Read `references/api-errors.md` if the API returns a
+non-200 status code" — rather than a generic "see references/ for details."
+
+---
+
+## Calibrating Control
+
+Not every part of a skill needs the same level of prescriptiveness.
+
+### Give freedom when approaches are equally valid
+
+For flexible tasks, explaining *why* is more effective than rigid directives.
+An agent that understands the purpose makes better context-dependent decisions.
+
+```markdown
+## Code review process
+1. Check all database queries for SQL injection (use parameterized queries)
+2. Verify authentication checks on every endpoint
+3. Look for race conditions in concurrent code paths
+4. Confirm error messages don't leak internal details
+```
+
+### Be prescriptive for fragile operations
+
+When a specific sequence must be followed or consistency matters:
+
+```markdown
+## Database migration
+
+Run exactly this sequence:
+```bash
+python scripts/migrate.py --verify --backup
+```
+Do not modify the command or add additional flags.
+```
+
+### Provide defaults, not menus
+
+Pick a default approach and mention alternatives briefly:
+
+**Too many options:**
+```markdown
+You can use pypdf, pdfplumber, PyMuPDF, or pdf2image...
+```
+
+**Clear default with escape hatch:**
+```markdown
+Use pdfplumber for text extraction. For scanned PDFs requiring OCR,
+use pdf2image with pytesseract instead.
+```
+
+---
+
+## Patterns for Effective Instructions
+
+### Gotchas sections (highest value)
+
+The highest-value content in many skills is a list of gotchas — environment-specific
+facts that defy reasonable assumptions:
+
+```markdown
+## Gotchas
+
+- The `users` table uses soft deletes. Queries must include
+  `WHERE deleted_at IS NULL` or results will include deactivated accounts.
+- The user ID is `user_id` in the database, `uid` in the auth service,
+  and `accountId` in the billing API. All three refer to the same value.
+- The `/health` endpoint returns 200 even if the database connection is down.
+  Use `/ready` to check full service health.
+```
+
+When an agent makes a mistake, add the correction to the gotchas section. This
+is one of the most direct ways to improve a skill iteratively.
+
+### Templates for output format
+
+When you need the agent to produce output in a specific format, provide a template.
+Agents pattern-match well against concrete structures:
+
+```markdown
+## Report structure
+
+Use this template:
+```markdown
+# [Analysis Title]
+## Executive summary
+[One-paragraph overview of key findings]
+## Key findings
+- Finding 1 with supporting data
+## Recommendations
+1. Specific actionable recommendation
+```
+```
+
+### Checklists for multi-step workflows
+
+```markdown
+## Processing workflow
+- [ ] Step 1: Analyze the input (run `scripts/analyze.py`)
+- [ ] Step 2: Create field mapping (edit `fields.json`)
+- [ ] Step 3: Validate mapping (run `scripts/validate.py`)
+- [ ] Step 4: Execute (run `scripts/process.py`)
+- [ ] Step 5: Verify output (run `scripts/verify.py`)
+```
+
+### Validation loops
+
+```markdown
+## Editing workflow
+1. Make your edits
+2. Run validation: `python scripts/validate.py output/`
+3. If validation fails: fix the issues and run validation again
+4. Only proceed when validation passes
+```
+
+### Procedures over declarations
+
+A skill should teach the agent *how to approach* a class of problems, not *what
+to produce* for a specific instance:
+
+**Specific answer — only useful for this exact task:**
+```markdown
+Join the `orders` table to `customers` on `customer_id`, filter where
+`region = 'EMEA'`, and sum the `amount` column.
+```
+
+**Reusable method — works for any analytical query:**
+```markdown
+1. Read the schema from `references/schema.yaml` to find relevant tables
+2. Join tables using the `_id` foreign key convention
+3. Apply filters from the user's request as WHERE clauses
+4. Aggregate numeric columns and format as a markdown table
+```
+
+---
+
+## Designing Coherent Units
+
+Skills scoped too narrowly force multiple skills to load for a single task.
+Skills scoped too broadly become hard to activate precisely.
+
+A skill for querying a database and formatting results may be one coherent unit.
+A skill that also covers database administration is probably trying to do too much.
+
+When optimizing: resist the urge to add more tools/functions. Removing a redundant
+or unclear tool is a valid, often better, optimization. A smaller, sharper skill
+outperforms a large bloated one.
+
+---
+
+## Tool Function Quality
+
+Since `.py` files become tools in the SkillBerry Store, tool quality matters.
+
+**Good tool functions:**
+- Have a single, clear responsibility
+- Include a docstring describing what they do, their parameters, and return value
+- Use type annotations on all parameters and return values
+- Handle edge cases gracefully with informative error messages
+- Are self-contained (no cross-file imports)
+
+**Red flags to fix when optimizing:**
+- Functions doing multiple unrelated things → split them
+- Vague parameter names (`data`, `input`, `value`) → use descriptive names
+- Missing docstrings → add them (the docstring becomes the tool description)
+- Overly broad `except Exception` → catch specific exceptions
+- Functions that are never called in practice → remove them
+
+---
+
+## Progressive Disclosure
+
+Structure skills to take advantage of how agents load content:
+
+1. **Metadata (~100 tokens)**: `name` and `description` — loaded at startup
+2. **Instructions (<5000 tokens recommended)**: full `SKILL.md` body — loaded on activation
+3. **Resources (as needed)**: files in `scripts/`, `references/`, `assets/` — loaded on demand
+
+Tell the agent exactly when to load reference files:
+```markdown
+If the API returns a non-200 status, read `references/error-codes.md` for
+the complete error reference before retrying.
+```
+
+This lets the agent load context on demand instead of up front, keeping the
+context window lean during normal runs.

--- a/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/knowledge/03-skill-description-optimization.md
+++ b/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/knowledge/03-skill-description-optimization.md
@@ -1,0 +1,177 @@
+# Optimizing Skill Descriptions
+
+Source: agentskills.io — adapted for the SkillBerry Store context.
+
+The `description` field in `SKILL.md` frontmatter is the primary mechanism agents
+use to decide whether to load a skill. An under-specified description means the
+skill won't trigger when it should; an over-broad description means it triggers
+when it shouldn't.
+
+---
+
+## How Skill Triggering Works
+
+Agents use **progressive disclosure**: at startup, they load only `name` and
+`description` — just enough to know when a skill might be relevant. When a task
+matches, the agent reads the full `SKILL.md` into context.
+
+The description carries the **entire burden of triggering**. If it doesn't convey
+when the skill is useful, the agent won't reach for it.
+
+Important nuance: agents typically only activate skills for tasks requiring
+knowledge or capabilities beyond what they can handle alone. A simple "read this
+PDF" may not trigger a PDF skill even with a perfect description — the agent
+handles it with basic tools. Specialised knowledge, domain workflows, and uncommon
+formats are where description quality makes the difference.
+
+---
+
+## Principles for Effective Descriptions
+
+### Use imperative phrasing
+
+Frame as an instruction to the agent: "Use this skill when…" rather than
+"This skill does…" The agent is deciding whether to act, so tell it when to act.
+
+### Focus on user intent, not implementation
+
+Describe what the user is trying to achieve, not the skill's internal mechanics.
+The agent matches against what the user asked for.
+
+### Err on the side of being pushy
+
+Explicitly list contexts where the skill applies, including cases where the user
+doesn't name the domain directly:
+
+```yaml
+description: >
+  Analyze CSV and tabular data files — compute summary statistics, add derived
+  columns, generate charts, and clean messy data. Use this skill when the user
+  has a CSV, TSV, or Excel file and wants to explore, transform, or visualize
+  the data, even if they don't explicitly mention "CSV" or "analysis."
+```
+
+### Keep it concise
+
+A few sentences to a short paragraph. The hard limit is 1024 characters.
+
+---
+
+## Before vs. After Examples
+
+```yaml
+# Before — too vague, won't trigger reliably
+description: Process CSV files.
+
+# After — specific about what it does AND when to use it
+description: >
+  Analyze CSV and tabular data files — compute summary statistics,
+  add derived columns, generate charts, and clean messy data. Use this
+  skill when the user has a CSV, TSV, or Excel file and wants to
+  explore, transform, or visualize the data, even if they don't
+  explicitly mention "CSV" or "analysis."
+```
+
+```yaml
+# Before — generic, doesn't convey scope
+description: Help with code review.
+
+# After — specific domains, clear trigger conditions
+description: >
+  Review Python code for security vulnerabilities, SQL injection risks,
+  authentication gaps, and race conditions. Use when asked to review,
+  audit, or check code quality — especially for backend services handling
+  user data or authentication flows.
+```
+
+```yaml
+# Before — too narrow, misses indirect triggers
+description: Extract text from PDF files.
+
+# After — covers indirect triggers and related tasks
+description: >
+  Extract text, tables, and form fields from PDF documents. Fill PDF forms
+  programmatically. Merge or split PDF files. Use when working with PDF
+  documents, invoices, contracts, scanned forms, or any task involving
+  PDF processing — even if the user says "document" instead of "PDF."
+```
+
+---
+
+## Common Description Failures
+
+### Too narrow — misses indirect phrasing
+The user says "my boss wants a chart from this data file" — the skill's
+description only mentions "CSV analysis." The agent doesn't connect the dots.
+
+**Fix:** Add phrases that cover how users actually ask, not just the technical term.
+
+### Too broad — triggers on irrelevant tasks
+A database query skill triggers when the user asks to "write a Python script
+that reads a CSV and uploads rows to Postgres" — not what the skill is for.
+
+**Fix:** Add specificity about what the skill does *not* do, or clarify boundaries.
+
+### Implementation focus instead of user intent
+"Uses pdfplumber to extract text via AST parsing" — the agent doesn't match
+this against "I need to pull the numbers from this invoice."
+
+**Fix:** Describe what the user is trying to accomplish, not how the skill works.
+
+### Missing trigger keywords
+A skill for working with Kubernetes has no mention of "k8s", "pods",
+"deployments", or "kubectl" — only "container orchestration."
+
+**Fix:** Include the vocabulary users actually use, including abbreviations and
+informal terms.
+
+---
+
+## Evaluating Description Quality
+
+When optimizing a description, consider these test queries mentally:
+
+**Should trigger:**
+- A casual phrasing that describes the need without naming the domain
+  ("my boss wants a chart from this data file")
+- A terse prompt with the domain term ("analyze my sales CSV")
+- A context-heavy prompt with file paths and column names
+- A multi-step request where the skill is only one part
+
+**Should NOT trigger (near-misses):**
+- Queries that share keywords but need something different
+  ("write a Python script that reads a CSV and uploads rows to Postgres"
+  should not trigger a CSV *analysis* skill)
+- General queries that the agent can handle alone
+  ("what's the weather today?")
+
+---
+
+## The Optimization Loop
+
+When a description isn't working:
+
+1. **If should-trigger queries are failing** — the description is too narrow.
+   Broaden scope or add context about when the skill is useful.
+
+2. **If should-not-trigger queries are false-triggering** — the description is
+   too broad. Add specificity about what the skill does *not* do.
+
+3. **Avoid keyword overfitting** — don't add the exact keywords from failed queries.
+   Find the general category those queries represent and address that.
+
+4. **Try structural changes** if incremental tweaks aren't working. A different
+   framing may break through where refinement can't.
+
+5. **Check the 1024-character limit** — descriptions tend to grow during
+   optimization. Trim if needed.
+
+---
+
+## Applying the Result
+
+1. Update the `description` field in `SKILL.md` frontmatter
+2. Verify it's under 1024 characters
+3. Verify `name` is still accurate (update if the skill's scope changed)
+4. The description should answer: "If an agent sees only this one sentence/paragraph,
+   would it know exactly when to reach for this skill?"

--- a/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/knowledge/04-snippet-optimization.md
+++ b/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/knowledge/04-snippet-optimization.md
@@ -1,0 +1,203 @@
+# Optimizing Snippets
+
+Snippets in the SkillBerry Store are **read-only textual reference material** — the
+SKILL.md body, documentation files, schemas, templates, and any non-Python file in
+the skill directory. Agents load them to understand context, follow procedures, or
+look up reference data.
+
+A snippet is well-optimized when an agent reads it and gets exactly the information
+it needs — no more, no less — to act correctly on the first attempt.
+
+---
+
+## Diagnose Before You Edit
+
+The most common optimization mistake is editing text based on what *looks* wrong,
+rather than what actually *causes failures*.
+
+Before changing anything, ask:
+
+1. **What task was the agent trying to do?**
+2. **At which step did behavior diverge from intent?**
+3. **Was the failure caused by missing information, ambiguous information, or
+   information the agent ignored?**
+
+These are three different problems requiring three different fixes:
+
+| Failure cause | Fix |
+|---|---|
+| Missing information | Add the specific fact, example, or constraint that was absent |
+| Ambiguous information | Replace the vague phrase with a concrete, specific one |
+| Information ignored | Move the critical point earlier; restructure so it can't be skipped |
+
+Editing text without diagnosing the failure often produces longer snippets that
+still fail for the same underlying reason.
+
+---
+
+## Signals a Snippet Needs Work
+
+A snippet is underperforming when execution traces show:
+
+- The agent tried multiple approaches before finding one that works (instructions
+  are vague — the agent is searching)
+- The agent followed the instructions literally but produced a wrong result (the
+  instructions describe the wrong thing)
+- The agent skipped steps in a multi-step procedure (the structure doesn't convey
+  dependencies clearly enough)
+- The agent made a mistake you had to correct, and the correction isn't in the
+  snippet yet
+- The same edge case fails repeatedly across different runs (a known gotcha is
+  undocumented)
+
+---
+
+## Targeted Mutations
+
+When you've diagnosed the problem, apply the smallest change that fixes it.
+
+### From generic to specific
+
+Vague instructions cause the agent to improvise. Replace them with concrete,
+domain-specific guidance.
+
+**Before:**
+```
+Handle errors appropriately and return a useful message.
+```
+
+**After:**
+```
+If the API returns 429, wait 2 seconds and retry once. If it returns 5xx,
+raise ValueError("service unavailable"). Do not expose raw HTTP status codes
+in the error message.
+```
+
+### From description to example
+
+When the intended output format or behavior is hard to describe, show it:
+
+**Before:**
+```
+Format the result as a summary with key findings.
+```
+
+**After:**
+```
+Format the result as:
+
+## Summary
+[One sentence describing overall outcome]
+
+## Key findings
+- Finding 1: [specific data point]
+- Finding 2: [specific data point]
+```
+
+### From implied to explicit
+
+Don't assume the agent will infer constraints. State them:
+
+**Before:**
+```
+Query the database for recent orders.
+```
+
+**After:**
+```
+Query the `orders` table. Always include `WHERE deleted_at IS NULL` — the
+table uses soft deletes and omitting this filter returns deactivated records.
+Limit to the last 90 days unless the user specifies otherwise.
+```
+
+### From one long block to layered disclosure
+
+If a snippet is long, the agent may read the beginning and skip the rest. Structure
+so that critical information comes first and reference material comes later:
+
+```markdown
+## Quick reference
+[3-5 lines covering the most common case — agent can stop here for simple tasks]
+
+## Full specification
+[Detailed rules and edge cases — agent reads this when the quick reference isn't enough]
+
+## Error reference
+[What specific errors mean and how to resolve them]
+```
+
+---
+
+## Gotchas: The Highest-Value Content
+
+The most impactful content in any snippet is a list of things the agent will get
+wrong without being told. These are not general best practices — they are specific
+corrections that real execution failures have surfaced.
+
+Good gotchas are:
+- **Concrete**: name the specific field, endpoint, value, or behavior
+- **Actionable**: tell the agent what to do, not just what not to do
+- **Short**: one or two lines each; a list of five sharp gotchas beats a paragraph
+  of caveats
+
+**Example gotchas section:**
+```markdown
+## Gotchas
+
+- The API returns `200 OK` even for validation failures — always check
+  `response.json()["status"]`, not the HTTP status code.
+- `user_id` in this API is a string UUID, not an integer. Passing an int
+  causes a silent 400 with no error message.
+- The `created_at` field is in Unix milliseconds, not seconds. Divide by
+  1000 before passing to `datetime.fromtimestamp()`.
+```
+
+When an execution trace reveals a mistake, add the correction to the gotchas
+section immediately. Do not wait for a second failure.
+
+---
+
+## What to Remove
+
+Snippets accumulate content over time. Remove content that:
+
+- Explains concepts the agent already knows from training (what JSON is, how
+  HTTP works, what a primary key does)
+- Repeats information already stated elsewhere in the skill
+- Covers edge cases that never occur in practice
+- Uses vague filler language ("make sure to", "be careful to", "try to") —
+  replace with a specific instruction or remove entirely
+
+A shorter snippet that covers only what the agent lacks is more effective than
+a comprehensive one the agent will skim.
+
+---
+
+## Templates as Snippets
+
+When the skill requires the agent to produce output in a specific format, a
+template snippet is more reliable than a prose description of the format.
+
+Store the template in a separate file (e.g., `assets/report-template.md`) and
+reference it conditionally in SKILL.md:
+
+```markdown
+When producing a report, use the template in `assets/report-template.md`.
+Load it only when the task requires a formatted report output.
+```
+
+This keeps SKILL.md lean while making the template available on demand.
+
+---
+
+## Checklist Before Finalising a Snippet
+
+- [ ] Does every instruction say *what to do*, not just *what to consider*?
+- [ ] Is each gotcha concrete enough that the agent couldn't misinterpret it?
+- [ ] Does the structure put the most-needed information first?
+- [ ] Have you removed content the agent already knows from training?
+- [ ] If there's an example, does it match the actual expected format exactly?
+- [ ] If there's a multi-step procedure, are the steps numbered with explicit
+      dependencies noted?
+- [ ] Is the snippet under 300 lines? If not, does the excess belong in a
+      separate reference file?

--- a/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/knowledge/05-tool-optimization.md
+++ b/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/knowledge/05-tool-optimization.md
@@ -1,0 +1,270 @@
+# Optimizing Tools
+
+Tools in the SkillBerry Store are Python functions. Every top-level `def` in a
+`.py` file becomes a callable tool. Quality has three independent dimensions —
+**correctness**, **discoverability**, and **usability** — and a tool that scores
+poorly on any one of them underperforms even if the others are excellent.
+
+---
+
+## Three Quality Dimensions
+
+### 1. Correctness
+The function does what it says it does. It handles edge cases, validates inputs,
+and fails loudly with informative errors rather than silently returning wrong results.
+
+### 2. Discoverability (docstring clarity)
+An agent reading only the function name and docstring can determine whether this
+is the right tool for a task. Poor discoverability means agents call the wrong tool
+or miss the tool entirely.
+
+### 3. Usability (parameter documentation)
+An agent can call the function correctly on the first attempt without guessing
+parameter types, formats, or constraints. Poor parameter documentation means
+agents pass wrong types, out-of-range values, or missing required fields.
+
+Treat all three as separate problems. A function with excellent logic but a vague
+docstring is not a good tool.
+
+---
+
+## Diagnosing Which Dimension Fails
+
+Before editing, identify which dimension is actually broken:
+
+| Symptom in execution traces | Dimension | Fix |
+|---|---|---|
+| Agent calls a different tool for a task this one handles | Discoverability | Rewrite the docstring description |
+| Agent calls this tool but with wrong arguments | Usability | Improve parameter documentation |
+| Agent calls tool correctly but result is wrong | Correctness | Fix the logic |
+| Agent tries tool, gets an exception, gives up | All three | Improve error messages AND parameter docs |
+| Tool works for common case but fails on edge inputs | Correctness | Add validation and edge-case handling |
+
+---
+
+## Correctness
+
+### Input validation
+Validate at the boundary. Don't assume callers provide clean inputs.
+
+```python
+def calculate_discount(price: float, discount_pct: float) -> float:
+    """..."""
+    if price < 0:
+        raise ValueError(f"price must be non-negative, got {price}")
+    if not 0 <= discount_pct <= 100:
+        raise ValueError(f"discount_pct must be 0-100, got {discount_pct}")
+    return price * (1 - discount_pct / 100)
+```
+
+### Informative error messages
+Error messages are part of the tool's interface. Agents read them when a call
+fails. A good error message tells the agent exactly what was wrong and what to
+provide instead.
+
+**Poor:**
+```python
+raise ValueError("invalid input")
+```
+
+**Good:**
+```python
+raise ValueError(
+    f"status must be one of ['active', 'inactive', 'pending'], got {status!r}"
+)
+```
+
+### Self-contained code
+Every `.py` file executes as a flat script. Cross-file imports **do not work**:
+
+```python
+# FORBIDDEN — causes "No module named 'scripts'" at runtime
+from scripts.utils import call_api
+import scripts.helpers
+```
+
+Use only stdlib imports. Runtime helpers provided by the store (e.g. `call_api`,
+`store_result`) are injected into scope automatically — call them directly without
+importing.
+
+### Simple, serialisable types
+All parameters and return values must be simple JSON-serialisable types. The store
+cannot pass complex objects between tools.
+
+| Use | Avoid |
+|---|---|
+| `str`, `int`, `float`, `bool` | `datetime`, `Path`, custom objects |
+| `list[str]`, `dict[str, int]` | `pd.DataFrame`, `np.ndarray` |
+| `Optional[str]` | `Any`, bare `Dict`, bare `List` |
+
+If you need to work with complex types internally, convert at the boundary:
+```python
+def analyse_data(rows: list[dict]) -> dict:
+    """..."""
+    import json
+    # work internally however you like
+    return {"result": "..."}
+```
+
+### Security
+Never introduce:
+- `eval()`, `exec()`, `__import__()`
+- `os.system()`, `subprocess.run()` with user-controlled strings
+- `pickle.loads()`, `yaml.load()` (use `yaml.safe_load()`)
+- Hardcoded credentials, API keys, passwords, tokens
+
+---
+
+## Discoverability
+
+The docstring's **first line** (the one-line summary) is the primary signal agents
+use to decide whether to call a tool. It must:
+
+- State what the function **does**, not how it works
+- Use action verbs: "Fetch", "Calculate", "Extract", "Convert", "Validate"
+- Include the domain nouns that appear in user requests: "invoice", "order",
+  "customer", "repository"
+- Be specific enough to distinguish this tool from similar ones
+
+**Poor (too vague):**
+```python
+def process_data(data: dict) -> dict:
+    """Process the input data."""
+```
+
+**Poor (describes implementation):**
+```python
+def get_discount(price: float, pct: float) -> float:
+    """Apply percentage-based reduction using multiplication."""
+```
+
+**Good:**
+```python
+def calculate_order_discount(order_total: float, discount_pct: float) -> float:
+    """Calculate the final price after applying a percentage discount to an order total."""
+```
+
+When optimizing discoverability, ask: "If an agent sees only this one line, would
+it know exactly when to reach for this tool?" If the answer is no, rewrite it.
+
+---
+
+## Usability — Parameter Documentation
+
+Each parameter needs enough documentation that an agent can call the tool correctly
+without guessing.
+
+### Required per parameter
+
+1. **Type** — in the function signature AND in the docstring
+2. **What it is** — brief description (one line)
+3. **Constraints** — range, format, allowed values, or units if relevant
+4. **Default behaviour** — what happens if optional and omitted
+
+### Google-style docstring format
+
+```python
+def fetch_orders(
+    customer_id: str,
+    status: str = "active",
+    limit: int = 50,
+) -> list[dict]:
+    """Fetch orders for a customer, filtered by status.
+
+    Args:
+        customer_id: UUID string identifying the customer. Must be a valid UUID v4.
+        status: Filter orders by status. One of: 'active', 'completed', 'cancelled'.
+            Defaults to 'active'.
+        limit: Maximum number of orders to return. Must be 1-200. Defaults to 50.
+
+    Returns:
+        List of order dicts, each with keys: id, status, total, created_at.
+
+    Raises:
+        ValueError: If customer_id is not a valid UUID or status is not recognised.
+        RuntimeError: If the orders service is unreachable.
+    """
+```
+
+### Use Literal types for fixed value sets
+
+When a parameter accepts only specific values, declare them explicitly:
+
+```python
+from typing import Literal
+
+def set_order_status(
+    order_id: str,
+    status: Literal["active", "completed", "cancelled"],
+) -> bool:
+    """Update the status of an order."""
+```
+
+This lets agents pass the correct value on the first attempt without guessing.
+
+### Return value documentation
+
+Document what the return value contains. If it's a dict, list the keys:
+
+```python
+Returns:
+    Dict with keys:
+        - 'success' (bool): Whether the operation completed.
+        - 'id' (str): The new record's UUID.
+        - 'errors' (list[str]): Validation errors, empty if success is True.
+```
+
+---
+
+## When to Split vs. Consolidate Functions
+
+**Split** a function when:
+- It does two distinct things that agents might need independently
+- The docstring requires "and" to describe what it does
+- Different callers need only part of its behaviour
+
+**Consolidate** functions when:
+- Two functions always get called together
+- One function is only ever a helper for another (and can't be a cross-file import)
+- Two functions have nearly identical signatures and logic
+
+When optimizing, err toward splitting. A tool with a narrow, clear purpose is
+more likely to be called correctly than one that does multiple things.
+
+---
+
+## Naming
+
+Function names become tool names in the store. They must be:
+
+- **Verb-first**: `calculate_`, `fetch_`, `extract_`, `validate_`, `convert_`
+- **Domain-specific**: include the entity the function acts on (`order`, `invoice`, `user`)
+- **Distinguishable**: if the skill has `get_order` and `get_invoice`, the names must
+  make the difference immediately obvious
+- **Snake_case** only
+
+**Poor names:** `process`, `handle`, `do_thing`, `run`, `execute`
+**Good names:** `calculate_invoice_total`, `fetch_customer_orders`, `validate_iban`
+
+---
+
+## Checklist Before Finalising a Tool
+
+**Correctness:**
+- [ ] All parameters validated with informative error messages
+- [ ] Edge cases handled (empty input, None, out-of-range values)
+- [ ] No cross-file imports (`from scripts.x import y`)
+- [ ] No `eval`, `exec`, hardcoded credentials, or unsafe calls
+- [ ] All types are simple and JSON-serialisable
+
+**Discoverability:**
+- [ ] First docstring line uses an action verb and names the domain entity
+- [ ] One-line summary distinguishes this tool from similar ones in the skill
+- [ ] Name is verb-first and domain-specific
+
+**Usability:**
+- [ ] Every parameter has type annotation in signature AND docstring
+- [ ] Constraints documented (range, format, allowed values)
+- [ ] Return value documents its structure if it's a dict or list
+- [ ] `Literal[...]` used for parameters with a fixed set of allowed values
+- [ ] Exceptions documented with the conditions that trigger them

--- a/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/knowledge/06-trajectory-based-optimization.md
+++ b/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/knowledge/06-trajectory-based-optimization.md
@@ -1,0 +1,283 @@
+# Trajectory-Based Skill Optimization
+
+When execution trajectories are provided in `context/trajectories/`, they are your
+most valuable optimization signal. Trajectories show exactly what happened when an
+agent used this skill in production — which tools were called, in what order, with
+what arguments, and whether the task succeeded or failed.
+
+**Use trajectories as ground truth.** Don't speculate about what might go wrong;
+read what actually went wrong.
+
+---
+
+## What a Trajectory Contains
+
+Each trajectory is a complete record of one agent session. It contains:
+
+- **Messages**: the turn-by-turn conversation — user requests, assistant responses,
+  tool calls, tool results, and system messages
+- **Tool calls**: every tool invoked, with the exact arguments passed
+- **Tool results**: what each tool returned (or what error it raised)
+- **Reward / outcome**: a score (0.0–1.0) or pass/fail indicating whether the
+  agent achieved the goal. Higher reward = better outcome.
+- **Metadata**: optional context such as task domain, task ID, or timestamps
+
+When a trajectory has a reward field, treat it as your primary signal:
+- `reward ≥ 0.8` — successful run; study what made it work
+- `reward ≤ 0.3` — failed run; diagnose the root cause
+- `0.3 < reward < 0.8` — partial success; identify what was achieved vs. missed
+
+---
+
+## Reading a Single Trajectory
+
+Before analysing patterns across many trajectories, understand each one fully.
+For every trajectory, determine:
+
+**1. What was the agent trying to do?**
+Read the user's initial message and any goal statement.
+
+**2. Did it succeed?**
+Check the reward score, the final assistant message, or any explicit outcome marker.
+
+**3. Where did things go wrong (or right)?**
+Step through the tool calls in order:
+- Which tools were called and in what sequence?
+- Were the arguments correct and complete?
+- Did any tool return an error? What was the error message?
+- Did the agent recover from errors or give up?
+- Were there unnecessary or redundant tool calls?
+- Was anything called in the wrong order?
+
+**4. What specific message IDs mark the key moments?**
+Note the message where the failure began, the message where a recovery happened,
+or the message that produced the decisive correct result. These are your evidence
+anchors for targeted edits.
+
+---
+
+## Evaluating Trajectories Across Seven Dimensions
+
+Not all failures are equal. For each trajectory, score these dimensions:
+
+| Dimension | Question | What 0 looks like | What 1 looks like |
+|---|---|---|---|
+| **Task success** | Did the agent complete the goal? | Gave up or wrong outcome | Fully achieved the user's goal |
+| **Tool selection** | Did the agent pick the right tools? | Used wrong tools, missed the right ones | Always chose the correct tool for each step |
+| **Parameter quality** | Were tool arguments correct? | Fabricated parameters, wrong types, out-of-range values | All arguments valid and appropriate |
+| **Plan efficiency** | Were steps minimal and direct? | Many redundant or circular calls | Reached the goal in the fewest reasonable steps |
+| **Policy compliance** | Were constraints and rules followed? | Violated stated policies | Fully respected all policies |
+| **Error recovery** | How were errors handled? | Gave up on first error | Diagnosed errors and recovered gracefully |
+| **Task complexity** | How hard was this task? | Trivial one-step task | Multi-step task requiring judgment |
+
+This framework helps you identify *which dimension* to fix. A skill with poor tool
+selection needs different changes than one with poor parameter quality.
+
+---
+
+## Handling Large Numbers of Trajectories
+
+When dozens or hundreds of trajectories are provided, reading every one in detail
+is impractical. Use a structured approach:
+
+### Step 1: Stratify by outcome
+
+Split trajectories into three groups:
+- **High-reward** (≥ 0.8): the skill working as intended
+- **Low-reward** (≤ 0.3): clear failures to analyse
+- **Mid-range** (0.3–0.8): partial successes (lower priority, address after
+  high and low groups)
+
+Start with low-reward trajectories — they contain the most actionable signal.
+
+### Step 2: Sample representatively
+
+You don't need to read every failure. Sample:
+- **5–10 low-reward trajectories** spanning different task types if available
+- **3–5 high-reward trajectories** to understand what to preserve
+- **2–3 mid-range trajectories** to understand partial failure modes
+
+If trajectories look similar (same tool sequence, same failure point), 3 is
+enough — you've already found the pattern.
+
+### Step 3: Cluster failures by root cause
+
+As you read failures, group them by what actually went wrong, not just by
+which tool failed. Common root cause clusters:
+
+| Cluster | Signature |
+|---|---|
+| **Wrong tool selected** | Agent calls tool A when tool B was clearly appropriate |
+| **Bad parameters** | Correct tool called, but with invalid/missing/wrong arguments |
+| **Missing tool** | Agent improvises a multi-step workaround for something a single tool should do |
+| **Wrong sequence** | Tools called in wrong order; result of step N needed before step N-1 |
+| **Policy violation** | Agent does something explicitly prohibited |
+| **Error not recovered** | First tool error causes agent to abandon the task |
+| **Redundant calls** | Same tool called multiple times with same arguments; extra round-trips |
+
+Once you've identified which clusters appear and how often, prioritise by:
+- **Frequency × severity**: a failure that occurs in 30% of runs and causes total
+  task failure is more important than one that occurs once and costs one extra tool call
+
+### Step 4: Verify a finding appears across multiple trajectories
+
+Before changing anything, confirm that a pattern you see in one trajectory appears
+in at least two or three others. Single-trajectory observations may be task-specific
+edge cases rather than systematic skill deficiencies.
+
+**Exception**: a single high-severity failure (policy violation, data corruption,
+security risk) warrants a fix even if it appears once.
+
+---
+
+## What to Preserve (from High-Reward Trajectories)
+
+Identify patterns that consistently produce successful outcomes:
+
+**Tool sequences that work**
+If high-reward runs consistently use a specific tool order (e.g., always validate
+before booking, always fetch schema before querying), document that order as an
+explicit workflow example or checklist in SKILL.md.
+
+**Parameter patterns that work**
+If successful runs consistently pass a parameter in a specific format or within a
+specific range, add that as a concrete example in the tool's docstring.
+
+**Recovery strategies that work**
+If high-reward runs show the agent retrying with adjusted arguments after a tool
+error, document the retry pattern explicitly — don't assume agents will infer it.
+
+**Guardrails that prevented failures**
+If a tool consistently returns a clear error when misused, and high-reward runs
+respect that, preserve the tool's validation logic and error messages — they are
+doing useful work.
+
+---
+
+## What to Fix (from Low-Reward Trajectories)
+
+### Tool selection failures → fix discoverability
+
+If the agent repeatedly picks the wrong tool, the right tool's description is
+failing. The agent doesn't recognise it as relevant to the task.
+
+Rewrite the docstring's first line to match the vocabulary and intent of failed
+requests. See `05-tool-optimization.md` for discoverability principles.
+
+### Parameter failures → fix usability
+
+If the agent calls the right tool but passes wrong arguments:
+- **Wrong type**: add explicit type annotations and docstring type constraints
+- **Out-of-range value**: add range constraints in the docstring and input validation in code
+- **Missing required field**: mark as non-optional and document in docstring
+- **Fabricated parameter name**: add `Literal[...]` type for fixed-value sets; list
+  all valid values explicitly in the docstring
+
+### Missing tool → consider a new composite tool
+
+If agents repeatedly string together 3–4 steps to accomplish what should be a
+single atomic operation, this is a signal that a composite tool is missing. Define
+a new function that wraps the common pattern.
+
+Only add a new tool if the pattern appears across multiple trajectories. Don't
+create tools for one-off task variants.
+
+### Wrong sequence → add a workflow snippet
+
+If agents consistently call tools in the wrong order, add an explicit workflow to
+SKILL.md:
+
+```markdown
+## Order processing workflow
+
+Always follow this sequence — steps have dependencies:
+1. `validate_order(order_id)` — must pass before any state changes
+2. `reserve_inventory(items)` — locks stock
+3. `charge_payment(amount)` — only after inventory confirmed
+4. `confirm_order(order_id)` — only after payment succeeds
+
+Do NOT call `charge_payment` before `reserve_inventory` — this causes inventory
+conflicts on concurrent orders.
+```
+
+### Policy violations → add a guardrail snippet
+
+If agents violate policies, the policy is either absent from the skill or buried
+where it won't be seen. Move it to a prominent position in SKILL.md with an
+explicit "never do X" statement.
+
+Example:
+```markdown
+## Policy constraints (read before any tool call)
+
+- NEVER cancel a confirmed order without explicit user confirmation
+- NEVER expose customer PII in tool arguments or response text
+- NEVER issue a refund above the original order total
+```
+
+### Error not recovered → improve error handling guidance
+
+If agents give up on first error, add explicit recovery instructions:
+
+```markdown
+If `reserve_inventory` returns InsufficientStockError:
+1. Call `check_alternatives(item_id)` to find substitute items
+2. Present alternatives to the user before abandoning
+Do NOT immediately return an error to the user.
+```
+
+### Redundant calls → add an efficiency note
+
+If agents call the same tool multiple times with the same arguments, cache the
+result and reference it:
+
+```markdown
+Fetch the customer record once at the start of the session and reuse it.
+Do not call `get_customer()` more than once per conversation.
+```
+
+---
+
+## Translating Trajectory Findings into Skill Changes
+
+| Finding | Where to apply the fix |
+|---|---|
+| Wrong tool selected | Rewrite tool function docstring first line |
+| Agent misuses a parameter | Add constraint to docstring + input validation in code |
+| Missing composite tool | Add new Python function in a `.py` file |
+| Steps in wrong order | Add numbered workflow checklist to SKILL.md |
+| Policy violated | Add prominent policy section to SKILL.md |
+| Error handling absent | Add recovery instructions to SKILL.md or tool docstring |
+| Redundant tool calls | Add efficiency guidance to SKILL.md |
+| Successful pattern lost | Add workflow example or gotcha to SKILL.md |
+
+---
+
+## Prioritising Across Many Findings
+
+After analysing a batch of trajectories, you will have more findings than you
+can address in one pass. Prioritise by:
+
+1. **High-frequency failures**: patterns that appear in ≥ 20% of runs
+2. **Total task failures**: failures where `reward = 0.0` (not just degraded)
+3. **High generality**: failures that occur across many different task types,
+   not just one specific scenario
+4. **Low fix complexity**: changes that are a one-line docstring update vs. a
+   full new tool (quick wins first)
+5. **Policy and security violations**: always fix regardless of frequency
+
+Defer low-frequency, case-specific, complex findings — they are edge cases that
+may not recur.
+
+---
+
+## Checklist Before Finishing Trajectory-Based Optimization
+
+- [ ] Identified which reward-group (high/low/mid) each trajectory belongs to
+- [ ] Sampled at least 5 low-reward and 3 high-reward trajectories
+- [ ] Clustered failures by root cause (not just by which tool failed)
+- [ ] Verified each finding appears in ≥ 2 trajectories (or is high-severity)
+- [ ] Documented at least one successful pattern worth preserving
+- [ ] Applied fixes to the highest-frequency, highest-severity failures
+- [ ] Did not add tools or snippets based on a single-trajectory observation
+- [ ] `required_outputs.json` lists each trajectory-informed change with its rationale

--- a/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/plugin.py
+++ b/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/plugin.py
@@ -1,0 +1,1 @@
+"""Skill Optimizer plugin stub — full implementation in later tasks."""

--- a/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/plugin.py
+++ b/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/plugin.py
@@ -431,6 +431,12 @@ class SkillberryPluginSkillOptimizer(PluginBase):
             if additional_context_dir:
                 shutil.copytree(additional_context_dir, str(context_dir / "additional_context"))
 
+            # Always stage the bundled knowledge base into context/knowledge/
+            knowledge_src = Path(__file__).parent / "knowledge"
+            if knowledge_src.exists():
+                shutil.copytree(str(knowledge_src), str(context_dir / "knowledge"))
+                logger.info(f"Staged knowledge base ({len(list(knowledge_src.iterdir()))} files) into context/knowledge/")
+
             prompt = build_runspace_prompt(
                 has_metadata=include_metadata,
                 has_trajectories=bool(trajectories_dir),

--- a/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/plugin.py
+++ b/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/plugin.py
@@ -1,1 +1,7 @@
 """Skill Optimizer plugin stub — full implementation in later tasks."""
+
+
+class SkillberryPluginSkillOptimizer:
+    """Stub for Skill Optimizer plugin. Full implementation in Task 3."""
+
+    pass

--- a/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/plugin.py
+++ b/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/plugin.py
@@ -204,9 +204,15 @@ class SkillberryPluginSkillOptimizer(PluginBase):
                 if container:
                     break
             if not container:
+                logger.debug("  [container] container not found within timeout")
                 return
             cid = container.short_id
-            logger.info(f"  [container:{cid}] Attaching to container logs...")
+            logger.info(
+                f"  [container] id={container.id}  short={cid}  workspace={workspace_root}\n"
+                f"  [container] Live inspect: docker exec {cid} ls /workspace/agent_workspace/editable\n"
+                f"  [container] NOTE: Claude runs in-memory — docker logs will be sparse until the "
+                f"run completes, then conversation.json is written to {workspace_root}"
+            )
             for chunk in container.logs(stream=True, follow=True, stderr=True, stdout=True):
                 if stop.is_set():
                     break
@@ -218,9 +224,63 @@ class SkillberryPluginSkillOptimizer(PluginBase):
         except Exception as e:
             logger.debug(f"Docker log streaming ended: {e}")
 
+    def _replay_conversation(self, conv_path: Path) -> None:
+        """Parse conversation.json and emit a full verbose log of every agent step."""
+        try:
+            conv = json.loads(conv_path.read_text(encoding="utf-8"))
+            if not isinstance(conv, list):
+                return
+            logger.info(f"  [replay] conversation.json ready — {len(conv)} messages:")
+            for msg in conv:
+                msg_type = msg.get("type", "")
+                data = msg.get("data", msg)
+                if msg_type == "assistant":
+                    for block in (data.get("content") or []):
+                        if not isinstance(block, dict):
+                            continue
+                        if block.get("type") == "text":
+                            text = block["text"].strip()
+                            if text:
+                                logger.info(f"  [agent] {text}")
+                        elif block.get("type") == "tool_use":
+                            tool_name = block.get("name", "?")
+                            inp = block.get("input", {})
+                            if "command" in inp:
+                                detail = inp["command"]
+                            elif "file_path" in inp or "path" in inp:
+                                fpath = inp.get("file_path") or inp.get("path", "")
+                                content_len = len(str(inp.get("content", "")))
+                                detail = f"{fpath} ({content_len} chars)" if "content" in inp else fpath
+                            else:
+                                detail = json.dumps(inp, ensure_ascii=False)[:300]
+                            logger.info(f"  [tool:{tool_name}] {detail}")
+                elif msg_type == "tool":
+                    content = data.get("content", "")
+                    if isinstance(content, list):
+                        for item in content:
+                            if isinstance(item, dict) and item.get("type") == "text":
+                                logger.info(f"  [result] {item['text'][:400]}")
+                    elif content:
+                        logger.info(f"  [result] {str(content)[:400]}")
+                elif msg_type == "result":
+                    turns = data.get("num_turns", "?")
+                    cost = data.get("total_cost_usd")
+                    usage = data.get("usage", {})
+                    out_tok = usage.get("output_tokens", "?")
+                    cache_r = usage.get("cache_read_input_tokens", 0)
+                    cost_str = f" ${cost:.4f}" if cost is not None else ""
+                    logger.info(
+                        f"  [done] {turns} turns, {out_tok} output tokens"
+                        f", {cache_r} cache-read tokens{cost_str}"
+                    )
+        except Exception as e:
+            logger.debug(f"Could not replay conversation from {conv_path}: {e}")
+
     async def _stream_progress(self, mode: str, workspace_root: Path, run_task: "asyncio.Task") -> None:
         editable = workspace_root / "agent_workspace" / "editable"
+        conv_path = workspace_root / "conversation.json"
         seen: set = set()
+        conv_replayed = False
         stop = threading.Event()
         if mode == "container":
             t = threading.Thread(
@@ -230,57 +290,32 @@ class SkillberryPluginSkillOptimizer(PluginBase):
         try:
             while not run_task.done():
                 await asyncio.sleep(5)
-                if not editable.exists():
-                    continue
-                current = {str(p) for p in editable.rglob("*") if p.is_file()}
-                for f in sorted(current - seen):
-                    logger.info(f"  [progress] created: {Path(f).relative_to(editable)}")
-                seen = current
+                # Poll editable/ for new files the agent is writing
+                if editable.exists():
+                    current = {str(p) for p in editable.rglob("*") if p.is_file()}
+                    for f in sorted(current - seen):
+                        logger.info(f"  [progress] created: {Path(f).relative_to(editable)}")
+                    seen = current
+                # conversation.json is written to the shared workspace volume just before
+                # the container/process exits — replay it immediately when it appears
+                if not conv_replayed and conv_path.exists():
+                    conv_replayed = True
+                    self._replay_conversation(conv_path)
         finally:
             stop.set()
 
     def _log_session_details(self, session_id: str) -> None:
+        """Log session summary and (if not already replayed during streaming) conversation."""
         try:
             workspace = session_workspace(session_id)
             summary_path = workspace / "summary.md"
             if summary_path.exists():
                 logger.info(f"Session summary:\n{summary_path.read_text(encoding='utf-8').strip()}")
+            # conversation.json is replayed live in _stream_progress when it first appears;
+            # replay again here only if the file wasn't caught during polling (e.g. very fast runs)
             conv_path = workspace / "conversation.json"
-            if not conv_path.exists():
-                return
-            conv = json.loads(conv_path.read_text(encoding="utf-8"))
-            if not isinstance(conv, list):
-                return
-            logger.info(f"Agent conversation replay ({len(conv)} messages):")
-            for msg in conv:
-                t = msg.get("type", "")
-                data = msg.get("data", msg)
-                if t == "assistant":
-                    for block in (data.get("content") or []):
-                        if not isinstance(block, dict):
-                            continue
-                        if block.get("type") == "text":
-                            text = block["text"].strip().replace("\n", " ")
-                            if text:
-                                logger.info(f"  [agent] {text[:200]}")
-                        elif block.get("type") == "tool_use":
-                            inp = block.get("input", {})
-                            detail = (
-                                inp.get("command") or inp.get("file_path")
-                                or inp.get("path") or str(inp)[:80]
-                            )
-                            logger.info(f"  [tool]  {block['name']}: {str(detail)[:120]}")
-                elif t == "result":
-                    turns = data.get("num_turns", "?")
-                    cost = data.get("total_cost_usd")
-                    usage = data.get("usage", {})
-                    out_tok = usage.get("output_tokens", "?")
-                    cache_r = usage.get("cache_read_input_tokens", 0)
-                    cost_str = f" ${cost:.4f}" if cost is not None else ""
-                    logger.info(
-                        f"  [done]  {turns} turns, {out_tok} output tokens"
-                        f", {cache_r} cache-read tokens{cost_str}"
-                    )
+            if conv_path.exists():
+                self._replay_conversation(conv_path)
         except Exception as e:
             logger.debug(f"Could not read session details for {session_id}: {e}")
 

--- a/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/plugin.py
+++ b/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/plugin.py
@@ -286,7 +286,7 @@ class SkillberryPluginSkillOptimizer(PluginBase):
 
     def _generate_output_skill_name(self, original_name: str, override: Optional[str] = None) -> str:
         """Generate the output skill name, appending numeric suffix if needed."""
-        if override:
+        if override is not None:
             return override
         existing_names = {s["name"] for s in self.store.list_skills()}
         base = f"{original_name}_optimized"
@@ -311,8 +311,16 @@ class SkillberryPluginSkillOptimizer(PluginBase):
         """Optimize an existing skill and import the result as a new skill."""
         if not self._runspace_available:
             raise RuntimeError("runspace-agent not available")
+        if export_skill_to_directory is None:
+            raise RuntimeError("skillberry_store exporter not available")
+        if import_from_anthropic_skill is None:
+            raise RuntimeError("skillberry_store importer not available")
         if self._store_api is None:
             raise RuntimeError("Store API not available")
+        if not self._credentials_configured and not agent_env:
+            raise RuntimeError(
+                "Anthropic credentials not configured. Set ANTHROPIC_API_KEY or provide agent_env"
+            )
 
         skill = self.store.get_skill(skill_uuid)
         if skill is None:
@@ -481,6 +489,7 @@ class SkillberryPluginSkillOptimizer(PluginBase):
                     "name": final_name,
                     "description": skill_description,
                     "tool_uuids": tool_uuids,
+                    "snippet_uuids": snippet_uuids,
                     "tags": list({"optimized"} | set(inherited_tags)),
                 }
                 created_skill = self.store.create_skill(skill_data)

--- a/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/plugin.py
+++ b/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/plugin.py
@@ -1,7 +1,620 @@
-"""Skill Optimizer plugin stub — full implementation in later tasks."""
+"""
+Skillberry Plugin Skill Optimizer — optimizes existing skills using RunSpace.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import shutil
+import tempfile
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict, Literal, Optional
+
+from skillberry_store.plugins.base import PluginBase, PluginMetadata, PluginType
+from skillberry_plugin_skill_optimizer.prompt import (
+    REQUIRED_OUTPUTS_FILENAME,
+    REQUIRED_OUTPUTS_TEMPLATE,
+    build_runspace_prompt,
+)
+
+logger = logging.getLogger(__name__)
+
+try:
+    import runspace_agent
+    from runspace_agent import RunspaceSession, run_agent
+    from runspace_agent.workspaces import session_workspace
+except ImportError:
+    runspace_agent = None
+    RunspaceSession = None
+    run_agent = None
+    session_workspace = None
+
+try:
+    from skillberry_store.tools.anthropic.importer import import_from_anthropic_skill
+except ImportError:
+    import_from_anthropic_skill = None
+
+try:
+    from skillberry_store.tools.anthropic.exporter import export_skill_to_directory
+except ImportError:
+    export_skill_to_directory = None
 
 
-class SkillberryPluginSkillOptimizer:
-    """Stub for Skill Optimizer plugin. Full implementation in Task 3."""
+async def optimize_skill_session(prompt, skill_dir, context_dir, options, mode, plugin_instance):
+    """Run a RunspaceSession to optimize a skill.
 
-    pass
+    Module-level so tests can patch it without reaching the real runspace layer.
+    Returns the RunspaceSession result (with .session_id attribute).
+    """
+    gen_session_id = uuid.uuid4().hex[:12]
+    workspace_root = session_workspace(gen_session_id)
+
+    session = RunspaceSession(
+        editable_dir=skill_dir,
+        context_dir=context_dir,
+        prompt=prompt,
+        agent_options=options,
+        preinstalled_skills=["skill-creator"],
+        mode=mode,
+    )
+
+    t0 = time.monotonic()
+    run_task = asyncio.create_task(run_agent(session, session_id=gen_session_id))
+    progress_task = asyncio.create_task(
+        plugin_instance._stream_progress(mode, workspace_root, run_task)
+    )
+    try:
+        result = await run_task
+    finally:
+        progress_task.cancel()
+        try:
+            await progress_task
+        except asyncio.CancelledError:
+            pass
+
+    elapsed = time.monotonic() - t0
+    if not result.success:
+        logger.error(
+            f"Agent failed after {elapsed:.1f}s: "
+            f"{result.agent_result.error or 'Unknown error'}"
+        )
+        raise RuntimeError(f"Agent failed: {result.agent_result.error or 'Unknown error'}")
+    logger.info(
+        f"Agent completed successfully in {elapsed:.1f}s "
+        f"(session {result.session_id}, "
+        f"{result.agent_result.total_tokens} tokens"
+        + (f", ${result.agent_result.total_cost_usd:.4f}" if result.agent_result.total_cost_usd else "")
+        + ")"
+    )
+    return result
+
+
+class SkillberryPluginSkillOptimizer(PluginBase):
+    """Plugin for optimizing existing Skillberry skills using RunSpace."""
+
+    def __init__(self):
+        super().__init__()
+
+        self._metadata = PluginMetadata(
+            name="Skill Optimizer",
+            version="0.1.0",
+            description="Optimize existing skills using RunSpace-powered Claude Code",
+            plugin_type=PluginType.OPTIMIZER,
+        )
+
+        self._status_message = "Initializing..."
+        self._runspace_available = False
+        self._credentials_configured = False
+        self._execution_mode = os.getenv("RUNSPACE_MODE", "container")
+        self._claude_settings = None
+
+        self._load_claude_settings()
+
+        if runspace_agent is not None:
+            try:
+                self._runspace_available = True
+                self._credentials_configured = self._check_credentials()
+
+                if self._credentials_configured:
+                    mode_label = f" ({self._execution_mode} mode)"
+                    source = " from ~/.claude/settings.json" if self._claude_settings else ""
+                    self._status_message = f"Ready{mode_label}{source}"
+                else:
+                    self._status_message = (
+                        "Missing credentials: Set ANTHROPIC_API_KEY, "
+                        "configure ~/.claude/settings.json, or provide "
+                        "ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN"
+                    )
+            except Exception as e:
+                self._status_message = f"Configuration error: {str(e)}"
+                logger.error(f"Failed to initialize: {e}", exc_info=True)
+        else:
+            self._status_message = "Missing dependency: runspace-agent not installed"
+
+    def _load_claude_settings(self):
+        settings_path = Path.home() / ".claude" / "settings.json"
+        if settings_path.exists():
+            try:
+                with open(settings_path, "r") as f:
+                    self._claude_settings = json.load(f)
+            except Exception as e:
+                logger.warning(f"Failed to load Claude settings: {e}")
+
+    def _check_credentials(self) -> bool:
+        if os.getenv("ANTHROPIC_API_KEY"):
+            return True
+        if os.getenv("ANTHROPIC_BASE_URL") and os.getenv("ANTHROPIC_AUTH_TOKEN"):
+            return True
+        if self._claude_settings:
+            if self._claude_settings.get("apiKey"):
+                return True
+            if self._claude_settings.get("baseUrl") and self._claude_settings.get("authToken"):
+                return True
+        return False
+
+    def _build_claude_env(self, override_env: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+        env = {}
+        if self._claude_settings:
+            if self._claude_settings.get("apiKey"):
+                env["ANTHROPIC_API_KEY"] = self._claude_settings["apiKey"]
+            if self._claude_settings.get("baseUrl"):
+                env["ANTHROPIC_BASE_URL"] = self._claude_settings["baseUrl"]
+            if self._claude_settings.get("authToken"):
+                env["ANTHROPIC_AUTH_TOKEN"] = self._claude_settings["authToken"]
+            if self._claude_settings.get("model"):
+                env["ANTHROPIC_MODEL"] = self._claude_settings["model"]
+        for var in ("ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_MODEL"):
+            val = os.getenv(var)
+            if val:
+                env[var] = val
+        if override_env:
+            env.update(override_env)
+        return env
+
+    @property
+    def metadata(self) -> PluginMetadata:
+        return self._metadata
+
+    def get_status_message(self) -> str:
+        return self._status_message
+
+    def is_enabled(self) -> bool:
+        return self._runspace_available and self._credentials_configured
+
+    def _stream_docker_logs(self, workspace_root: Path, stop: threading.Event) -> None:
+        try:
+            import docker
+            client = docker.from_env()
+            container = None
+            for _ in range(60):
+                if stop.is_set():
+                    return
+                time.sleep(0.5)
+                for c in client.containers.list():
+                    for mount in c.attrs.get("Mounts", []):
+                        if str(workspace_root) in mount.get("Source", ""):
+                            container = c
+                            break
+                    if container:
+                        break
+                if container:
+                    break
+            if not container:
+                return
+            cid = container.short_id
+            logger.info(f"  [container:{cid}] Attaching to container logs...")
+            for chunk in container.logs(stream=True, follow=True, stderr=True, stdout=True):
+                if stop.is_set():
+                    break
+                line = chunk.decode("utf-8", errors="replace").rstrip()
+                if line:
+                    logger.info(f"  [container:{cid}] {line}")
+        except ImportError:
+            logger.debug("Docker SDK not available")
+        except Exception as e:
+            logger.debug(f"Docker log streaming ended: {e}")
+
+    async def _stream_progress(self, mode: str, workspace_root: Path, run_task: "asyncio.Task") -> None:
+        editable = workspace_root / "agent_workspace" / "editable"
+        seen: set = set()
+        stop = threading.Event()
+        if mode == "container":
+            t = threading.Thread(
+                target=self._stream_docker_logs, args=(workspace_root, stop), daemon=True
+            )
+            t.start()
+        try:
+            while not run_task.done():
+                await asyncio.sleep(5)
+                if not editable.exists():
+                    continue
+                current = {str(p) for p in editable.rglob("*") if p.is_file()}
+                for f in sorted(current - seen):
+                    logger.info(f"  [progress] created: {Path(f).relative_to(editable)}")
+                seen = current
+        finally:
+            stop.set()
+
+    def _log_session_details(self, session_id: str) -> None:
+        try:
+            workspace = session_workspace(session_id)
+            summary_path = workspace / "summary.md"
+            if summary_path.exists():
+                logger.info(f"Session summary:\n{summary_path.read_text(encoding='utf-8').strip()}")
+            conv_path = workspace / "conversation.json"
+            if not conv_path.exists():
+                return
+            conv = json.loads(conv_path.read_text(encoding="utf-8"))
+            if not isinstance(conv, list):
+                return
+            logger.info(f"Agent conversation replay ({len(conv)} messages):")
+            for msg in conv:
+                t = msg.get("type", "")
+                data = msg.get("data", msg)
+                if t == "assistant":
+                    for block in (data.get("content") or []):
+                        if not isinstance(block, dict):
+                            continue
+                        if block.get("type") == "text":
+                            text = block["text"].strip().replace("\n", " ")
+                            if text:
+                                logger.info(f"  [agent] {text[:200]}")
+                        elif block.get("type") == "tool_use":
+                            inp = block.get("input", {})
+                            detail = (
+                                inp.get("command") or inp.get("file_path")
+                                or inp.get("path") or str(inp)[:80]
+                            )
+                            logger.info(f"  [tool]  {block['name']}: {str(detail)[:120]}")
+                elif t == "result":
+                    turns = data.get("num_turns", "?")
+                    cost = data.get("total_cost_usd")
+                    usage = data.get("usage", {})
+                    out_tok = usage.get("output_tokens", "?")
+                    cache_r = usage.get("cache_read_input_tokens", 0)
+                    cost_str = f" ${cost:.4f}" if cost is not None else ""
+                    logger.info(
+                        f"  [done]  {turns} turns, {out_tok} output tokens"
+                        f", {cache_r} cache-read tokens{cost_str}"
+                    )
+        except Exception as e:
+            logger.debug(f"Could not read session details for {session_id}: {e}")
+
+    def _generate_output_skill_name(self, original_name: str, override: Optional[str] = None) -> str:
+        """Generate the output skill name, appending numeric suffix if needed."""
+        if override:
+            return override
+        existing_names = {s["name"] for s in self.store.list_skills()}
+        base = f"{original_name}_optimized"
+        if base not in existing_names:
+            return base
+        i = 1
+        while f"{base}({i})" in existing_names:
+            i += 1
+        return f"{base}({i})"
+
+    async def optimize_skill(
+        self,
+        skill_uuid: str,
+        output_skill_name: Optional[str] = None,
+        include_metadata: bool = True,
+        trajectories_dir: Optional[str] = None,
+        additional_context_dir: Optional[str] = None,
+        agent_env: Optional[Dict[str, str]] = None,
+        execution_mode: Optional[str] = None,
+        max_turns: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Optimize an existing skill and import the result as a new skill."""
+        if not self._runspace_available:
+            raise RuntimeError("runspace-agent not available")
+        if self._store_api is None:
+            raise RuntimeError("Store API not available")
+
+        skill = self.store.get_skill(skill_uuid)
+        if skill is None:
+            raise ValueError(f"Skill {skill_uuid!r} not found")
+
+        if trajectories_dir and not Path(trajectories_dir).exists():
+            raise ValueError(f"trajectories_dir does not exist: {trajectories_dir!r}")
+        if additional_context_dir and not Path(additional_context_dir).exists():
+            raise ValueError(f"additional_context_dir does not exist: {additional_context_dir!r}")
+
+        original_name = skill["name"]
+        logger.info(f"Optimizing skill '{original_name}' ({skill_uuid})...")
+
+        from claude_code_sdk import ClaudeCodeOptions
+
+        claude_env = self._build_claude_env(agent_env)
+        options = ClaudeCodeOptions(
+            env=claude_env,
+            max_turns=max_turns or int(os.getenv("RUNSPACE_MAX_TURNS", "300")),
+        )
+        raw_mode = execution_mode or self._execution_mode
+        mode: Literal["local", "container"] = "container" if raw_mode == "container" else "local"
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            skill_dir = temp_path / "skill"
+            skill_dir.mkdir()
+            context_dir = temp_path / "context"
+            context_dir.mkdir()
+
+            tools = skill.get("tools", [])
+            snippets = skill.get("snippets", [])
+            tool_modules: Dict[str, str] = {}
+            for tool in tools:
+                if tool.get("module_name"):
+                    try:
+                        content = self.store.tools.read_file(
+                            tool["uuid"], tool["module_name"], raw_content=True
+                        )
+                        tool_modules[tool["name"]] = content
+                    except Exception as e:
+                        logger.warning(f"Could not read module for tool '{tool['name']}': {e}")
+
+            export_skill_to_directory(skill, tools, snippets, str(skill_dir), tool_modules)
+            logger.info(f"Exported skill to {skill_dir}")
+
+            (skill_dir / REQUIRED_OUTPUTS_FILENAME).write_text(
+                json.dumps(REQUIRED_OUTPUTS_TEMPLATE, indent=2)
+            )
+
+            if include_metadata:
+                metadata = {
+                    "name": skill.get("name"),
+                    "description": skill.get("description"),
+                    "tags": skill.get("tags", []),
+                    "extra": skill.get("extra", {}),
+                    "tools": [
+                        {"name": t.get("name"), "description": t.get("description")}
+                        for t in tools
+                    ],
+                    "snippets": [
+                        {"name": s.get("name"), "description": s.get("description")}
+                        for s in snippets
+                    ],
+                }
+                (context_dir / "skill_metadata.json").write_text(
+                    json.dumps(metadata, indent=2)
+                )
+
+            if trajectories_dir:
+                shutil.copytree(trajectories_dir, str(context_dir / "trajectories"))
+
+            if additional_context_dir:
+                shutil.copytree(additional_context_dir, str(context_dir / "additional_context"))
+
+            prompt = build_runspace_prompt(
+                has_metadata=include_metadata,
+                has_trajectories=bool(trajectories_dir),
+                has_additional_context=bool(additional_context_dir),
+            )
+
+            try:
+                result = await optimize_skill_session(
+                    prompt, skill_dir, context_dir, options, mode, self
+                )
+                self._log_session_details(result.session_id)
+            except Exception as e:
+                logger.error(f"RunSpace session failed: {e}", exc_info=True)
+                raise RuntimeError(f"Optimization failed: {str(e)}")
+
+            if mode == "container":
+                import_dir = (
+                    session_workspace(result.session_id) / "agent_workspace" / "editable"
+                )
+            else:
+                import_dir = skill_dir
+
+            clean_dir = temp_path / "import_clean"
+            shutil.copytree(str(import_dir), str(clean_dir))
+            req_file = clean_dir / REQUIRED_OUTPUTS_FILENAME
+            opt_metadata: Dict[str, Any] = {}
+            if req_file.exists():
+                try:
+                    opt_metadata = json.loads(req_file.read_text())
+                    req_file.unlink()
+                except Exception as e:
+                    logger.warning(f"Could not parse {REQUIRED_OUTPUTS_FILENAME}: {e}")
+            else:
+                logger.warning(f"{REQUIRED_OUTPUTS_FILENAME} not found in session output")
+
+            final_name = self._generate_output_skill_name(original_name, override=output_skill_name)
+
+            try:
+                skill_name_result, skill_description, imported_tools, imported_snippets, ignored = (
+                    import_from_anthropic_skill(
+                        source_type="folder",
+                        source_data=str(clean_dir),
+                        snippet_mode="file",
+                        treat_all_as_documents=False,
+                    )
+                )
+                logger.info(
+                    f"Imported '{skill_name_result}': {len(imported_tools)} tools, "
+                    f"{len(imported_snippets)} snippets, {len(ignored)} ignored"
+                )
+
+                tool_uuids = []
+                for tool in imported_tools:
+                    try:
+                        tool_tags = list(getattr(tool, "tags", None) or [])
+                        tool_data = {
+                            "name": tool.name,
+                            "description": tool.description or "",
+                            "programming_language": tool.programming_language or "python",
+                            "params": tool.params or {},
+                            "returns": tool.returns or {},
+                            "tags": tool_tags,
+                        }
+                        module_bytes = tool.module_content.encode() if tool.module_content else b""
+                        module_filename = tool.source_file_name or f"{tool.name}.py"
+                        created = self.store.create_tool(
+                            tool_data, module_content=module_bytes, module_filename=module_filename
+                        )
+                        tool_uuids.append(created["uuid"])
+                    except Exception as e:
+                        logger.error(f"Failed to create tool '{tool.name}': {e}", exc_info=True)
+
+                snippet_uuids = []
+                for snippet in imported_snippets:
+                    try:
+                        snippet_tags = list(getattr(snippet, "tags", None) or [])
+                        snippet_data = {
+                            "name": snippet.name,
+                            "content": snippet.content,
+                            "tags": snippet_tags,
+                            "description": snippet.description or "",
+                            "version": getattr(snippet, "version", "1.0.0"),
+                        }
+                        created = self.store.create_snippet(snippet_data)
+                        snippet_uuids.append(created["uuid"])
+                    except Exception as e:
+                        logger.error(f"Failed to create snippet '{snippet.name}': {e}", exc_info=True)
+
+                inherited_tags = [t for t in skill.get("tags", []) if t]
+                skill_data = {
+                    "name": final_name,
+                    "description": skill_description,
+                    "tool_uuids": tool_uuids,
+                    "tags": list({"optimized"} | set(inherited_tags)),
+                }
+                created_skill = self.store.create_skill(skill_data)
+                logger.info(f"Created optimized skill '{final_name}' ({created_skill['uuid']})")
+
+                self.store.update_skill_metadata(
+                    created_skill["uuid"],
+                    {
+                        "optimization": {
+                            **opt_metadata,
+                            "source_skill_uuid": skill_uuid,
+                            "source_skill_name": original_name,
+                        }
+                    },
+                )
+
+                return {
+                    "success": True,
+                    "skill": created_skill,
+                    "tools_count": len(tool_uuids),
+                    "snippets_count": len(snippet_uuids),
+                    "optimization_rationale": opt_metadata.get("optimization_rationale", ""),
+                }
+
+            except Exception as e:
+                logger.error(f"Failed to import optimized skill: {e}", exc_info=True)
+                raise RuntimeError(f"Skill import failed: {str(e)}")
+
+    def get_router(self):
+        """Register plugin API routes."""
+        from fastapi import APIRouter, HTTPException
+        from pydantic import BaseModel
+        from typing import List, Optional
+
+        router = APIRouter()
+
+        class OptimizeSkillRequest(BaseModel):
+            skill_uuid: str
+            output_skill_name: Optional[str] = None
+            include_metadata: bool = True
+            trajectories_dir: Optional[str] = None
+            additional_context_dir: Optional[str] = None
+            agent_env: Optional[Dict[str, str]] = None
+            execution_mode: Optional[str] = None
+            max_turns: Optional[int] = None
+
+        @router.post("/optimize-skill")
+        async def optimize_skill_endpoint(request: OptimizeSkillRequest):
+            """Optimize an existing skill using RunSpace."""
+            if not self.is_enabled():
+                raise HTTPException(status_code=503, detail=self._status_message)
+
+            try:
+                result = await self.optimize_skill(
+                    skill_uuid=request.skill_uuid,
+                    output_skill_name=request.output_skill_name,
+                    include_metadata=request.include_metadata,
+                    trajectories_dir=request.trajectories_dir,
+                    additional_context_dir=request.additional_context_dir,
+                    agent_env=request.agent_env,
+                    execution_mode=request.execution_mode,
+                    max_turns=request.max_turns,
+                )
+                return {
+                    "success": True,
+                    "message": f"Skill '{result['skill']['name']}' optimized successfully.",
+                    "skill_name": result["skill"]["name"],
+                    "skill_uuid": result["skill"]["uuid"],
+                    "tools_count": result["tools_count"],
+                    "snippets_count": result["snippets_count"],
+                    "optimization_rationale": result.get("optimization_rationale", ""),
+                }
+            except ValueError as e:
+                status = 404 if "not found" in str(e) else 400
+                raise HTTPException(status_code=status, detail=str(e))
+            except Exception as e:
+                logger.error(f"Optimization endpoint error: {e}", exc_info=True)
+                raise HTTPException(status_code=500, detail=str(e))
+
+        return router
+
+    def get_cli_commands(self) -> Optional[Dict[str, Any]]:
+        return None
+
+    def get_ui_config(self) -> Optional[Dict[str, Any]]:
+        return {
+            "icon": "SparklesIcon",
+            "color": "#F59E0B",
+            "actions": [
+                {
+                    "label": "Optimize Skill",
+                    "endpoint": "/api/plugins/skill-optimizer/optimize-skill",
+                    "method": "POST",
+                    "params_schema": {
+                        "type": "object",
+                        "properties": {
+                            "skill_uuid": {
+                                "type": "string",
+                                "description": "UUID of the skill to optimize",
+                            },
+                            "output_skill_name": {
+                                "type": "string",
+                                "description": "Name for the optimized skill (auto-generated if not set)",
+                            },
+                            "include_metadata": {
+                                "type": "boolean",
+                                "default": True,
+                                "description": "Include skill tags and extra metadata in context",
+                            },
+                            "trajectories_dir": {
+                                "type": "string",
+                                "description": "Local path to folder containing execution trajectories",
+                            },
+                            "additional_context_dir": {
+                                "type": "string",
+                                "description": "Local path to folder with additional optimization context",
+                            },
+                            "agent_env": {
+                                "type": "object",
+                                "description": "Credential overrides for Claude Code (e.g., ANTHROPIC_API_KEY)",
+                            },
+                            "execution_mode": {
+                                "type": "string",
+                                "enum": ["container", "local"],
+                                "default": "container",
+                                "description": "Execution mode: 'local' (faster) or 'container' (safer, requires Docker)",
+                            },
+                            "max_turns": {
+                                "type": "integer",
+                                "description": "Maximum conversation turns for Claude Code (default: 300)",
+                            },
+                        },
+                        "required": ["skill_uuid"],
+                    },
+                }
+            ],
+        }

--- a/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/prompt.py
+++ b/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/prompt.py
@@ -31,12 +31,13 @@ def build_runspace_prompt(
     """Build the optimization prompt for RunspaceAgent."""
     # context/knowledge/ is always present — it's bundled with the optimizer
     inventory_lines = [
-        "- context/knowledge/ — READ ALL FIVE FILES BEFORE MAKING ANY CHANGES:\n"
+        "- context/knowledge/ — READ ALL FILES BEFORE MAKING ANY CHANGES:\n"
         "    01-skillberry-store-format.md        — format rules the SkillBerry Store importer enforces\n"
         "    02-skill-best-practices.md           — how to write high-quality skill instructions\n"
         "    03-skill-description-optimization.md — how to write descriptions that trigger reliably\n"
         "    04-snippet-optimization.md           — how to diagnose and improve textual snippets\n"
-        "    05-tool-optimization.md              — correctness, discoverability, and usability for tools",
+        "    05-tool-optimization.md              — correctness, discoverability, and usability for tools\n"
+        "    06-trajectory-based-optimization.md  — how to read trajectories and translate findings into skill changes",
     ]
     if has_metadata:
         inventory_lines.append(
@@ -58,18 +59,19 @@ def build_runspace_prompt(
     if has_trajectories:
         analyze_block = """\
 HOW TO ANALYZE TRAJECTORIES:
-1. Read the trajectories and their `reward` values. Higher reward = better outcome.
-2. Study SUCCESSFUL trajectories (high reward) — understand what to preserve.
-3. Study FAILED trajectories (low reward) — find WHERE and WHY the agent went wrong
-   (wrong tool, wrong arguments, unnecessary steps, policy violations, etc.).
-4. Cluster strengths (preserve) and weaknesses (fix).
-5. Improve the skill GENERICALLY so it transfers to unseen/production tasks.
-   Do NOT overfit to the specific trajectories — fix the underlying behavior:
-   - Remove tools made redundant by better ones.
-   - Add guardrails/checks to prevent the failure modes you found.
-   - Add helper/composite tools that simplify the agent's job.
-   - Clarify tool descriptions/signatures so the agent picks the right tool
-     with correct arguments.
+Read context/knowledge/06-trajectory-based-optimization.md for the complete guide.
+Summary of the process:
+
+1. Stratify by reward: high (>=0.8) = study to preserve; low (<=0.3) = diagnose to fix.
+2. Sample representatively — 5-10 low-reward and 3-5 high-reward trajectories is enough.
+3. Cluster failures by root cause: wrong tool selected, bad parameters, missing tool,
+   wrong sequence, policy violation, error not recovered, redundant calls.
+4. Verify each finding appears in >=2 trajectories before changing anything.
+5. Prioritise: high frequency × total task failure × high generality × low fix complexity.
+6. Improve GENERICALLY — fix the underlying behavior, not individual task instances.
+   Do NOT overfit to specific trajectories.
+7. Use the finding→fix translation table in 06-trajectory-based-optimization.md
+   to route each finding to the right file (tool docstring, SKILL.md, new function).
 """
     else:
         analyze_block = """\

--- a/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/prompt.py
+++ b/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/prompt.py
@@ -29,7 +29,13 @@ def build_runspace_prompt(
     has_additional_context: bool = False,
 ) -> str:
     """Build the optimization prompt for RunspaceAgent."""
-    inventory_lines = []
+    # context/knowledge/ is always present — it's bundled with the optimizer
+    inventory_lines = [
+        "- context/knowledge/ — READ THIS FIRST. Contains three files:\n"
+        "    01-skillberry-store-format.md  — complete format rules for the SkillBerry Store importer\n"
+        "    02-skill-best-practices.md     — how to write high-quality skill instructions and tools\n"
+        "    03-skill-description-optimization.md — how to write descriptions that trigger reliably",
+    ]
     if has_metadata:
         inventory_lines.append(
             "- context/skill_metadata.json — skill tags, extra metadata, "
@@ -45,7 +51,7 @@ def build_runspace_prompt(
             "- context/additional_context/ — additional context "
             "(documentation, requirements, examples, domain knowledge, etc.)."
         )
-    inventory = "\n".join(inventory_lines) if inventory_lines else "(No additional context provided.)"
+    inventory = "\n".join(inventory_lines)
 
     if has_trajectories:
         analyze_block = """\

--- a/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/prompt.py
+++ b/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/prompt.py
@@ -1,0 +1,145 @@
+"""Optimization prompt builder for the Skill Optimizer RunSpace session."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+REQUIRED_OUTPUTS_FILENAME = "required_outputs.json"
+
+REQUIRED_OUTPUTS_TEMPLATE: Dict[str, Any] = {
+    "skill_name": "",
+    "skill_description": "",
+    "optimization_rationale": "",
+    "issues_addressed": [],
+    "tools_added": [],
+    "tools_modified": [],
+    "tools_removed": [],
+    "snippets_added": [],
+    "snippets_modified": [],
+    "snippets_removed": [],
+    "ready_for_deployment": True,
+}
+
+
+def build_runspace_prompt(
+    *,
+    has_metadata: bool = False,
+    has_trajectories: bool = False,
+    has_additional_context: bool = False,
+) -> str:
+    """Build the optimization prompt for RunspaceAgent."""
+    inventory_lines = []
+    if has_metadata:
+        inventory_lines.append(
+            "- context/skill_metadata.json — skill tags, extra metadata, "
+            "and tool/snippet descriptions."
+        )
+    if has_trajectories:
+        inventory_lines.append(
+            "- context/trajectories/ — execution trajectories from prior skill runs "
+            "(each entry has a `reward` value; higher = better outcome)."
+        )
+    if has_additional_context:
+        inventory_lines.append(
+            "- context/additional_context/ — additional context "
+            "(documentation, requirements, examples, domain knowledge, etc.)."
+        )
+    inventory = "\n".join(inventory_lines) if inventory_lines else "(No additional context provided.)"
+
+    if has_trajectories:
+        analyze_block = """\
+HOW TO ANALYZE TRAJECTORIES:
+1. Read the trajectories and their `reward` values. Higher reward = better outcome.
+2. Study SUCCESSFUL trajectories (high reward) — understand what to preserve.
+3. Study FAILED trajectories (low reward) — find WHERE and WHY the agent went wrong
+   (wrong tool, wrong arguments, unnecessary steps, policy violations, etc.).
+4. Cluster strengths (preserve) and weaknesses (fix).
+5. Improve the skill GENERICALLY so it transfers to unseen/production tasks.
+   Do NOT overfit to the specific trajectories — fix the underlying behavior:
+   - Remove tools made redundant by better ones.
+   - Add guardrails/checks to prevent the failure modes you found.
+   - Add helper/composite tools that simplify the agent's job.
+   - Clarify tool descriptions/signatures so the agent picks the right tool
+     with correct arguments.
+"""
+    else:
+        analyze_block = """\
+HOW TO ANALYZE:
+Read the skill content and any context provided. Improve clarity, correctness, and
+completeness. Look for ambiguous tool descriptions, missing guardrails, redundant
+tools, or structural issues that would cause an agent to misuse the skill. Remove
+tools that are unclear or redundant — a smaller, sharper skill is better than a
+large bloated one.
+"""
+
+    required_outputs_pretty = json.dumps(REQUIRED_OUTPUTS_TEMPLATE, indent=2)
+
+    return f"""\
+You are optimizing a Skillberry skill. The editable directory IS the current skill,
+exported from the Skillberry Store in Anthropic format. Your job: improve it, then
+leave it importable back into the store.
+
+CONTEXT LAYOUT:
+{inventory}
+
+{analyze_block}
+=== SKILLBERRY STORE ANTHROPIC SKILL FORMAT (MUST FOLLOW) ===
+
+The editable directory is re-imported into the Skillberry Store after you finish.
+Keep it store-compatible:
+
+PYTHON FILES (.py) -> TOOLS:
+- Each .py file is AST-parsed; every top-level `def` becomes a separate tool.
+- Function name -> tool name; docstring -> description; type annotations +
+  docstring Args -> parameter schema.
+- A .py file with no functions becomes one tool named after the file.
+
+NON-CODE FILES (.md, .txt, .json, ...) -> SNIPPETS:
+- All non-Python files become read-only reference snippets.
+- The SKILL.md body (everything after the YAML frontmatter) also becomes a snippet.
+
+SKILL.md FRONTMATTER RULES:
+- Must start with a `---`-delimited YAML frontmatter block.
+- ONLY `name` and `description` are recognized — do not add other fields.
+- `name` must be kebab-case, max 64 characters.
+- `description` must be present, max 1024 characters.
+
+PYTHON FILE FORMAT RULES:
+- Each .py file must be self-contained: only stdlib imports + injected helpers.
+- No relative or cross-file imports (`from scripts.foo import bar` is FORBIDDEN).
+- Runtime helpers are INJECTED into execution scope — call them directly,
+  do NOT import them.
+
+PRESERVE STRUCTURE:
+- Do NOT rename, move, or delete existing files.
+- Keep the output directory structure the same as the input.
+- Do NOT leave temporary files in the directory — they will be imported.
+- Keep SKILL.md frontmatter valid at all times.
+
+SKILL NAME:
+- If you made meaningful changes, update SKILL.md `name` to a new kebab-case
+  name (max 64 characters) that hints at what changed.
+- Put the SAME value in `skill_name` in required_outputs.json.
+- IMPORTANT: only change the NAME VALUE inside SKILL.md — do NOT create
+  subdirectories, do NOT move SKILL.md, do NOT rename the editable directory.
+
+=== REQUIRED OUTPUT CONTRACT ===
+The editable directory contains a file named `{REQUIRED_OUTPUTS_FILENAME}`. You MUST
+open it and fill in EVERY field describing the changes you made, then save it.
+The optimizer reads this file to record what changed. Template:
+
+{required_outputs_pretty}
+
+Field meanings:
+- skill_name: the (possibly updated) kebab-case skill name from SKILL.md frontmatter.
+- skill_description: the skill description from SKILL.md frontmatter.
+- optimization_rationale: a concise explanation of what you changed and why.
+- issues_addressed: list of the failure modes / issues you fixed.
+- tools_added / tools_modified / tools_removed: function names added, changed, removed.
+- snippets_added / snippets_modified / snippets_removed: non-code files changed.
+- ready_for_deployment: true if the skill is valid and ready to upload.
+
+`{REQUIRED_OUTPUTS_FILENAME}` is a temporary contract file — the optimizer removes it
+before importing the skill back into the store.
+"""

--- a/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/prompt.py
+++ b/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/prompt.py
@@ -31,10 +31,12 @@ def build_runspace_prompt(
     """Build the optimization prompt for RunspaceAgent."""
     # context/knowledge/ is always present — it's bundled with the optimizer
     inventory_lines = [
-        "- context/knowledge/ — READ THIS FIRST. Contains three files:\n"
-        "    01-skillberry-store-format.md  — complete format rules for the SkillBerry Store importer\n"
-        "    02-skill-best-practices.md     — how to write high-quality skill instructions and tools\n"
-        "    03-skill-description-optimization.md — how to write descriptions that trigger reliably",
+        "- context/knowledge/ — READ ALL FIVE FILES BEFORE MAKING ANY CHANGES:\n"
+        "    01-skillberry-store-format.md        — format rules the SkillBerry Store importer enforces\n"
+        "    02-skill-best-practices.md           — how to write high-quality skill instructions\n"
+        "    03-skill-description-optimization.md — how to write descriptions that trigger reliably\n"
+        "    04-snippet-optimization.md           — how to diagnose and improve textual snippets\n"
+        "    05-tool-optimization.md              — correctness, discoverability, and usability for tools",
     ]
     if has_metadata:
         inventory_lines.append(

--- a/plugins/skillberry-plugin-skill-optimizer/tests/test_skill_optimizer_plugin.py
+++ b/plugins/skillberry-plugin-skill-optimizer/tests/test_skill_optimizer_plugin.py
@@ -2,7 +2,10 @@
 
 import json
 import os
+import shutil
+import tempfile
 import pytest
+from pathlib import Path
 from unittest.mock import Mock, patch, AsyncMock
 
 from skillberry_plugin_skill_optimizer.prompt import (
@@ -185,3 +188,305 @@ def test_status_message_missing_credentials():
         with patch("skillberry_plugin_skill_optimizer.plugin.runspace_agent", new=Mock()):
             p = SkillberryPluginSkillOptimizer()
     assert "credentials" in p.get_status_message().lower()
+
+
+# ---------------------------------------------------------------------------
+# Naming tests
+# ---------------------------------------------------------------------------
+
+def test_naming_no_conflict(plugin, mock_store):
+    plugin.set_store_api(mock_store)
+    # existing names: ["other-skill"] — "my-skill_optimized" is free
+    name = plugin._generate_output_skill_name("my-skill")
+    assert name == "my-skill_optimized"
+
+
+def test_naming_conflict_appends_1(plugin, mock_store):
+    mock_store.list_skills.return_value = [
+        {"name": "other-skill"},
+        {"name": "my-skill_optimized"},
+    ]
+    plugin.set_store_api(mock_store)
+    name = plugin._generate_output_skill_name("my-skill")
+    assert name == "my-skill_optimized(1)"
+
+
+def test_naming_conflict_appends_2(plugin, mock_store):
+    mock_store.list_skills.return_value = [
+        {"name": "my-skill_optimized"},
+        {"name": "my-skill_optimized(1)"},
+    ]
+    plugin.set_store_api(mock_store)
+    name = plugin._generate_output_skill_name("my-skill")
+    assert name == "my-skill_optimized(2)"
+
+
+def test_naming_user_override(plugin, mock_store):
+    plugin.set_store_api(mock_store)
+    name = plugin._generate_output_skill_name("my-skill", override="custom-name")
+    assert name == "custom-name"
+    mock_store.list_skills.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# optimize_skill tests
+# ---------------------------------------------------------------------------
+
+def _make_mock_result(session_id="abc123def456"):
+    result = Mock()
+    result.success = True
+    result.session_id = session_id
+    result.agent_result = Mock(total_tokens=1000, total_cost_usd=0.01, error=None)
+    return result
+
+
+def _make_mock_tool():
+    tool = Mock()
+    tool.name = "my_tool"
+    tool.description = "A tool"
+    tool.programming_language = "python"
+    tool.params = {}
+    tool.returns = {}
+    tool.tags = []
+    tool.module_content = "def my_tool():\n    pass\n"
+    tool.source_file_name = "my_tool.py"
+    return tool
+
+
+@pytest.mark.asyncio
+async def test_optimize_skill_happy_path(plugin, mock_store):
+    plugin.set_store_api(mock_store)
+
+    fake_req_outputs = {
+        **REQUIRED_OUTPUTS_TEMPLATE,
+        "skill_name": "my-skill-v2",
+        "optimization_rationale": "Improved tool descriptions",
+        "tools_modified": ["my_tool"],
+    }
+
+    async def fake_optimize_session(prompt, skill_dir, context_dir, options, mode, plugin_inst):
+        Path(skill_dir / REQUIRED_OUTPUTS_FILENAME).write_text(
+            json.dumps(fake_req_outputs)
+        )
+        return _make_mock_result()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch(
+            "skillberry_plugin_skill_optimizer.plugin.optimize_skill_session",
+            side_effect=fake_optimize_session,
+        ), patch(
+            "skillberry_plugin_skill_optimizer.plugin.export_skill_to_directory"
+        ), patch(
+            "skillberry_plugin_skill_optimizer.plugin.import_from_anthropic_skill",
+            return_value=("my-skill-v2", "Optimized skill", [_make_mock_tool()], [], []),
+        ), patch(
+            "skillberry_plugin_skill_optimizer.plugin.session_workspace",
+            return_value=Path(tmpdir),
+        ):
+            result = await plugin.optimize_skill(
+                skill_uuid="skill-uuid-123",
+                execution_mode="local",
+            )
+
+    assert result["success"] is True
+    assert result["skill"]["name"] == "my-skill_optimized"
+    assert result["tools_count"] == 1
+    assert result["snippets_count"] == 0
+    mock_store.update_skill_metadata.assert_called_once()
+    call_args = mock_store.update_skill_metadata.call_args
+    opt_meta = call_args[0][1]["optimization"]
+    assert opt_meta["optimization_rationale"] == "Improved tool descriptions"
+    assert opt_meta["source_skill_uuid"] == "skill-uuid-123"
+    assert opt_meta["source_skill_name"] == "my-skill"
+
+
+@pytest.mark.asyncio
+async def test_skill_not_found_raises(plugin, mock_store):
+    mock_store.get_skill.return_value = None
+    plugin.set_store_api(mock_store)
+    with pytest.raises(ValueError, match="not found"):
+        await plugin.optimize_skill(skill_uuid="nonexistent-uuid")
+
+
+@pytest.mark.asyncio
+async def test_bad_trajectories_dir_raises(plugin, mock_store):
+    plugin.set_store_api(mock_store)
+    with pytest.raises(ValueError, match="trajectories_dir"):
+        await plugin.optimize_skill(
+            skill_uuid="skill-uuid-123",
+            trajectories_dir="/nonexistent/path/to/trajectories",
+        )
+
+
+@pytest.mark.asyncio
+async def test_bad_additional_context_dir_raises(plugin, mock_store):
+    plugin.set_store_api(mock_store)
+    with pytest.raises(ValueError, match="additional_context_dir"):
+        await plugin.optimize_skill(
+            skill_uuid="skill-uuid-123",
+            additional_context_dir="/nonexistent/path/to/context",
+        )
+
+
+@pytest.mark.asyncio
+async def test_missing_required_outputs_still_imports(plugin, mock_store):
+    plugin.set_store_api(mock_store)
+
+    async def fake_session_no_outputs(prompt, skill_dir, context_dir, options, mode, plugin_inst):
+        # Agent does NOT write required_outputs.json
+        return _make_mock_result()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch(
+            "skillberry_plugin_skill_optimizer.plugin.optimize_skill_session",
+            side_effect=fake_session_no_outputs,
+        ), patch(
+            "skillberry_plugin_skill_optimizer.plugin.export_skill_to_directory"
+        ), patch(
+            "skillberry_plugin_skill_optimizer.plugin.import_from_anthropic_skill",
+            return_value=("my-skill-v2", "Optimized", [_make_mock_tool()], [], []),
+        ), patch(
+            "skillberry_plugin_skill_optimizer.plugin.session_workspace",
+            return_value=Path(tmpdir),
+        ):
+            result = await plugin.optimize_skill(
+                skill_uuid="skill-uuid-123",
+                execution_mode="local",
+            )
+
+    assert result["success"] is True
+    mock_store.update_skill_metadata.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_metadata_context_written_when_enabled(plugin, mock_store):
+    plugin.set_store_api(mock_store)
+    written_context_files = []
+
+    async def fake_session_capture(prompt, skill_dir, context_dir, options, mode, plugin_inst):
+        if context_dir.exists():
+            written_context_files.extend(
+                str(p) for p in Path(context_dir).rglob("*") if p.is_file()
+            )
+        return _make_mock_result()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch(
+            "skillberry_plugin_skill_optimizer.plugin.optimize_skill_session",
+            side_effect=fake_session_capture,
+        ), patch(
+            "skillberry_plugin_skill_optimizer.plugin.export_skill_to_directory"
+        ), patch(
+            "skillberry_plugin_skill_optimizer.plugin.import_from_anthropic_skill",
+            return_value=("my-skill", "desc", [], [], []),
+        ), patch(
+            "skillberry_plugin_skill_optimizer.plugin.session_workspace",
+            return_value=Path(tmpdir),
+        ):
+            await plugin.optimize_skill(
+                skill_uuid="skill-uuid-123",
+                include_metadata=True,
+                execution_mode="local",
+            )
+
+    assert any("skill_metadata.json" in f for f in written_context_files)
+
+
+# ---------------------------------------------------------------------------
+# Router tests
+# ---------------------------------------------------------------------------
+
+def test_router_is_not_none(plugin):
+    router = plugin.get_router()
+    assert router is not None
+
+
+def test_router_has_optimize_skill_endpoint(plugin):
+    from fastapi import FastAPI
+    app = FastAPI()
+    app.include_router(plugin.get_router())
+    routes = [r.path for r in app.routes]
+    assert "/optimize-skill" in routes
+
+
+def test_router_returns_503_when_disabled():
+    with patch("skillberry_plugin_skill_optimizer.plugin.runspace_agent", new=None):
+        p = SkillberryPluginSkillOptimizer()
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    app = FastAPI()
+    app.include_router(p.get_router())
+    client = TestClient(app)
+    response = client.post("/optimize-skill", json={"skill_uuid": "some-uuid"})
+    assert response.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_router_optimize_skill_endpoint(plugin, mock_store):
+    plugin.set_store_api(mock_store)
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    app = FastAPI()
+    app.include_router(plugin.get_router())
+    client = TestClient(app)
+
+    with patch.object(
+        plugin,
+        "optimize_skill",
+        new=AsyncMock(return_value={
+            "success": True,
+            "skill": {"uuid": "new-uuid", "name": "my-skill_optimized"},
+            "tools_count": 1,
+            "snippets_count": 0,
+            "optimization_rationale": "Improved",
+        }),
+    ):
+        response = client.post("/optimize-skill", json={"skill_uuid": "skill-uuid-123"})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+    assert data["skill_name"] == "my-skill_optimized"
+    assert data["skill_uuid"] == "new-uuid"
+
+
+# ---------------------------------------------------------------------------
+# UI config tests
+# ---------------------------------------------------------------------------
+
+def test_ui_config_not_none(plugin):
+    assert plugin.get_ui_config() is not None
+
+
+def test_ui_config_shape(plugin):
+    config = plugin.get_ui_config()
+    assert config["icon"] == "SparklesIcon"
+    assert config["color"] == "#F59E0B"
+    assert len(config["actions"]) == 1
+
+
+def test_ui_config_action(plugin):
+    action = plugin.get_ui_config()["actions"][0]
+    assert action["label"] == "Optimize Skill"
+    assert "optimize-skill" in action["endpoint"]
+    assert action["method"] == "POST"
+
+
+def test_ui_config_params_schema(plugin):
+    schema = plugin.get_ui_config()["actions"][0]["params_schema"]
+    assert schema["required"] == ["skill_uuid"]
+    props = schema["properties"]
+    assert "skill_uuid" in props
+    assert "output_skill_name" in props
+    assert "include_metadata" in props
+    assert props["include_metadata"].get("default") is True
+    assert "trajectories_dir" in props
+    assert "additional_context_dir" in props
+    assert "execution_mode" in props
+    assert "container" in props["execution_mode"]["enum"]
+    assert "local" in props["execution_mode"]["enum"]
+
+
+def test_get_cli_commands_returns_none(plugin):
+    assert plugin.get_cli_commands() is None

--- a/plugins/skillberry-plugin-skill-optimizer/tests/test_skill_optimizer_plugin.py
+++ b/plugins/skillberry-plugin-skill-optimizer/tests/test_skill_optimizer_plugin.py
@@ -83,3 +83,105 @@ def test_build_prompt_contains_required_outputs_template():
     # The template JSON must appear verbatim in the prompt
     for key in REQUIRED_OUTPUTS_TEMPLATE:
         assert key in prompt
+
+
+from skillberry_store.plugins.base import PluginType
+from skillberry_plugin_skill_optimizer.plugin import SkillberryPluginSkillOptimizer
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def plugin():
+    with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):
+        with patch("skillberry_plugin_skill_optimizer.plugin.runspace_agent", new=Mock()):
+            p = SkillberryPluginSkillOptimizer()
+    return p
+
+
+@pytest.fixture
+def mock_store():
+    store = Mock()
+    store.get_skill = Mock(return_value={
+        "uuid": "skill-uuid-123",
+        "name": "my-skill",
+        "description": "A test skill",
+        "tags": ["python", "test"],
+        "extra": {},
+        "tool_uuids": ["tool-uuid-1"],
+        "snippet_uuids": [],
+        "tools": [
+            {
+                "uuid": "tool-uuid-1",
+                "name": "my_tool",
+                "description": "A tool",
+                "programming_language": "python",
+                "module_name": "my_tool.py",
+                "tags": [],
+            }
+        ],
+        "snippets": [],
+    })
+    store.list_skills = Mock(return_value=[{"name": "other-skill"}])
+    store.tools = Mock()
+    store.tools.read_file = Mock(return_value="def my_tool():\n    pass\n")
+    store.create_tool = Mock(return_value={"uuid": "new-tool-uuid", "name": "my_tool"})
+    store.create_snippet = Mock(return_value={"uuid": "new-snip-uuid", "name": "my_snip"})
+    store.create_skill = Mock(return_value={
+        "uuid": "new-skill-uuid",
+        "name": "my-skill_optimized",
+        "description": "Optimized skill",
+    })
+    store.update_skill_metadata = Mock(return_value=True)
+    return store
+
+
+# ---------------------------------------------------------------------------
+# Plugin init / metadata tests
+# ---------------------------------------------------------------------------
+
+def test_plugin_metadata(plugin):
+    assert plugin.metadata.name == "Skill Optimizer"
+    assert plugin.metadata.plugin_type == PluginType.OPTIMIZER
+    assert plugin.metadata.version == "0.1.0"
+
+
+def test_is_enabled_with_runspace_and_credentials(plugin):
+    assert plugin.is_enabled() is True
+
+
+def test_is_enabled_without_runspace():
+    with patch("skillberry_plugin_skill_optimizer.plugin.runspace_agent", new=None):
+        p = SkillberryPluginSkillOptimizer()
+    assert p.is_enabled() is False
+
+
+def test_is_enabled_without_credentials():
+    env = {k: v for k, v in os.environ.items()
+           if k not in ("ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN")}
+    with patch.dict(os.environ, env, clear=True):
+        with patch("skillberry_plugin_skill_optimizer.plugin.runspace_agent", new=Mock()):
+            p = SkillberryPluginSkillOptimizer()
+    assert p.is_enabled() is False
+
+
+def test_status_message_ready(plugin):
+    msg = plugin.get_status_message()
+    assert "Ready" in msg
+
+
+def test_status_message_missing_runspace():
+    with patch("skillberry_plugin_skill_optimizer.plugin.runspace_agent", new=None):
+        p = SkillberryPluginSkillOptimizer()
+    assert "runspace-agent" in p.get_status_message()
+
+
+def test_status_message_missing_credentials():
+    env = {k: v for k, v in os.environ.items()
+           if k not in ("ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN")}
+    with patch.dict(os.environ, env, clear=True):
+        with patch("skillberry_plugin_skill_optimizer.plugin.runspace_agent", new=Mock()):
+            p = SkillberryPluginSkillOptimizer()
+    assert "credentials" in p.get_status_message().lower()

--- a/plugins/skillberry-plugin-skill-optimizer/tests/test_skill_optimizer_plugin.py
+++ b/plugins/skillberry-plugin-skill-optimizer/tests/test_skill_optimizer_plugin.py
@@ -1,0 +1,85 @@
+"""Tests for the Skill Optimizer plugin."""
+
+import json
+import os
+import pytest
+from unittest.mock import Mock, patch, AsyncMock
+
+from skillberry_plugin_skill_optimizer.prompt import (
+    REQUIRED_OUTPUTS_FILENAME,
+    REQUIRED_OUTPUTS_TEMPLATE,
+    build_runspace_prompt,
+)
+
+
+# ---------------------------------------------------------------------------
+# prompt.py tests
+# ---------------------------------------------------------------------------
+
+def test_required_outputs_template_has_all_fields():
+    required_keys = {
+        "skill_name", "skill_description", "optimization_rationale",
+        "issues_addressed", "tools_added", "tools_modified", "tools_removed",
+        "snippets_added", "snippets_modified", "snippets_removed",
+        "ready_for_deployment",
+    }
+    assert required_keys == set(REQUIRED_OUTPUTS_TEMPLATE.keys())
+
+
+def test_required_outputs_filename():
+    assert REQUIRED_OUTPUTS_FILENAME == "required_outputs.json"
+
+
+def test_build_prompt_no_context():
+    prompt = build_runspace_prompt(
+        has_metadata=False, has_trajectories=False, has_additional_context=False
+    )
+    assert "optimizing a Skillberry skill" in prompt
+    assert "REQUIRED OUTPUT CONTRACT" in prompt
+    assert "required_outputs.json" in prompt
+    assert "SKILLBERRY STORE ANTHROPIC SKILL FORMAT" in prompt
+    # No context sections should appear
+    assert "skill_metadata.json" not in prompt
+    assert "trajectories/" not in prompt
+    assert "additional_context/" not in prompt
+
+
+def test_build_prompt_with_metadata():
+    prompt = build_runspace_prompt(
+        has_metadata=True, has_trajectories=False, has_additional_context=False
+    )
+    assert "skill_metadata.json" in prompt
+
+
+def test_build_prompt_with_trajectories():
+    prompt = build_runspace_prompt(
+        has_metadata=False, has_trajectories=True, has_additional_context=False
+    )
+    assert "trajectories/" in prompt
+    assert "reward" in prompt  # trajectory analysis instructions
+    assert "overfit" in prompt
+
+
+def test_build_prompt_with_additional_context():
+    prompt = build_runspace_prompt(
+        has_metadata=False, has_trajectories=False, has_additional_context=True
+    )
+    assert "additional_context/" in prompt
+
+
+def test_build_prompt_all_context():
+    prompt = build_runspace_prompt(
+        has_metadata=True, has_trajectories=True, has_additional_context=True
+    )
+    assert "skill_metadata.json" in prompt
+    assert "trajectories/" in prompt
+    assert "additional_context/" in prompt
+
+
+def test_build_prompt_contains_required_outputs_template():
+    prompt = build_runspace_prompt(
+        has_metadata=False, has_trajectories=False, has_additional_context=False
+    )
+    # The template JSON must appear verbatim in the prompt
+    for key in REQUIRED_OUTPUTS_TEMPLATE:
+        assert key in prompt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,6 +181,10 @@ plugin-sast = [
   "skillberry-plugin-sast>=0.1.0",
 ]
 
+plugin-skill-optimizer = [
+  "skillberry-plugin-skill-optimizer>=0.1.0",
+]
+
 # Install all plugins
 plugins-all = [
   "skillberry-plugin-creator>=0.2.0",
@@ -191,6 +195,7 @@ plugins-all = [
   "skillberry-plugin-anthropic-skill-generator>=0.1.0",
   "skillberry-plugin-kagenti-approver>=0.1.0",
   "skillberry-plugin-sast>=0.1.0",
+  "skillberry-plugin-skill-optimizer>=0.1.0",
 ]
 
 test = [
@@ -207,6 +212,7 @@ skillberry-plugin-mcp-importer = { path = "plugins/skillberry-plugin-mcp-importe
 skillberry-plugin-anthropic-skill-generator = { path = "plugins/skillberry-plugin-anthropic-skill-generator", editable = true }
 skillberry-plugin-kagenti-approver = { path = "plugins/skillberry-plugin-kagenti-approver", editable = true }
 skillberry-plugin-sast = { path = "plugins/skillberry-plugin-sast", editable = true }
+skillberry-plugin-skill-optimizer = { path = "plugins/skillberry-plugin-skill-optimizer", editable = true }
 llm-client = { path = "skillberry-common/packages/llm-client", editable = true }
 torch = { index = "pytorch-cpu" }
 


### PR DESCRIPTION
Closes #192.

## Summary
- New plugin `skillberry-plugin-skill-optimizer` (`PluginType.OPTIMIZER`) that exports an existing skill, runs a RunSpace Claude Code optimization session, and imports the result as a new skill
- `prompt.py` module owns the optimization prompt and `REQUIRED_OUTPUTS_TEMPLATE` contract (separated from orchestration for easier iteration)
- `plugin.py` orchestrates export → context staging → RunSpace → import → metadata write-back
- Registered in root `pyproject.toml` (`plugins-all` + `[tool.uv.sources]`)
- 34 tests covering naming, optimize_skill flow, router, UI config

## Design decisions
- Follows the Anthropic Skill Generator architecture exactly — same RunSpace wiring, same credential loading, same import path
- `optimize_skill_session()` extracted as module-level function for clean test patching
- Optimization metadata (rationale, tools changed, issues addressed, source skill UUID) written to the new skill's `extra.optimization` field
- `conversation.json` is polled live from the shared workspace volume and replayed to the logger the moment it appears — gives full step-by-step visibility without requiring changes to runspace-agent
- Container ID logged on start so operators can run `docker exec <id> ls /workspace/...` for live inspection

## Testing
- `cd plugins/skillberry-plugin-skill-optimizer && python -m pytest tests/ -v` → 34 passed

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>