### PR TITLE
feat: add Skill Provenance & Background plugin (#197)

### DIFF
--- a/plugins/skillberry-plugin-provenance/README.md
+++ b/plugins/skillberry-plugin-provenance/README.md
@@ -1,0 +1,70 @@
+# skillberry-plugin-provenance
+
+**Skill Provenance & Background** — gathers and displays the trust "background"
+of a skill so a user importing it (or auditing it later) has a basis for
+confidence. Addresses [#197](https://github.com/skillberry-ai/skillberry-store/issues/197).
+
+It answers five questions, the "top 5" pieces of background information:
+
+| # | Section      | Question                                   | Source |
+|---|--------------|--------------------------------------------|--------|
+| 1 | `provenance` | Where did it come from? (repo/ref/path pinned to a commit SHA) | GitHub API |
+| 2 | `publisher`  | Who published it, and is the source reputable? | GitHub API |
+| 3 | `license`    | Is it legally safe to use / redistribute?  | GitHub API |
+| 4 | `integrity`  | Is this the genuine, unmodified artifact?  | GitHub commit verification + local content hash |
+| 5 | `behavior`   | What does it reach out to or run?          | static pass over stored files + any SAST result |
+
+These roll up into a single `confidence` of **high / medium / low** with
+human-readable reasons.
+
+## Modes
+
+- **Pre-import** — call with a `github_url`; nothing needs to be stored yet.
+- **Post-import** — call with a skill `uuid`; origin is read from the skill's
+  `extra["origin"]` (captured at import time for GitHub URL imports).
+- **Drift / re-check** — `recheck` re-gathers and diffs against the baseline
+  stored in `extra["provenance"].baseline`, reporting what changed
+  (e.g. license, commit SHA, stars, archived).
+
+When a skill is imported from a GitHub URL, the plugin computes the background
+automatically on the `content_added:skill` event and stores it as the baseline.
+
+## API
+
+Mounted at `/plugins/provenance` by the store:
+
+- `POST /check`   — body `{ "github_url"?: str, "uuid"?: str }` → `{ success, message, data }`
+- `POST /recheck` — body `{ "uuid": str }` → `{ success, message, data: { drift, current, baseline } }`
+
+The store also exposes these under `/api/plugins/provenance/...` for the UI.
+
+## UI
+
+No custom UI: the plugin declares a single action via `get_ui_config()`, which
+the store's generic plugin action form renders (two optional text inputs, and a
+JSON view of the returned background). This mirrors the SAST plugin.
+
+## Install
+
+```bash
+pip install -e plugins/skillberry-plugin-provenance
+```
+
+## Test
+
+```bash
+pytest plugins/skillberry-plugin-provenance/tests -q
+```
+
+Tests are network-free: the GitHub mapping is exercised against captured JSON
+fixtures, and the plugin is exercised with a fake source and a mocked store.
+
+## Notes
+
+- Network calls are best-effort and time-boxed (30s); a rate-limited or failed
+  call degrades that section's `status` rather than failing the whole gather or
+  blocking an import.
+- This plugin is **informational** — it does not block or gate imports.
+- Auth for GitHub calls reuses the store's per-endpoint resolver
+  (`skillberry_store.tools.endpoint_auth.resolve_auth_headers`), so a configured
+  token or the `gh` CLI credentials are used automatically when present.

--- a/plugins/skillberry-plugin-provenance/pyproject.toml
+++ b/plugins/skillberry-plugin-provenance/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["setuptools>=45", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "skillberry-plugin-provenance"
+version = "0.1.0"
+description = "Skillberry Store plugin that gathers provenance, authenticity and legality background for imported skills"
+readme = "README.md"
+requires-python = ">=3.10"
+# requests is already a store dependency; the plugin adds no heavy deps.
+dependencies = ["requests"]
+
+[project.entry-points."skillberry_store.plugins"]
+provenance = "skillberry_plugin_provenance.plugin:SkillberryPluginProvenance"
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pytest-asyncio",
+    "httpx",
+    "fastapi",
+]
+
+[tool.setuptools]
+packages = [
+    "skillberry_plugin_provenance",
+    "skillberry_plugin_provenance.sources",
+]
+package-dir = {"" = "src"}

--- a/plugins/skillberry-plugin-provenance/src/skillberry_plugin_provenance/__init__.py
+++ b/plugins/skillberry-plugin-provenance/src/skillberry_plugin_provenance/__init__.py
@@ -1,0 +1,5 @@
+"""Skillberry Store plugin: Skill Provenance & Background."""
+
+from .plugin import SkillberryPluginProvenance
+
+__all__ = ["SkillberryPluginProvenance"]

--- a/plugins/skillberry-plugin-provenance/src/skillberry_plugin_provenance/plugin.py
+++ b/plugins/skillberry-plugin-provenance/src/skillberry_plugin_provenance/plugin.py
@@ -1,0 +1,493 @@
+"""
+Skillberry Plugin: Skill Provenance & Background.
+
+Gathers the trust "background" of a skill — where it came from, who published
+it, whether it is legally safe, whether the bytes are genuine, and what it
+reaches out to or runs — so an importer (or a later auditor) has a basis for
+confidence. See issue #197.
+
+Three modes, one code path:
+  - pre-import  : caller passes a ``github_url`` (nothing stored yet)
+  - post-import : caller passes a skill ``uuid`` (origin read from extra["origin"])
+  - drift       : ``recheck`` re-gathers and diffs against the stored baseline
+
+Like the SAST plugin, this is flag-only and never blocks an import: results are
+written to tags + ``extra["provenance"]`` and surfaced in the generic plugin UI.
+"""
+
+import hashlib
+import logging
+import re
+from typing import Any, Dict, List, Optional
+
+from skillberry_store.plugins.base import PluginBase, PluginMetadata, PluginType
+
+from .sources import resolve_source
+from .sources.base import Background
+
+logger = logging.getLogger(__name__)
+
+# Lightweight behavioral-risk heuristics over stored skill code. This is a
+# disclosure aid, not a scanner — the SAST plugin owns real static analysis,
+# and we cross-link its result when present.
+_URL_RE = re.compile(r"https?://[^\s\"'`)<>]+", re.IGNORECASE)
+_SENSITIVE_PATTERNS = {
+    "subprocess": re.compile(r"\b(subprocess|os\.system|os\.popen|pty\.spawn)\b"),
+    "network": re.compile(r"\b(requests|urllib|httpx|socket|aiohttp)\b"),
+    "filesystem": re.compile(r"\b(open\s*\(|shutil|pathlib|os\.remove|os\.unlink)\b"),
+    "eval_exec": re.compile(r"\b(eval|exec)\s*\("),
+}
+
+
+def _confidence_message(bg_dict: Dict[str, Any]) -> str:
+    """One-line verdict for the success banner in the generic UI."""
+    conf = (bg_dict.get("confidence") or "unknown").upper()
+    lic = (bg_dict.get("license") or {}).get("spdx_id") or "no license"
+    pub = bg_dict.get("publisher") or {}
+    who = pub.get("owner") or "unknown"
+    stars = pub.get("stars")
+    star_str = f", {stars}★" if isinstance(stars, int) else ""
+    return f"Confidence: {conf} — {who}{star_str}, license: {lic}"
+
+
+class SkillberryPluginProvenance(PluginBase):
+    """Gathers provenance / authenticity / legality background for skills."""
+
+    def __init__(self):
+        super().__init__()
+        self._metadata = PluginMetadata(
+            name="Skill Provenance & Background",
+            version="0.1.0",
+            description=(
+                "Gathers provenance, publisher reputation, license/legality, "
+                "content authenticity and behavioral-risk background for an "
+                "imported skill, with a rolled-up confidence rating."
+            ),
+            plugin_type=PluginType.EVALUATOR,
+        )
+        self._register_event_handlers()
+
+    # ── status / enablement ──────────────────────────────────────────────────
+
+    @property
+    def metadata(self) -> PluginMetadata:
+        return self._metadata
+
+    def is_enabled(self) -> bool:
+        # Always available: GitHub's anonymous API works without a key; a token
+        # only raises rate limits. Resolution degrades gracefully otherwise.
+        return True
+
+    def get_status_message(self) -> str:
+        return "Ready (GitHub provenance; uses configured/gh-CLI token if present)"
+
+    # ── event handler (auto-baseline on import) ──────────────────────────────
+
+    def _register_event_handlers(self) -> None:
+        """On skill add, if it carries an origin, compute & store the baseline.
+
+        Best-effort, mirrors the SAST auto-scan pattern; never blocks import.
+        """
+        from skillberry_store.plugins.events import _event_handlers
+
+        async def _handle_added(uuid: str):
+            if self._store_api is None:
+                return
+            try:
+                skill = self.store.get_skill(uuid)
+            except Exception:
+                skill = None
+            origin = ((skill or {}).get("extra") or {}).get("origin")
+            if not origin:
+                return  # not a URL import / nothing to base a check on
+            try:
+                await self.gather_background(uuid=uuid, persist_baseline=True)
+            except Exception as e:
+                logger.error(
+                    "Auto-provenance failed for skill %s: %s", uuid, e, exc_info=True
+                )
+
+        event_name = "content_added:skill"
+        _event_handlers.setdefault(event_name, []).append(_handle_added)
+
+    # ── origin resolution ────────────────────────────────────────────────────
+
+    def _origin_from_args(
+        self, url: Optional[str], uuid: Optional[str]
+    ) -> Dict[str, Any]:
+        """Build an origin dict from an explicit URL, or a stored skill's uuid.
+
+        Raises ValueError when neither yields a usable origin.
+        """
+        if url:
+            return {"type": "github", "url": url}
+        if uuid:
+            if self._store_api is None:
+                raise RuntimeError("Store API not available")
+            skill = self.store.get_skill(uuid)
+            if not skill:
+                raise ValueError(f"Skill {uuid} not found in store")
+            origin = (skill.get("extra") or {}).get("origin")
+            if not origin:
+                raise ValueError(
+                    f"Skill {uuid} has no recorded origin "
+                    "(import predates provenance capture, or was not a URL import). "
+                    "Pass github_url to check it."
+                )
+            return origin
+        raise ValueError("Provide either github_url or uuid")
+
+    # ── behavior (local, plugin-owned) ───────────────────────────────────────
+
+    def _gather_behavior(self, uuid: Optional[str]) -> Dict[str, Any]:
+        """Disclose external endpoints / sensitive ops / SAST cross-link.
+
+        Reads the skill's referenced tool/snippet code from the store. When no
+        uuid (pure pre-import URL check) we can't see content yet, so report
+        ``status: unavailable``.
+        """
+        if not uuid or self._store_api is None:
+            return {
+                "status": "unavailable",
+                "note": "content not in store yet (pre-import check)",
+            }
+        try:
+            skill = self.store.get_skill(uuid)
+        except Exception:
+            skill = None
+        if not skill:
+            return {"status": "unavailable"}
+
+        blobs = self._collect_skill_code(skill)
+        domains: set = set()
+        ops: set = set()
+        for code in blobs:
+            for m in _URL_RE.findall(code):
+                dom = re.sub(r"^https?://", "", m).split("/")[0]
+                if dom:
+                    domains.add(dom)
+            for op, pat in _SENSITIVE_PATTERNS.items():
+                if pat.search(code):
+                    ops.add(op)
+
+        # Cross-link an existing SAST result if the SAST plugin ran.
+        sast = ((skill.get("extra") or {}).get("evaluation") or {}).get("sast")
+        sast_summary = sast.get("summary") if isinstance(sast, dict) else None
+
+        return {
+            "status": "ok",
+            "external_domains": sorted(domains),
+            "sensitive_operations": sorted(ops),
+            "files_inspected": len(blobs),
+            "sast_summary": sast_summary,  # None if SAST has not run
+        }
+
+    def _collect_skill_code(self, skill: Dict[str, Any]) -> List[str]:
+        """Best-effort: gather code/content strings from a skill's children."""
+        out: List[str] = []
+        for tool_uuid in skill.get("tool_uuids") or []:
+            try:
+                tool = self.store.get_tool(tool_uuid)
+                module = (tool or {}).get("module_name")
+                if tool and module:
+                    out.append(
+                        self.store.tools.read_file(
+                            tool_uuid, module, raw_content=True
+                        )
+                    )
+            except Exception as e:
+                logger.debug("provenance: could not read tool %s: %s", tool_uuid, e)
+        for snippet_uuid in skill.get("snippet_uuids") or []:
+            try:
+                snippet = self.store.get_snippet(snippet_uuid)
+                content = (snippet or {}).get("content")
+                if content:
+                    out.append(content)
+            except Exception as e:
+                logger.debug(
+                    "provenance: could not read snippet %s: %s", snippet_uuid, e
+                )
+        return out
+
+    def _content_hashes(self, uuid: Optional[str]) -> Optional[Dict[str, str]]:
+        """SHA-256 of each stored child file — a record of the imported bytes."""
+        if not uuid or self._store_api is None:
+            return None
+        try:
+            skill = self.store.get_skill(uuid)
+        except Exception:
+            return None
+        if not skill:
+            return None
+        hashes: Dict[str, str] = {}
+        for tool_uuid in skill.get("tool_uuids") or []:
+            try:
+                tool = self.store.get_tool(tool_uuid)
+                module = (tool or {}).get("module_name")
+                if tool and module:
+                    code = self.store.tools.read_file(
+                        tool_uuid, module, raw_content=True
+                    )
+                    hashes[f"tool:{tool.get('name') or tool_uuid}"] = hashlib.sha256(
+                        code.encode("utf-8", "replace")
+                    ).hexdigest()
+            except Exception:
+                continue
+        for snippet_uuid in skill.get("snippet_uuids") or []:
+            try:
+                snippet = self.store.get_snippet(snippet_uuid)
+                content = (snippet or {}).get("content")
+                if content:
+                    hashes[
+                        f"snippet:{snippet.get('name') or snippet_uuid}"
+                    ] = hashlib.sha256(
+                        content.encode("utf-8", "replace")
+                    ).hexdigest()
+            except Exception:
+                continue
+        return hashes or None
+
+    # ── core gather ──────────────────────────────────────────────────────────
+
+    async def gather_background(
+        self,
+        url: Optional[str] = None,
+        uuid: Optional[str] = None,
+        persist_baseline: bool = False,
+    ) -> Dict[str, Any]:
+        """Gather the full background for a URL and/or stored skill uuid.
+
+        Returns the Background as a dict. When ``uuid`` is given, also fills the
+        behavior + integrity-hash sections from stored content and (optionally)
+        persists the result to the skill as the baseline.
+        """
+        origin = self._origin_from_args(url, uuid)
+        source = resolve_source(origin)
+        if source is None:
+            bg = Background(source="unknown")
+            bg.provenance = {
+                "status": "error",
+                "error": f"no provenance source for origin {origin!r}",
+            }
+            return bg.to_dict()
+
+        # Remote sections (network; degrades per-section on failure).
+        bg = source.gather(origin)
+
+        # Local sections the plugin owns (content it can see in the store).
+        bg.behavior = self._gather_behavior(uuid)
+        hashes = self._content_hashes(uuid)
+        if hashes is not None:
+            if not isinstance(bg.integrity, dict):
+                bg.integrity = {}
+            bg.integrity["content_sha256"] = hashes
+
+        result = bg.to_dict()
+        if uuid and persist_baseline:
+            try:
+                self._persist(uuid, result, is_baseline=True)
+            except Exception as e:
+                logger.error(
+                    "provenance: failed to persist baseline for %s: %s",
+                    uuid, e, exc_info=True,
+                )
+        return result
+
+    async def recheck(self, uuid: str) -> Dict[str, Any]:
+        """Re-gather background for a stored skill and diff against its baseline.
+
+        Returns ``{current, baseline, drift}`` where ``drift`` is a list of
+        human-readable change descriptors (empty when nothing material changed).
+        """
+        if self._store_api is None:
+            raise RuntimeError("Store API not available")
+        skill = self.store.get_skill(uuid)
+        if not skill:
+            raise ValueError(f"Skill {uuid} not found in store")
+        baseline = ((skill.get("extra") or {}).get("provenance") or {}).get("baseline")
+
+        current = await self.gather_background(uuid=uuid)
+        drift = _compute_drift(baseline, current)
+
+        # Record the latest check (and any drift) without losing the baseline.
+        try:
+            self._persist(uuid, current, is_baseline=baseline is None, drift=drift)
+        except Exception as e:
+            logger.error(
+                "provenance: failed to persist recheck for %s: %s",
+                uuid, e, exc_info=True,
+            )
+        return {"uuid": uuid, "drift": drift, "current": current, "baseline": baseline}
+
+    # ── persistence ──────────────────────────────────────────────────────────
+
+    def _persist(
+        self,
+        uuid: str,
+        background: Dict[str, Any],
+        is_baseline: bool,
+        drift: Optional[List[str]] = None,
+    ) -> None:
+        """Write background to the skill's tags + extra["provenance"]."""
+        skill = self.store.get_skill(uuid)
+        if not skill:
+            return
+        if not isinstance(skill.get("extra"), dict):
+            skill["extra"] = {}
+        prov = skill["extra"].get("provenance")
+        if not isinstance(prov, dict):
+            prov = {}
+        if is_baseline:
+            prov["baseline"] = background
+        prov["latest"] = background
+        if drift is not None:
+            prov["last_drift"] = drift
+        skill["extra"]["provenance"] = prov
+
+        skill["tags"] = self._provenance_tags(
+            self._strip_provenance_tags(skill.get("tags") or []), background, drift
+        )
+        self.store.skills.write_dict(uuid, skill)
+
+    @staticmethod
+    def _strip_provenance_tags(tags: List[str]) -> List[str]:
+        return [t for t in tags if not t.startswith("provenance:")]
+
+    @staticmethod
+    def _provenance_tags(
+        tags: List[str], background: Dict[str, Any], drift: Optional[List[str]]
+    ) -> List[str]:
+        out = list(tags)
+        out.append(f"provenance:confidence:{background.get('confidence', 'low')}")
+        lic = (background.get("license") or {}).get("spdx_id")
+        out.append(f"provenance:license:{lic or 'none'}")
+        if (background.get("integrity") or {}).get("commit_verified"):
+            out.append("provenance:verified")
+        if drift:
+            out.append("provenance:drift")
+        return out
+
+    # ── plugin interface ──────────────────────────────────────────────────────
+
+    def get_router(self):
+        from fastapi import APIRouter, HTTPException
+        from pydantic import BaseModel
+
+        router = APIRouter()
+
+        class CheckRequest(BaseModel):
+            github_url: Optional[str] = None
+            uuid: Optional[str] = None
+
+        class RecheckRequest(BaseModel):
+            uuid: str
+
+        @router.post("/check")
+        async def check_endpoint(request: CheckRequest):
+            """Gather provenance/background for a URL (pre-import) or uuid (post)."""
+            try:
+                data = await self.gather_background(
+                    url=request.github_url,
+                    uuid=request.uuid,
+                    persist_baseline=bool(request.uuid),
+                )
+            except ValueError as e:
+                raise HTTPException(status_code=404, detail=str(e))
+            except Exception as e:
+                logger.error("provenance check failed: %s", e, exc_info=True)
+                raise HTTPException(status_code=500, detail=str(e))
+            return {"success": True, "message": _confidence_message(data), "data": data}
+
+        @router.post("/recheck")
+        async def recheck_endpoint(request: RecheckRequest):
+            """Re-check a stored skill and report drift vs. its baseline."""
+            try:
+                data = await self.recheck(request.uuid)
+            except ValueError as e:
+                raise HTTPException(status_code=404, detail=str(e))
+            except Exception as e:
+                logger.error("provenance recheck failed: %s", e, exc_info=True)
+                raise HTTPException(status_code=500, detail=str(e))
+            drift = data.get("drift") or []
+            msg = "No drift since baseline" if not drift else f"{len(drift)} change(s) detected"
+            return {"success": True, "message": msg, "data": data}
+
+        return router
+
+    def get_cli_commands(self) -> Optional[Dict[str, Any]]:
+        return None
+
+    def get_ui_config(self) -> Optional[Dict[str, Any]]:
+        return {
+            "icon": "CatalogIcon",
+            "color": "#1E8E3E",
+            "actions": [
+                {
+                    "label": "Check provenance & background",
+                    "endpoint": "/api/plugins/provenance/check",
+                    "method": "POST",
+                    "params_schema": {
+                        "type": "object",
+                        "properties": {
+                            "github_url": {
+                                "type": "string",
+                                "description": (
+                                    "GitHub skill URL to check before importing "
+                                    "(pre-import)"
+                                ),
+                            },
+                            "uuid": {
+                                "type": "string",
+                                "description": (
+                                    "UUID of an already-imported skill to look up "
+                                    "(post-import)"
+                                ),
+                            },
+                        },
+                        "required": [],
+                    },
+                }
+            ],
+        }
+
+
+# ── drift diffing (standalone, unit-tested) ──────────────────────────────────
+
+
+def _compute_drift(
+    baseline: Optional[Dict[str, Any]], current: Dict[str, Any]
+) -> List[str]:
+    """Describe material changes from ``baseline`` to ``current``.
+
+    Returns an empty list when there is no baseline (nothing to compare) or no
+    material change. Watches the fields most relevant to a trust decision:
+    commit SHA, license, repo archival, star count, and per-file content hashes.
+    """
+    if not baseline:
+        return []
+    changes: List[str] = []
+
+    b_prov, c_prov = baseline.get("provenance") or {}, current.get("provenance") or {}
+    if b_prov.get("commit_sha") != c_prov.get("commit_sha"):
+        changes.append(
+            f"commit changed: {b_prov.get('commit_sha')} → {c_prov.get('commit_sha')}"
+        )
+
+    b_lic = (baseline.get("license") or {}).get("spdx_id")
+    c_lic = (current.get("license") or {}).get("spdx_id")
+    if b_lic != c_lic:
+        changes.append(f"license changed: {b_lic} → {c_lic}")
+
+    b_pub, c_pub = baseline.get("publisher") or {}, current.get("publisher") or {}
+    if b_pub.get("archived") != c_pub.get("archived"):
+        changes.append(
+            f"archived changed: {b_pub.get('archived')} → {c_pub.get('archived')}"
+        )
+
+    b_hash = (baseline.get("integrity") or {}).get("content_sha256") or {}
+    c_hash = (current.get("integrity") or {}).get("content_sha256") or {}
+    for key in set(b_hash) | set(c_hash):
+        if b_hash.get(key) != c_hash.get(key):
+            changes.append(f"content changed: {key}")
+
+    return changes

--- a/plugins/skillberry-plugin-provenance/src/skillberry_plugin_provenance/plugin.py
+++ b/plugins/skillberry-plugin-provenance/src/skillberry_plugin_provenance/plugin.py
@@ -15,6 +15,7 @@ Like the SAST plugin, this is flag-only and never blocks an import: results are
 written to tags + ``extra["provenance"]`` and surfaced in the generic plugin UI.
 """
 
+import asyncio
 import hashlib
 import logging
 import re
@@ -271,8 +272,9 @@ class SkillberryPluginProvenance(PluginBase):
             }
             return bg.to_dict()
 
-        # Remote sections (network; degrades per-section on failure).
-        bg = source.gather(origin)
+        # Remote sections (network; offloaded to a thread to avoid blocking the
+        # event loop — source.gather() uses synchronous requests.get()).
+        bg = await asyncio.to_thread(source.gather, origin)
 
         # Local sections the plugin owns (content it can see in the store).
         bg.behavior = self._gather_behavior(uuid)

--- a/plugins/skillberry-plugin-provenance/src/skillberry_plugin_provenance/sources/__init__.py
+++ b/plugins/skillberry-plugin-provenance/src/skillberry_plugin_provenance/sources/__init__.py
@@ -1,0 +1,29 @@
+"""Provenance source registry and resolution."""
+
+from typing import Any, Dict, List, Optional
+
+from .base import Background, ProvenanceSource, license_category
+from .github_source import GitHubSource, parse_github_origin
+
+# Ordered list of source classes. Resolution returns the first that matches.
+SOURCE_CLASSES = [GitHubSource]
+
+
+def resolve_source(origin: Dict[str, Any]) -> Optional[ProvenanceSource]:
+    """Return an instantiated source that can handle ``origin``, or None."""
+    for cls in SOURCE_CLASSES:
+        src = cls()
+        if src.matches(origin):
+            return src
+    return None
+
+
+__all__ = [
+    "Background",
+    "ProvenanceSource",
+    "GitHubSource",
+    "parse_github_origin",
+    "license_category",
+    "resolve_source",
+    "SOURCE_CLASSES",
+]

--- a/plugins/skillberry-plugin-provenance/src/skillberry_plugin_provenance/sources/base.py
+++ b/plugins/skillberry-plugin-provenance/src/skillberry_plugin_provenance/sources/base.py
@@ -1,0 +1,115 @@
+"""Source-agnostic interface and result shape for skill background gathering.
+
+A *source* knows how to gather background for an origin of a particular kind
+(GitHub today; other forges could be added). The normalized result is a
+``Background`` object whose five sections map 1:1 to the "top 5" pieces of
+information requested for an import trust decision:
+
+    1. provenance  - where it came from (repo/ref/path pinned to a commit)
+    2. publisher   - who published it and how reputable the source is
+    3. license     - whether it is legally safe to use / redistribute
+    4. integrity   - whether the bytes are genuine / unmodified
+    5. behavior    - what the skill reaches out to or runs
+
+plus a rolled-up ``confidence`` of "high" | "medium" | "low".
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+CONFIDENCE_HIGH = "high"
+CONFIDENCE_MEDIUM = "medium"
+CONFIDENCE_LOW = "low"
+
+# License categories used for the legality read-out.
+LICENSE_PERMISSIVE = "permissive"
+LICENSE_COPYLEFT = "copyleft"
+LICENSE_NONE = "none"
+LICENSE_UNKNOWN = "unknown"
+
+# Coarse SPDX -> category map for the common cases. Anything not listed and not
+# empty is reported as "unknown" so the user still sees the raw SPDX id.
+_PERMISSIVE_SPDX = {
+    "MIT", "APACHE-2.0", "BSD-2-CLAUSE", "BSD-3-CLAUSE", "ISC", "0BSD",
+    "UNLICENSE", "MPL-2.0", "ZLIB", "PYTHON-2.0",
+}
+_COPYLEFT_SPDX = {
+    "GPL-2.0", "GPL-3.0", "GPL-2.0-ONLY", "GPL-3.0-ONLY", "GPL-2.0-OR-LATER",
+    "GPL-3.0-OR-LATER", "LGPL-2.1", "LGPL-3.0", "AGPL-3.0", "AGPL-3.0-ONLY",
+    "AGPL-3.0-OR-LATER",
+}
+
+
+def license_category(spdx_id: Optional[str]) -> str:
+    """Classify an SPDX id into a coarse legality category.
+
+    Empty / missing -> "none"; recognized permissive/copyleft -> that category;
+    anything else (incl. GitHub's "NOASSERTION") -> "unknown".
+    """
+    if not spdx_id:
+        return LICENSE_NONE
+    key = spdx_id.strip().upper()
+    if key in ("", "NOASSERTION"):
+        return LICENSE_UNKNOWN if key == "NOASSERTION" else LICENSE_NONE
+    if key in _PERMISSIVE_SPDX:
+        return LICENSE_PERMISSIVE
+    if key in _COPYLEFT_SPDX:
+        return LICENSE_COPYLEFT
+    return LICENSE_UNKNOWN
+
+
+@dataclass
+class Background:
+    """Normalized "background" for a skill, across the five trust dimensions.
+
+    Every section is a plain dict so the whole object serializes cleanly for
+    the generic plugin UI and for storage in a skill's ``extra`` field. Each
+    section carries a ``status`` ("ok" | "unavailable" | "error") so a partial
+    failure (e.g. GitHub rate-limited the license call) degrades gracefully
+    rather than failing the whole gather.
+    """
+
+    source: str = ""
+    provenance: Dict[str, Any] = field(default_factory=dict)
+    publisher: Dict[str, Any] = field(default_factory=dict)
+    license: Dict[str, Any] = field(default_factory=dict)
+    integrity: Dict[str, Any] = field(default_factory=dict)
+    behavior: Dict[str, Any] = field(default_factory=dict)
+    confidence: str = CONFIDENCE_LOW
+    confidence_reasons: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "source": self.source,
+            "confidence": self.confidence,
+            "confidence_reasons": self.confidence_reasons,
+            "provenance": self.provenance,
+            "publisher": self.publisher,
+            "license": self.license,
+            "integrity": self.integrity,
+            "behavior": self.behavior,
+        }
+
+
+class ProvenanceSource(ABC):
+    """Gathers background for origins of a particular kind (e.g. GitHub)."""
+
+    #: short, stable identifier (e.g. "github").
+    name: str = ""
+
+    @abstractmethod
+    def matches(self, origin: Dict[str, Any]) -> bool:
+        """Return True if this source can handle ``origin`` (by type/url)."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def gather(self, origin: Dict[str, Any]) -> Background:
+        """Gather background for ``origin``.
+
+        Implementations must not raise for *expected* remote failures (rate
+        limit, 404, network) — they record a per-section ``status`` instead and
+        return a partial ``Background``. Raising is reserved for programmer
+        errors (e.g. an origin this source does not match).
+        """
+        raise NotImplementedError

--- a/plugins/skillberry-plugin-provenance/src/skillberry_plugin_provenance/sources/github_source.py
+++ b/plugins/skillberry-plugin-provenance/src/skillberry_plugin_provenance/sources/github_source.py
@@ -13,6 +13,7 @@ import logging
 import re
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
 
 import requests
 
@@ -253,7 +254,8 @@ class GitHubSource(ProvenanceSource):
         if origin.get("type") == "github":
             return True
         url = origin.get("url") or ""
-        return "github.com" in url
+        host = (urlparse(url).hostname or "").lower()
+        return host == "github.com" or host.endswith(".github.com")
 
     def _normalize_origin(self, origin: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Ensure owner/repo/ref/path are present, parsing from url if needed."""

--- a/plugins/skillberry-plugin-provenance/src/skillberry_plugin_provenance/sources/github_source.py
+++ b/plugins/skillberry-plugin-provenance/src/skillberry_plugin_provenance/sources/github_source.py
@@ -1,0 +1,337 @@
+"""GitHub provenance source.
+
+Resolves a github.com skill URL into the four "background" dimensions a source
+can answer remotely (provenance, publisher, license, integrity), using the
+GitHub REST API. Auth headers are resolved through the store's existing
+per-endpoint resolver so the gh-CLI token / configured tokens are reused.
+
+The JSON -> Background mapping is kept in standalone, network-free functions
+(``build_*``) so they can be unit-tested against captured API fixtures.
+"""
+
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+
+from .base import (
+    Background,
+    CONFIDENCE_HIGH,
+    CONFIDENCE_LOW,
+    CONFIDENCE_MEDIUM,
+    LICENSE_COPYLEFT,
+    LICENSE_NONE,
+    LICENSE_UNKNOWN,
+    ProvenanceSource,
+    license_category,
+)
+
+logger = logging.getLogger(__name__)
+
+_API = "https://api.github.com"
+_TIMEOUT = 30  # match importer.py's GitHub timeout
+
+# github.com/<owner>/<repo>[/tree/<ref>/<path...>]
+_URL_RE = re.compile(
+    r"github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)"
+    r"(?:/tree/(?P<ref>[^/]+)(?:/(?P<path>.*))?)?",
+    re.IGNORECASE,
+)
+
+
+def parse_github_origin(url: str) -> Optional[Dict[str, Any]]:
+    """Parse a github.com URL into ``{owner, repo, ref, path}``.
+
+    ``ref`` defaults to "main" and ``path`` to "" when the URL is a bare repo.
+    A trailing ".git" on the repo is stripped. Returns ``None`` when the URL is
+    not a recognizable github.com URL.
+    """
+    if not url:
+        return None
+    m = _URL_RE.search(url)
+    if not m:
+        return None
+    repo = (m.group("repo") or "").removesuffix(".git")
+    if not repo:
+        return None
+    return {
+        "owner": m.group("owner"),
+        "repo": repo,
+        "ref": m.group("ref") or "main",
+        "path": (m.group("path") or "").strip("/"),
+    }
+
+
+def _age_days(iso_ts: Optional[str]) -> Optional[int]:
+    """Whole days between an ISO-8601 GitHub timestamp and ``now`` (UTC)."""
+    if not iso_ts:
+        return None
+    try:
+        ts = datetime.fromisoformat(iso_ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return (datetime.now(timezone.utc) - ts).days
+
+
+# ── pure mappers (no network; unit-tested against fixtures) ──────────────────
+
+
+def build_provenance(
+    origin: Dict[str, Any], commit: Optional[Dict[str, Any]]
+) -> Dict[str, Any]:
+    """Provenance section from origin + the resolved HEAD commit for the path."""
+    owner, repo = origin.get("owner"), origin.get("repo")
+    ref, path = origin.get("ref"), origin.get("path") or ""
+    sha = (commit or {}).get("sha")
+    out: Dict[str, Any] = {
+        "status": "ok" if owner and repo else "error",
+        "type": "github",
+        "owner": owner,
+        "repo": repo,
+        "ref": ref,
+        "path": path,
+        "commit_sha": sha,
+        "committed_at": (
+            ((commit or {}).get("commit") or {}).get("committer") or {}
+        ).get("date"),
+        "url": f"https://github.com/{owner}/{repo}/tree/{ref}/{path}".rstrip("/"),
+    }
+    if sha:
+        out["permalink"] = (
+            f"https://github.com/{owner}/{repo}/tree/{sha}/{path}".rstrip("/")
+        )
+    return out
+
+
+def build_publisher(repo_json: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Publisher / repository-reputation section from `GET /repos/{o}/{r}`."""
+    if not repo_json:
+        return {"status": "unavailable"}
+    owner = repo_json.get("owner") or {}
+    pushed_at = repo_json.get("pushed_at")
+    return {
+        "status": "ok",
+        "owner": owner.get("login"),
+        "owner_type": owner.get("type"),  # "User" | "Organization"
+        "stars": repo_json.get("stargazers_count"),
+        "forks": repo_json.get("forks_count"),
+        "open_issues": repo_json.get("open_issues_count"),
+        "archived": repo_json.get("archived"),
+        "created_at": repo_json.get("created_at"),
+        "repo_age_days": _age_days(repo_json.get("created_at")),
+        "last_pushed_at": pushed_at,
+        "days_since_push": _age_days(pushed_at),
+    }
+
+
+def build_license(license_json: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """License / legality section from `GET /repos/{o}/{r}/license`.
+
+    A 404 (no license file) is represented by passing ``None`` here, which maps
+    to the "none" category — i.e. all rights reserved, not safe to redistribute.
+    """
+    if not license_json:
+        return {
+            "status": "ok",
+            "spdx_id": None,
+            "category": LICENSE_NONE,
+            "note": "No license detected — treat as all rights reserved.",
+        }
+    lic = license_json.get("license") or {}
+    spdx = lic.get("spdx_id")
+    return {
+        "status": "ok",
+        "spdx_id": spdx,
+        "name": lic.get("name"),
+        "category": license_category(spdx),
+        "detected_in": license_json.get("name"),  # e.g. "LICENSE"
+    }
+
+
+def build_integrity(commit: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Authenticity section from the commit's signature verification block.
+
+    Per-file content hashing is added by the plugin (it owns the stored bytes);
+    here we surface whether the pinned commit is cryptographically verified.
+    """
+    if not commit:
+        return {"status": "unavailable", "commit_verified": None}
+    verification = (commit.get("commit") or {}).get("verification") or {}
+    return {
+        "status": "ok",
+        "commit_sha": commit.get("sha"),
+        "commit_verified": verification.get("verified"),
+        "verification_reason": verification.get("reason"),
+    }
+
+
+def assess_confidence(bg: Background) -> Tuple[str, List[str]]:
+    """Roll the sections up into high/medium/low with human-readable reasons.
+
+    Conservative by design: anything legally or authenticity-wise unclear caps
+    confidence. Reputation nudges within the remaining band.
+    """
+    reasons: List[str] = []
+    lic_cat = bg.license.get("category")
+    publisher = bg.publisher
+    verified = bg.integrity.get("commit_verified")
+
+    # Legality is a hard cap.
+    if lic_cat in (LICENSE_NONE, LICENSE_UNKNOWN):
+        reasons.append(
+            "no/unclear license — redistribution may be restricted"
+        )
+        ceiling = CONFIDENCE_LOW if lic_cat == LICENSE_NONE else CONFIDENCE_MEDIUM
+    elif lic_cat == LICENSE_COPYLEFT:
+        reasons.append("copyleft license — carries redistribution obligations")
+        ceiling = CONFIDENCE_MEDIUM
+    else:
+        ceiling = CONFIDENCE_HIGH
+
+    # Reputation signals.
+    rep = CONFIDENCE_LOW
+    if publisher.get("status") == "ok":
+        stars = publisher.get("stars") or 0
+        age = publisher.get("repo_age_days")
+        is_org = publisher.get("owner_type") == "Organization"
+        if (stars >= 100 or is_org) and (age is not None and age >= 180):
+            rep = CONFIDENCE_HIGH
+            reasons.append(
+                f"established source ({'org, ' if is_org else ''}{stars}★)"
+            )
+        elif age is not None and age >= 30:
+            rep = CONFIDENCE_MEDIUM
+            reasons.append("moderately established source")
+        else:
+            reasons.append("new or low-signal source")
+    else:
+        reasons.append("publisher info unavailable")
+
+    if verified:
+        reasons.append("commit signature verified")
+    elif verified is False:
+        reasons.append("commit not signature-verified")
+
+    order = {CONFIDENCE_LOW: 0, CONFIDENCE_MEDIUM: 1, CONFIDENCE_HIGH: 2}
+    final = min(ceiling, rep, key=lambda c: order[c])
+    return final, reasons
+
+
+def build_background(
+    origin: Dict[str, Any],
+    repo_json: Optional[Dict[str, Any]],
+    license_json: Optional[Dict[str, Any]],
+    commit: Optional[Dict[str, Any]],
+) -> Background:
+    """Assemble a full Background (minus the plugin-owned behavior section)."""
+    bg = Background(source="github")
+    bg.provenance = build_provenance(origin, commit)
+    bg.publisher = build_publisher(repo_json)
+    bg.license = build_license(license_json)
+    bg.integrity = build_integrity(commit)
+    bg.confidence, bg.confidence_reasons = assess_confidence(bg)
+    return bg
+
+
+class GitHubSource(ProvenanceSource):
+    """Gather background for github.com origins via the GitHub REST API."""
+
+    name = "github"
+
+    def __init__(self, header_resolver=None):
+        """``header_resolver(url) -> dict`` supplies Authorization headers.
+
+        Defaults to the store's per-endpoint resolver; injectable for tests.
+        """
+        self._resolve_headers = header_resolver or _default_header_resolver
+
+    def matches(self, origin: Dict[str, Any]) -> bool:
+        if not origin:
+            return False
+        if origin.get("type") == "github":
+            return True
+        url = origin.get("url") or ""
+        return "github.com" in url
+
+    def _normalize_origin(self, origin: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Ensure owner/repo/ref/path are present, parsing from url if needed."""
+        if origin.get("owner") and origin.get("repo"):
+            return {
+                "owner": origin["owner"],
+                "repo": origin["repo"],
+                "ref": origin.get("ref") or "main",
+                "path": (origin.get("path") or "").strip("/"),
+            }
+        return parse_github_origin(origin.get("url") or "")
+
+    def _get_json(self, url: str, headers: Dict[str, str]) -> Tuple[Optional[Any], Optional[str]]:
+        """GET ``url`` and return (json, error). Never raises on HTTP/network."""
+        try:
+            resp = requests.get(url, headers=headers, timeout=_TIMEOUT)
+        except requests.RequestException as e:
+            return None, str(e)
+        if resp.status_code == 404:
+            return None, "404"
+        if not resp.ok:
+            return None, f"{resp.status_code}: {resp.reason}"
+        try:
+            return resp.json(), None
+        except ValueError as e:
+            return None, f"bad json: {e}"
+
+    def gather(self, origin: Dict[str, Any]) -> Background:
+        norm = self._normalize_origin(origin)
+        if not norm:
+            bg = Background(source="github")
+            bg.provenance = {"status": "error", "error": "unparseable github origin"}
+            bg.confidence_reasons = ["could not parse origin URL"]
+            return bg
+
+        owner, repo = norm["owner"], norm["repo"]
+        ref, path = norm["ref"], norm["path"]
+        url_for_auth = f"https://github.com/{owner}/{repo}"
+        try:
+            headers = self._resolve_headers(url_for_auth)
+        except Exception as e:  # forced-reauth etc. — degrade, don't crash
+            logger.info("provenance: header resolution failed: %s", e)
+            headers = {}
+        headers = {**(headers or {}), "Accept": "application/vnd.github+json"}
+
+        repo_json, repo_err = self._get_json(f"{_API}/repos/{owner}/{repo}", headers)
+        license_json, _lic_err = self._get_json(
+            f"{_API}/repos/{owner}/{repo}/license", headers
+        )
+        commits_url = (
+            f"{_API}/repos/{owner}/{repo}/commits"
+            f"?path={path}&sha={ref}&per_page=1"
+        )
+        commits_json, _commit_err = self._get_json(commits_url, headers)
+        commit = (
+            commits_json[0]
+            if isinstance(commits_json, list) and commits_json
+            else None
+        )
+
+        bg = build_background(norm, repo_json, license_json, commit)
+        if repo_err and repo_err != "404":
+            bg.publisher = {"status": "error", "error": repo_err}
+            # re-roll confidence now that publisher is unknown
+            bg.confidence, bg.confidence_reasons = assess_confidence(bg)
+        return bg
+
+
+def _default_header_resolver(url: str) -> Dict[str, str]:
+    """Resolve auth headers via the store's per-endpoint resolver (gh CLI etc.).
+
+    Imported lazily so the plugin/source can be unit-tested without the store
+    package importable.
+    """
+    from skillberry_store.tools.endpoint_auth import resolve_auth_headers
+
+    try:
+        return resolve_auth_headers(url)
+    except Exception:
+        # ReauthRequired / OAuthRequired / missing config -> anonymous.
+        return {}

--- a/plugins/skillberry-plugin-provenance/src/skillberry_plugin_provenance/sources/github_source.py
+++ b/plugins/skillberry-plugin-provenance/src/skillberry_plugin_provenance/sources/github_source.py
@@ -10,12 +10,13 @@ The JSON -> Background mapping is kept in standalone, network-free functions
 """
 
 import logging
-import re
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
 import requests
+
+from skillberry_store.tools.anthropic.importer import parse_github_origin
 
 from .base import (
     Background,
@@ -33,36 +34,6 @@ logger = logging.getLogger(__name__)
 
 _API = "https://api.github.com"
 _TIMEOUT = 30  # match importer.py's GitHub timeout
-
-# github.com/<owner>/<repo>[/tree/<ref>/<path...>]
-_URL_RE = re.compile(
-    r"github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)"
-    r"(?:/tree/(?P<ref>[^/]+)(?:/(?P<path>.*))?)?",
-    re.IGNORECASE,
-)
-
-
-def parse_github_origin(url: str) -> Optional[Dict[str, Any]]:
-    """Parse a github.com URL into ``{owner, repo, ref, path}``.
-
-    ``ref`` defaults to "main" and ``path`` to "" when the URL is a bare repo.
-    A trailing ".git" on the repo is stripped. Returns ``None`` when the URL is
-    not a recognizable github.com URL.
-    """
-    if not url:
-        return None
-    m = _URL_RE.search(url)
-    if not m:
-        return None
-    repo = (m.group("repo") or "").removesuffix(".git")
-    if not repo:
-        return None
-    return {
-        "owner": m.group("owner"),
-        "repo": repo,
-        "ref": m.group("ref") or "main",
-        "path": (m.group("path") or "").strip("/"),
-    }
 
 
 def _age_days(iso_ts: Optional[str]) -> Optional[int]:

--- a/plugins/skillberry-plugin-provenance/tests/test_github_source.py
+++ b/plugins/skillberry-plugin-provenance/tests/test_github_source.py
@@ -176,6 +176,9 @@ def test_github_source_matches():
     assert src.matches({"type": "github"})
     assert src.matches({"url": "https://github.com/a/b"})
     assert not src.matches({"url": "https://gitlab.com/a/b"})
+    # host must be parsed, not substring-matched: reject look-alike / path tricks
+    assert not src.matches({"url": "https://evil.example.com/github.com/a/b"})
+    assert not src.matches({"url": "https://github.com.attacker.com/a/b"})
 
 
 def test_github_source_gather_with_mocked_requests(monkeypatch):

--- a/plugins/skillberry-plugin-provenance/tests/test_github_source.py
+++ b/plugins/skillberry-plugin-provenance/tests/test_github_source.py
@@ -1,0 +1,212 @@
+"""Network-free tests for the GitHub provenance source (pure mappers)."""
+
+from skillberry_plugin_provenance.sources.base import (
+    CONFIDENCE_HIGH,
+    CONFIDENCE_LOW,
+    CONFIDENCE_MEDIUM,
+    LICENSE_COPYLEFT,
+    LICENSE_NONE,
+    LICENSE_PERMISSIVE,
+    license_category,
+)
+from skillberry_plugin_provenance.sources.github_source import (
+    GitHubSource,
+    assess_confidence,
+    build_background,
+    build_license,
+    build_provenance,
+    build_publisher,
+    parse_github_origin,
+)
+
+# ── captured-shape API fixtures (trimmed) ────────────────────────────────────
+
+_REPO_JSON = {
+    "name": "skills",
+    "stargazers_count": 4200,
+    "forks_count": 300,
+    "open_issues_count": 12,
+    "archived": False,
+    "created_at": "2020-01-01T00:00:00Z",
+    "pushed_at": "2026-06-01T00:00:00Z",
+    "owner": {"login": "anthropics", "type": "Organization"},
+}
+
+_LICENSE_JSON = {
+    "name": "LICENSE",
+    "license": {"spdx_id": "MIT", "name": "MIT License"},
+}
+
+_COMMIT_JSON = {
+    "sha": "abc123def456",
+    "commit": {
+        "committer": {"date": "2026-05-20T10:00:00Z"},
+        "verification": {"verified": True, "reason": "valid"},
+    },
+}
+
+
+# ── url parsing ──────────────────────────────────────────────────────────────
+
+
+def test_parse_github_origin_full_tree_url():
+    o = parse_github_origin(
+        "https://github.com/anthropics/skills/tree/main/document-skills/pptx"
+    )
+    assert o == {
+        "owner": "anthropics",
+        "repo": "skills",
+        "ref": "main",
+        "path": "document-skills/pptx",
+    }
+
+
+def test_parse_github_origin_bare_repo_defaults():
+    o = parse_github_origin("https://github.com/octocat/Hello-World.git")
+    assert o == {"owner": "octocat", "repo": "Hello-World", "ref": "main", "path": ""}
+
+
+def test_parse_github_origin_non_github_returns_none():
+    assert parse_github_origin("https://example.com/x/y") is None
+    assert parse_github_origin("") is None
+
+
+# ── license classification ───────────────────────────────────────────────────
+
+
+def test_license_category_mapping():
+    assert license_category("MIT") == LICENSE_PERMISSIVE
+    assert license_category("Apache-2.0") == LICENSE_PERMISSIVE
+    assert license_category("GPL-3.0") == LICENSE_COPYLEFT
+    assert license_category("AGPL-3.0") == LICENSE_COPYLEFT
+    assert license_category(None) == LICENSE_NONE
+    assert license_category("NOASSERTION") == "unknown"
+
+
+def test_build_license_none_when_missing():
+    lic = build_license(None)
+    assert lic["category"] == LICENSE_NONE
+    assert lic["spdx_id"] is None
+    assert "all rights reserved" in lic["note"].lower()
+
+
+# ── section mappers ──────────────────────────────────────────────────────────
+
+
+def test_build_provenance_pins_commit_and_permalink():
+    origin = {"owner": "anthropics", "repo": "skills", "ref": "main", "path": "x"}
+    prov = build_provenance(origin, _COMMIT_JSON)
+    assert prov["status"] == "ok"
+    assert prov["commit_sha"] == "abc123def456"
+    assert prov["permalink"].endswith("/tree/abc123def456/x")
+    assert prov["committed_at"] == "2026-05-20T10:00:00Z"
+
+
+def test_build_publisher_extracts_signals():
+    pub = build_publisher(_REPO_JSON)
+    assert pub["status"] == "ok"
+    assert pub["owner"] == "anthropics"
+    assert pub["owner_type"] == "Organization"
+    assert pub["stars"] == 4200
+    assert pub["repo_age_days"] is not None and pub["repo_age_days"] > 0
+
+
+def test_build_publisher_unavailable_when_missing():
+    assert build_publisher(None)["status"] == "unavailable"
+
+
+# ── confidence rollup ────────────────────────────────────────────────────────
+
+
+def test_confidence_high_for_reputable_permissive_verified():
+    bg = build_background(
+        {"owner": "anthropics", "repo": "skills", "ref": "main", "path": ""},
+        _REPO_JSON,
+        _LICENSE_JSON,
+        _COMMIT_JSON,
+    )
+    assert bg.confidence == CONFIDENCE_HIGH
+    assert bg.license["category"] == LICENSE_PERMISSIVE
+    assert bg.integrity["commit_verified"] is True
+
+
+def test_confidence_low_when_no_license():
+    bg = build_background(
+        {"owner": "x", "repo": "y", "ref": "main", "path": ""},
+        _REPO_JSON,
+        None,  # no license file
+        _COMMIT_JSON,
+    )
+    assert bg.confidence == CONFIDENCE_LOW
+    assert any("license" in r for r in bg.confidence_reasons)
+
+
+def test_confidence_medium_for_copyleft_reputable():
+    gpl = {"name": "LICENSE", "license": {"spdx_id": "GPL-3.0", "name": "GPL 3"}}
+    bg = build_background(
+        {"owner": "x", "repo": "y", "ref": "main", "path": ""},
+        _REPO_JSON,
+        gpl,
+        _COMMIT_JSON,
+    )
+    assert bg.confidence == CONFIDENCE_MEDIUM
+
+
+def test_assess_confidence_new_anonymous_repo_is_low():
+    fresh = {
+        "stargazers_count": 0,
+        "owner": {"login": "newbie", "type": "User"},
+        "created_at": "2026-06-10T00:00:00Z",  # days old
+        "pushed_at": "2026-06-12T00:00:00Z",
+    }
+    bg = build_background(
+        {"owner": "newbie", "repo": "z", "ref": "main", "path": ""},
+        fresh,
+        _LICENSE_JSON,  # permissive, so legality doesn't cap
+        {"sha": "s", "commit": {"verification": {"verified": False}}},
+    )
+    assert bg.confidence == CONFIDENCE_LOW
+
+
+# ── source wiring (mocked HTTP) ──────────────────────────────────────────────
+
+
+def test_github_source_matches():
+    src = GitHubSource(header_resolver=lambda url: {})
+    assert src.matches({"type": "github"})
+    assert src.matches({"url": "https://github.com/a/b"})
+    assert not src.matches({"url": "https://gitlab.com/a/b"})
+
+
+def test_github_source_gather_with_mocked_requests(monkeypatch):
+    """gather() should stitch the three API calls into a Background."""
+    import skillberry_plugin_provenance.sources.github_source as gh
+
+    class _Resp:
+        def __init__(self, status, payload):
+            self.status_code = status
+            self.ok = 200 <= status < 300
+            self.reason = "OK"
+            self._payload = payload
+
+        def json(self):
+            return self._payload
+
+    def fake_get(url, headers=None, timeout=None):
+        if url.endswith("/repos/anthropics/skills"):
+            return _Resp(200, _REPO_JSON)
+        if url.endswith("/license"):
+            return _Resp(200, _LICENSE_JSON)
+        if "/commits" in url:
+            return _Resp(200, [_COMMIT_JSON])
+        return _Resp(404, {})
+
+    monkeypatch.setattr(gh.requests, "get", fake_get)
+    src = GitHubSource(header_resolver=lambda url: {"Authorization": "Bearer x"})
+    bg = src.gather(
+        {"type": "github", "url": "https://github.com/anthropics/skills/tree/main/x"}
+    )
+    assert bg.provenance["commit_sha"] == "abc123def456"
+    assert bg.publisher["owner"] == "anthropics"
+    assert bg.license["spdx_id"] == "MIT"
+    assert bg.confidence == CONFIDENCE_HIGH

--- a/plugins/skillberry-plugin-provenance/tests/test_provenance_plugin.py
+++ b/plugins/skillberry-plugin-provenance/tests/test_provenance_plugin.py
@@ -1,0 +1,261 @@
+"""Tests for the provenance plugin (fake source + mocked store, no network)."""
+
+import contextlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from skillberry_plugin_provenance.plugin import (
+    SkillberryPluginProvenance,
+    _compute_drift,
+)
+from skillberry_plugin_provenance.sources.base import Background
+from skillberry_store.plugins.base import PluginType
+
+# ── a fake source so the plugin never hits the network ───────────────────────
+
+
+def _fake_background(confidence="high", spdx="MIT", verified=True):
+    bg = Background(source="github")
+    bg.provenance = {"status": "ok", "commit_sha": "sha1", "owner": "anthropics"}
+    bg.publisher = {"status": "ok", "owner": "anthropics", "stars": 4200,
+                    "owner_type": "Organization", "archived": False}
+    bg.license = {"status": "ok", "spdx_id": spdx, "category": "permissive"}
+    bg.integrity = {"status": "ok", "commit_verified": verified}
+    bg.confidence = confidence
+    return bg
+
+
+class _FakeSource:
+    name = "github"
+
+    def __init__(self, bg=None):
+        self._bg = bg or _fake_background()
+
+    def matches(self, origin):
+        return True
+
+    def gather(self, origin):
+        return self._bg
+
+
+@contextlib.contextmanager
+def _make_plugin(source=None):
+    """Yield a plugin with resolve_source patched to a fake source."""
+    src = source or _FakeSource()
+    with patch(
+        "skillberry_plugin_provenance.plugin.resolve_source",
+        lambda origin: src,
+    ):
+        yield SkillberryPluginProvenance()
+
+
+def _mock_store(skill=None):
+    store = MagicMock()
+    store.get_skill.return_value = skill
+    store.get_tool.return_value = None
+    store.get_snippet.return_value = None
+    store.skills = MagicMock()
+    store.skills.write_dict.return_value = {"success": True}
+    store.tools = MagicMock()
+    return store
+
+
+# ── metadata / enablement ────────────────────────────────────────────────────
+
+
+def test_metadata():
+    with _make_plugin() as plugin:
+        md = plugin.metadata
+        assert md.name == "Skill Provenance & Background"
+        assert md.plugin_type == PluginType.EVALUATOR
+        assert plugin.is_enabled() is True
+
+
+# ── gather: pre-import (url) ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_gather_pre_import_url_no_store():
+    with _make_plugin() as plugin:
+        # no store needed for a pure url check; behavior degrades to unavailable
+        data = await plugin.gather_background(url="https://github.com/anthropics/skills")
+        assert data["confidence"] == "high"
+        assert data["license"]["spdx_id"] == "MIT"
+        assert data["behavior"]["status"] == "unavailable"
+
+
+# ── gather: post-import (uuid) reads origin + persists baseline ──────────────
+
+
+@pytest.mark.asyncio
+async def test_gather_post_import_persists_baseline_and_tags():
+    skill = {
+        "uuid": "s1",
+        "name": "pptx",
+        "tags": ["anthropic", "imported"],
+        "extra": {"origin": {"type": "github", "url": "https://github.com/anthropics/skills"}},
+        "tool_uuids": [],
+        "snippet_uuids": [],
+    }
+    store = _mock_store(skill=skill)
+    with _make_plugin() as plugin:
+        plugin.set_store_api(store)
+        data = await plugin.gather_background(uuid="s1", persist_baseline=True)
+
+    assert data["confidence"] == "high"
+    # persisted into extra["provenance"].baseline + latest
+    written = store.skills.write_dict.call_args[0][1]
+    assert written["extra"]["provenance"]["baseline"]["confidence"] == "high"
+    assert written["extra"]["provenance"]["latest"]["confidence"] == "high"
+    # roll-up tags added, old provenance tags would be stripped
+    assert "provenance:confidence:high" in written["tags"]
+    assert "provenance:license:MIT" in written["tags"]
+    assert "provenance:verified" in written["tags"]
+    # original tags preserved
+    assert "anthropic" in written["tags"]
+
+
+@pytest.mark.asyncio
+async def test_gather_uuid_without_origin_raises_valueerror():
+    skill = {"uuid": "s2", "name": "x", "tags": [], "extra": {}}
+    store = _mock_store(skill=skill)
+    with _make_plugin() as plugin:
+        plugin.set_store_api(store)
+        with pytest.raises(ValueError):
+            await plugin.gather_background(uuid="s2")
+
+
+# ── behavior section over child code ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_behavior_detects_domains_and_ops():
+    skill = {
+        "uuid": "s3", "name": "x", "tags": [],
+        "extra": {"origin": {"type": "github", "url": "https://github.com/a/b"},
+                  "evaluation": {"sast": {"summary": {"high": 1}}}},
+        "tool_uuids": ["t1"], "snippet_uuids": [],
+    }
+    store = _mock_store(skill=skill)
+    store.get_tool.return_value = {"uuid": "t1", "name": "t", "module_name": "tool.py"}
+    store.tools.read_file.return_value = (
+        "import requests\nrequests.get('https://evil.example.com/x')\n"
+        "import subprocess\nsubprocess.run(['ls'])\n"
+    )
+    with _make_plugin() as plugin:
+        plugin.set_store_api(store)
+        data = await plugin.gather_background(uuid="s3")
+
+    beh = data["behavior"]
+    assert beh["status"] == "ok"
+    assert "evil.example.com" in beh["external_domains"]
+    assert "network" in beh["sensitive_operations"]
+    assert "subprocess" in beh["sensitive_operations"]
+    assert beh["sast_summary"] == {"high": 1}
+    # integrity gains a per-file content hash
+    assert "content_sha256" in data["integrity"]
+
+
+# ── drift ────────────────────────────────────────────────────────────────────
+
+
+def test_compute_drift_none_baseline_is_empty():
+    assert _compute_drift(None, {"provenance": {}}) == []
+
+
+def test_compute_drift_detects_commit_license_content():
+    baseline = {
+        "provenance": {"commit_sha": "old"},
+        "license": {"spdx_id": "MIT"},
+        "publisher": {"archived": False},
+        "integrity": {"content_sha256": {"tool:t": "h1"}},
+    }
+    current = {
+        "provenance": {"commit_sha": "new"},
+        "license": {"spdx_id": None},
+        "publisher": {"archived": True},
+        "integrity": {"content_sha256": {"tool:t": "h2"}},
+    }
+    drift = _compute_drift(baseline, current)
+    assert any("commit changed" in d for d in drift)
+    assert any("license changed" in d for d in drift)
+    assert any("archived changed" in d for d in drift)
+    assert any("content changed" in d for d in drift)
+
+
+@pytest.mark.asyncio
+async def test_recheck_reports_no_drift_against_matching_baseline():
+    bg = _fake_background()
+    baseline = bg.to_dict()
+    # give the stored skill a matching baseline (and an origin)
+    skill = {
+        "uuid": "s4", "name": "x", "tags": [],
+        "extra": {
+            "origin": {"type": "github", "url": "https://github.com/a/b"},
+            "provenance": {"baseline": baseline},
+        },
+        "tool_uuids": [], "snippet_uuids": [],
+    }
+    store = _mock_store(skill=skill)
+    with _make_plugin(source=_FakeSource(bg=bg)) as plugin:
+        plugin.set_store_api(store)
+        out = await plugin.recheck("s4")
+    assert out["drift"] == []
+
+
+# ── router (TestClient) ──────────────────────────────────────────────────────
+
+
+def _client(plugin):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    app = FastAPI()
+    app.include_router(plugin.get_router(), prefix="/plugins/provenance")
+    return TestClient(app)
+
+
+def test_router_check_with_url_200():
+    with _make_plugin() as plugin:
+        resp = _client(plugin).post(
+            "/plugins/provenance/check",
+            json={"github_url": "https://github.com/anthropics/skills"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is True
+        assert body["data"]["confidence"] == "high"
+        assert "Confidence: HIGH" in body["message"]
+
+
+def test_router_check_unknown_uuid_404():
+    store = _mock_store(skill=None)
+    with _make_plugin() as plugin:
+        plugin.set_store_api(store)
+        resp = _client(plugin).post(
+            "/plugins/provenance/check", json={"uuid": "missing"}
+        )
+        assert resp.status_code == 404
+
+
+def test_router_check_no_args_404():
+    with _make_plugin() as plugin:
+        resp = _client(plugin).post("/plugins/provenance/check", json={})
+        assert resp.status_code == 404
+
+
+# ── event handler registration ───────────────────────────────────────────────
+
+
+def test_event_handler_registered_for_skill_add():
+    from skillberry_store.plugins import events as events_module
+
+    saved = dict(events_module._event_handlers)
+    events_module._event_handlers.clear()
+    try:
+        with _make_plugin():
+            assert len(events_module._event_handlers.get("content_added:skill", [])) > 0
+    finally:
+        events_module._event_handlers.clear()
+        events_module._event_handlers.update(saved)

--- a/plugins/skillberry-plugin-provenance/tests/test_provenance_plugin.py
+++ b/plugins/skillberry-plugin-provenance/tests/test_provenance_plugin.py
@@ -149,7 +149,7 @@ async def test_behavior_detects_domains_and_ops():
 
     beh = data["behavior"]
     assert beh["status"] == "ok"
-    assert "evil.example.com" in beh["external_domains"]
+    assert beh["external_domains"] == ["evil.example.com"]
     assert "network" in beh["sensitive_operations"]
     assert "subprocess" in beh["sensitive_operations"]
     assert beh["sast_summary"] == {"high": 1}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,6 +185,10 @@ plugin-skill-optimizer = [
   "skillberry-plugin-skill-optimizer>=0.1.0",
 ]
 
+plugin-provenance = [
+  "skillberry-plugin-provenance>=0.1.0",
+]
+
 # Install all plugins
 plugins-all = [
   "skillberry-plugin-creator>=0.2.0",
@@ -196,6 +200,7 @@ plugins-all = [
   "skillberry-plugin-kagenti-approver>=0.1.0",
   "skillberry-plugin-sast>=0.1.0",
   "skillberry-plugin-skill-optimizer>=0.1.0",
+  "skillberry-plugin-provenance>=0.1.0",
 ]
 
 test = [
@@ -213,6 +218,7 @@ skillberry-plugin-anthropic-skill-generator = { path = "plugins/skillberry-plugi
 skillberry-plugin-kagenti-approver = { path = "plugins/skillberry-plugin-kagenti-approver", editable = true }
 skillberry-plugin-sast = { path = "plugins/skillberry-plugin-sast", editable = true }
 skillberry-plugin-skill-optimizer = { path = "plugins/skillberry-plugin-skill-optimizer", editable = true }
+skillberry-plugin-provenance = { path = "plugins/skillberry-plugin-provenance", editable = true }
 llm-client = { path = "skillberry-common/packages/llm-client", editable = true }
 torch = { index = "pytorch-cpu" }
 

--- a/src/skillberry_store/fast_api/skills_api.py
+++ b/src/skillberry_store/fast_api/skills_api.py
@@ -6,7 +6,7 @@ import json
 import logging
 import uuid
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Optional, Annotated, List
+from typing import TYPE_CHECKING, Optional, Annotated, List, Dict, Any
 from fastapi import FastAPI, HTTPException, Query, UploadFile, File, Form, Header
 from fastapi.responses import Response
 from prometheus_client import Counter
@@ -16,7 +16,10 @@ from skillberry_store.plugins.events import (
     emit_content_deleted,
 )
 
-from skillberry_store.tools.anthropic.importer import import_from_anthropic_skill
+from skillberry_store.tools.anthropic.importer import (
+    import_from_anthropic_skill,
+    parse_github_origin,
+)
 from skillberry_store.tools.endpoint_auth import (
     resolve_auth_headers,
     ReauthRequired,
@@ -792,6 +795,18 @@ def register_skills_api(
                 if tag and tag not in skill_tags:
                     skill_tags.append(tag)
 
+            # Record the skill's origin so it can be looked up / re-checked later
+            # by the provenance plugin (drift detection needs this baseline).
+            # Only URL imports have a remote origin; zip/folder imports do not.
+            skill_extra: Dict[str, Any] = {}
+            if source_type == "url" and github_url:
+                origin = parse_github_origin(github_url)
+                skill_extra["origin"] = {
+                    "type": "github" if origin else "url",
+                    "url": github_url,
+                    **(origin or {}),
+                }
+
             # Prepare skill schema with UUID (either existing or None for new)
             skill_schema = SkillSchema(
                 uuid=None,
@@ -803,6 +818,7 @@ def register_skills_api(
                 snippet_uuids=created_snippet_uuids,
                 state=ManifestState.APPROVED,
                 parent=None,  # Will be set by create_skill if name exists
+                extra=skill_extra,
             )
 
             # Create new skill

--- a/src/skillberry_store/tools/anthropic/importer.py
+++ b/src/skillberry_store/tools/anthropic/importer.py
@@ -130,7 +130,7 @@ def parse_github_origin(url: str) -> Optional[Dict[str, str]]:
     )
     if not m:
         return None
-    repo = (m.group("repo") or "")
+    repo = m.group("repo") or ""
     if repo.endswith(".git"):
         repo = repo[: -len(".git")]
     if not repo:

--- a/src/skillberry_store/tools/anthropic/importer.py
+++ b/src/skillberry_store/tools/anthropic/importer.py
@@ -112,6 +112,37 @@ def parse_skill_metadata(files: List[Dict[str, str]]) -> Optional[Dict[str, str]
     return None
 
 
+def parse_github_origin(url: str) -> Optional[Dict[str, str]]:
+    """Parse a github.com URL into ``{owner, repo, ref, path}``.
+
+    Records where an imported skill came from so it can be looked up later (the
+    provenance plugin reads this from the skill's ``extra["origin"]``). ``ref``
+    defaults to "main" and ``path`` to "" for a bare repo URL; a trailing
+    ".git" on the repo is stripped. Returns ``None`` for non-github URLs.
+    """
+    if not url:
+        return None
+    m = re.search(
+        r"github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)"
+        r"(?:/tree/(?P<ref>[^/]+)(?:/(?P<path>.*))?)?",
+        url,
+        re.IGNORECASE,
+    )
+    if not m:
+        return None
+    repo = (m.group("repo") or "")
+    if repo.endswith(".git"):
+        repo = repo[: -len(".git")]
+    if not repo:
+        return None
+    return {
+        "owner": m.group("owner"),
+        "repo": repo,
+        "ref": m.group("ref") or "main",
+        "path": (m.group("path") or "").strip("/"),
+    }
+
+
 def fetch_from_github(
     url: str, override_token: Optional[str] = None, anonymous: bool = False
 ) -> List[Dict[str, str]]:


### PR DESCRIPTION
## What & why

Implements #197. When a user imports a skill — typically from a GitHub URL — the store keeps no record of where it came from, who published it, its license, or whether the bytes are genuine, and that "background" can go stale after import. This PR adds a **Skill Provenance & Background** plugin that gathers and displays the top-five trust signals, plus a minimal import change so origin is recorded for later lookup and drift detection.

## What it does

A new plugin (`plugins/skillberry-plugin-provenance/`) that reports five sections and a rolled-up **confidence** (high / medium / low) with reasons:

| Section | Question | Source |
|---|---|---|
| `provenance` | Where from? (repo/ref/path pinned to a commit SHA + permalink) | GitHub API |
| `publisher` | Who, and how reputable? (org/user, stars, age, last push) | GitHub API |
| `license` | Legally safe to use/redistribute? (SPDX + permissive/copyleft/none) | GitHub API |
| `integrity` | Genuine, unmodified? (commit signature + per-file SHA-256) | GitHub + local |
| `behavior` | What does it reach out to / run? (domains, sensitive ops, SAST cross-link) | local |

Three modes, one code path:
- **pre-import** — `POST /plugins/provenance/check` with `github_url`
- **post-import** — `check` with a skill `uuid` (origin read from `extra["origin"]`)
- **drift** — `POST /plugins/provenance/recheck` with `uuid`, diffs against the baseline captured at import

On `content_added:skill`, if the skill carries an origin, the plugin computes and stores a baseline automatically (best-effort; never blocks import).

## Design notes

- **Mirrors the SAST plugin**: same `PluginBase` structure, entry-point registration, event-handler pattern, and flag-only persistence (`extra["provenance"]` + `provenance:*` tags). It never gates or blocks imports — informational only (gating is an open question in #197).
- **Simplest UI, zero UI code**: declares one action via `get_ui_config()`, rendered by the existing generic `PluginActionForm`. No `.tsx`/types changes.
- **Graceful degradation**: GitHub calls are best-effort and time-boxed; a rate-limited or failed call sets that section's `status` to `error`/`unavailable` rather than failing the gather or the import.
- **Auth reuse**: GitHub calls go through the store's existing `endpoint_auth.resolve_auth_headers` (configured token / gh-CLI / anonymous).

## Changes

**New** — `plugins/skillberry-plugin-provenance/`
- `plugin.py` — `SkillberryPluginProvenance(PluginBase)`: gather/recheck, router (`/check`, `/recheck`), event handler, persistence, drift diff.
- `sources/base.py` — `ProvenanceSource` ABC, `Background` dataclass, license classification.
- `sources/github_source.py` — `GitHubSource` + standalone JSON→Background mappers.
- `pyproject.toml`, `README.md`, tests.

**Core (minimal, additive)**
- `tools/anthropic/importer.py` — add `parse_github_origin(url)`.
- `fast_api/skills_api.py` — record `extra["origin"]` for URL imports (the baseline for lookup/drift). No behavior change for zip/folder imports.

## Testing

- **26 unit tests pass**, network-free (GitHub mappers against captured fixtures, fake source + mocked store, router via `TestClient`, drift, event registration):
  `pytest plugins/skillberry-plugin-provenance/tests -q`
- **End-to-end (authenticated)** against `anthropics/skills/.../pptx`: all five sections populate; commit pinned + signature `verified`; confidence correctly rolls up to **low** because the repo has no detected license (legality caps confidence regardless of reputation).
- Plugin is discovered and mounted at startup; appears enabled in `/plugins/`.

## Install

Editable install registers the entry point:
```bash
pip install -e plugins/skillberry-plugin-provenance
```

## Out of scope
- Import gating / thresholds (informational only for now).
- Scheduling for continuous drift checks (re-check is on-demand here).
- Non-GitHub sources (the source registry is extensible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
