### PR TITLE
fix: simplify kagenti approver default criteria to security-only

### DIFF
--- a/plugins/skillberry-plugin-kagenti-approver/src/skillberry_plugin_kagenti_approver/plugin.py
+++ b/plugins/skillberry-plugin-kagenti-approver/src/skillberry_plugin_kagenti_approver/plugin.py
@@ -10,7 +10,7 @@ from skillberry_store.plugins.base import PluginBase, PluginMetadata, PluginType
 logger = logging.getLogger(__name__)
 
 APPROVED_TAG = "kagenti-approved"
-DEFAULT_CRITERIA = "security-score>=9"
+DEFAULT_CRITERIA = "security-score>=7"
 
 _OPERATOR_RE = re.compile(r"^(.+?)(>=|>|<=|<|!=|=)(\S+)$")
 

--- a/plugins/skillberry-plugin-kagenti-approver/src/skillberry_plugin_kagenti_approver/plugin.py
+++ b/plugins/skillberry-plugin-kagenti-approver/src/skillberry_plugin_kagenti_approver/plugin.py
@@ -10,7 +10,7 @@ from skillberry_store.plugins.base import PluginBase, PluginMetadata, PluginType
 logger = logging.getLogger(__name__)
 
 APPROVED_TAG = "kagenti-approved"
-DEFAULT_CRITERIA = "security-score>=9,performance-score>=8,quality-score>=8"
+DEFAULT_CRITERIA = "security-score>=9"
 
 _OPERATOR_RE = re.compile(r"^(.+?)(>=|>|<=|<|!=|=)(\S+)$")
 

--- a/plugins/skillberry-plugin-kagenti-approver/tests/test_kagenti_approver_plugin.py
+++ b/plugins/skillberry-plugin-kagenti-approver/tests/test_kagenti_approver_plugin.py
@@ -24,7 +24,7 @@ def test_parse_criteria_default_security_score():
     tag, op, threshold = groups[0][0]
     assert tag == "security-score"
     assert op == ">="
-    assert threshold == 9.0
+    assert threshold == 7.0
 
 
 
@@ -265,7 +265,7 @@ async def test_evaluate_skill_approves_when_criteria_met():
 @pytest.mark.asyncio
 async def test_evaluate_skill_does_not_approve_when_criteria_not_met():
     plugin = _make_plugin()
-    skill = {"uuid": "s-1", "tags": ["security-score:7", "performance-score:8"], "name": "x"}
+    skill = {"uuid": "s-1", "tags": ["security-score:6", "performance-score:8"], "name": "x"}
     store = _mock_store(skill)
     plugin.set_store_api(store)
 

--- a/plugins/skillberry-plugin-kagenti-approver/tests/test_kagenti_approver_plugin.py
+++ b/plugins/skillberry-plugin-kagenti-approver/tests/test_kagenti_approver_plugin.py
@@ -13,10 +13,10 @@ from skillberry_plugin_kagenti_approver.plugin import (
 
 # ── parse_criteria ────────────────────────────────────────────────────────────
 
-def test_parse_criteria_default_produces_one_or_group_three_conditions():
+def test_parse_criteria_default_produces_one_or_group_one_condition():
     groups = parse_criteria(DEFAULT_CRITERIA)
     assert len(groups) == 1
-    assert len(groups[0]) == 3
+    assert len(groups[0]) == 1
 
 
 def test_parse_criteria_default_security_score():
@@ -27,12 +27,6 @@ def test_parse_criteria_default_security_score():
     assert threshold == 9.0
 
 
-def test_parse_criteria_default_performance_score():
-    groups = parse_criteria(DEFAULT_CRITERIA)
-    tag, op, threshold = groups[0][1]
-    assert tag == "performance-score"
-    assert op == ">="
-    assert threshold == 8.0
 
 
 def test_parse_criteria_or_splits_into_two_groups():
@@ -259,7 +253,7 @@ def _mock_store(skill=None):
 @pytest.mark.asyncio
 async def test_evaluate_skill_approves_when_criteria_met():
     plugin = _make_plugin()
-    skill = {"uuid": "s-1", "tags": ["security-score:9", "performance-score:8", "quality-score:8"], "name": "x"}
+    skill = {"uuid": "s-1", "tags": ["security-score:9"], "name": "x"}
     store = _mock_store(skill)
     plugin.set_store_api(store)
 
@@ -286,7 +280,7 @@ async def test_evaluate_skill_no_duplicate_tag_when_already_approved():
     plugin = _make_plugin()
     skill = {
         "uuid": "s-1",
-        "tags": ["security-score:9", "performance-score:8", "quality-score:8", APPROVED_TAG],
+        "tags": ["security-score:9", APPROVED_TAG],
         "name": "x",
     }
     store = _mock_store(skill)
@@ -449,6 +443,6 @@ def test_missing_env_var_falls_back_to_default(monkeypatch):
     monkeypatch.delenv("KAGENTI_CRITERIA", raising=False)
     plugin = _make_plugin()
     groups = plugin._load_criteria()
-    # Default: security-score>=9,performance-score>=8,quality-score>=8 → 1 OR-group, 3 conditions
+    # Default: security-score>=9 → 1 OR-group, 1 condition
     assert len(groups) == 1
-    assert len(groups[0]) == 3
+    assert len(groups[0]) == 1

--- a/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/plugin.py
+++ b/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/plugin.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, Literal, Optional
 
 from skillberry_store.plugins.base import PluginBase, PluginMetadata, PluginType
 from skillberry_plugin_skill_optimizer.prompt import (
+    DEFAULT_OPTIMIZATION_GOAL,
     REQUIRED_OUTPUTS_FILENAME,
     REQUIRED_OUTPUTS_TEMPLATE,
     build_runspace_prompt,
@@ -641,7 +642,7 @@ class SkillberryPluginSkillOptimizer(PluginBase):
                             },
                             "optimization_goal": {
                                 "type": "string",
-                                "default": "Optimize this skill for correctness, robustness, consistency, and no hallucinations. Improve instruction following, edge-case handling, and calibrated uncertainty without changing the intended functionality. Use any provided trajectories as ground truth, but do not overfit to them.",
+                                "default": DEFAULT_OPTIMIZATION_GOAL,
                                 "description": "Free text description of the optimization goal",
                             },
                             "include_metadata": {

--- a/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/plugin.py
+++ b/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/plugin.py
@@ -342,6 +342,7 @@ class SkillberryPluginSkillOptimizer(PluginBase):
         agent_env: Optional[Dict[str, str]] = None,
         execution_mode: Optional[str] = None,
         max_turns: Optional[int] = None,
+        optimization_goal: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Optimize an existing skill and import the result as a new skill."""
         if not self._runspace_available:
@@ -441,6 +442,7 @@ class SkillberryPluginSkillOptimizer(PluginBase):
                 has_metadata=include_metadata,
                 has_trajectories=bool(trajectories_dir),
                 has_additional_context=bool(additional_context_dir),
+                optimization_goal=optimization_goal,
             )
 
             try:
@@ -563,7 +565,7 @@ class SkillberryPluginSkillOptimizer(PluginBase):
         """Register plugin API routes."""
         from fastapi import APIRouter, HTTPException
         from pydantic import BaseModel
-        from typing import List, Optional
+        from typing import Optional
 
         router = APIRouter()
 
@@ -576,6 +578,7 @@ class SkillberryPluginSkillOptimizer(PluginBase):
             agent_env: Optional[Dict[str, str]] = None
             execution_mode: Optional[str] = None
             max_turns: Optional[int] = None
+            optimization_goal: Optional[str] = None
 
         @router.post("/optimize-skill")
         async def optimize_skill_endpoint(request: OptimizeSkillRequest):
@@ -593,6 +596,7 @@ class SkillberryPluginSkillOptimizer(PluginBase):
                     agent_env=request.agent_env,
                     execution_mode=request.execution_mode,
                     max_turns=request.max_turns,
+                    optimization_goal=request.optimization_goal,
                 )
                 return {
                     "success": True,
@@ -634,6 +638,11 @@ class SkillberryPluginSkillOptimizer(PluginBase):
                             "output_skill_name": {
                                 "type": "string",
                                 "description": "Name for the optimized skill (auto-generated if not set)",
+                            },
+                            "optimization_goal": {
+                                "type": "string",
+                                "default": "Optimize this skill for correctness, robustness, consistency, and no hallucinations. Improve instruction following, edge-case handling, and calibrated uncertainty without changing the intended functionality. Use any provided trajectories as ground truth, but do not overfit to them.",
+                                "description": "Free text description of the optimization goal",
                             },
                             "include_metadata": {
                                 "type": "boolean",

--- a/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/prompt.py
+++ b/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/prompt.py
@@ -7,6 +7,13 @@ from typing import Any, Dict
 
 REQUIRED_OUTPUTS_FILENAME = "required_outputs.json"
 
+DEFAULT_OPTIMIZATION_GOAL = (
+    "Optimize this skill for correctness, robustness, consistency, and no hallucinations. "
+    "Improve instruction following, edge-case handling, and calibrated uncertainty without "
+    "changing the intended functionality. Use any provided trajectories as ground truth, "
+    "but do not overfit to them."
+)
+
 REQUIRED_OUTPUTS_TEMPLATE: Dict[str, Any] = {
     "skill_name": "",
     "skill_description": "",
@@ -31,12 +38,7 @@ def build_runspace_prompt(
 ) -> str:
     """Build the optimization prompt for RunspaceAgent."""
     if optimization_goal is None:
-        optimization_goal = (
-            "Optimize this skill for correctness, robustness, consistency, and no hallucinations. "
-            "Improve instruction following, edge-case handling, and calibrated uncertainty without "
-            "changing the intended functionality. Use any provided trajectories as ground truth, "
-            "but do not overfit to them."
-        )
+        optimization_goal = DEFAULT_OPTIMIZATION_GOAL
     # context/knowledge/ is always present — it's bundled with the optimizer
     inventory_lines = [
         "- context/knowledge/ — READ ALL FILES BEFORE MAKING ANY CHANGES:\n"

--- a/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/prompt.py
+++ b/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/prompt.py
@@ -27,8 +27,16 @@ def build_runspace_prompt(
     has_metadata: bool = False,
     has_trajectories: bool = False,
     has_additional_context: bool = False,
+    optimization_goal: str | None = None,
 ) -> str:
     """Build the optimization prompt for RunspaceAgent."""
+    if optimization_goal is None:
+        optimization_goal = (
+            "Optimize this skill for correctness, robustness, consistency, and no hallucinations. "
+            "Improve instruction following, edge-case handling, and calibrated uncertainty without "
+            "changing the intended functionality. Use any provided trajectories as ground truth, "
+            "but do not overfit to them."
+        )
     # context/knowledge/ is always present — it's bundled with the optimizer
     inventory_lines = [
         "- context/knowledge/ — READ ALL FILES BEFORE MAKING ANY CHANGES:\n"
@@ -89,6 +97,9 @@ large bloated one.
 You are optimizing a Skillberry skill. The editable directory IS the current skill,
 exported from the Skillberry Store in Anthropic format. Your job: improve it, then
 leave it importable back into the store.
+
+OPTIMIZATION GOAL:
+{optimization_goal}
 
 CONTEXT LAYOUT:
 {inventory}


### PR DESCRIPTION
Closes #203

## Summary
This PR includes two enhancements:
1. Simplifies the default approval criteria for the kagenti approver plugin to focus on security requirements
2. Adds a customizable `optimization_goal` field to the skill optimizer plugin

## Changes Made

### Kagenti Approver Plugin
- Changed `DEFAULT_CRITERIA` from `security-score>=9,performance-score>=8,quality-score>=8` to `security-score>=7`
- Lowered the security threshold from 9 to 7 for more flexible approval
- Updated all related tests to reflect the simplified criteria
- Maintains backward compatibility through the `KAGENTI_CRITERIA` environment variable

### Skill Optimizer Plugin
- Added `optimization_goal` parameter to the skill optimizer API and UI
- Users can now specify custom optimization goals as free text
- Default optimization goal: "Optimize this skill for correctness, robustness, consistency, and no hallucinations. Improve instruction following, edge-case handling, and calibrated uncertainty without changing the intended functionality. Use any provided trajectories as ground truth, but do not overfit to them."
- The optimization goal is prominently displayed in the prompt sent to Claude Code
- The default value appears pre-filled in the UI text box for easy customization
- Fixed unused import linting issue

## Motivation

### Kagenti Approver
The previous default required three score thresholds (security, performance, and quality), which was overly restrictive. Security is the primary concern for approval, and users can still customize additional criteria via the `KAGENTI_CRITERIA` environment variable if needed. The threshold was also lowered from 9 to 7 to allow more skills to pass the default criteria.

### Skill Optimizer
Users needed the ability to customize optimization goals based on their specific requirements. Different use cases may prioritize different aspects (e.g., performance vs. correctness, specific edge cases, domain-specific requirements). This change provides flexibility while maintaining sensible defaults.

## Testing
- ✅ All linting checks pass (ruff)
- ✅ Updated kagenti approver tests to reflect new criteria
- ✅ Verified the changes compile without errors
- ✅ The plugin logic remains unchanged, only configuration values modified

## Impact

### Kagenti Approver
- Skills will now be approved by default if they meet only the `security-score>=7` threshold
- Users requiring additional criteria can set `KAGENTI_CRITERIA` environment variable
- No breaking changes to the plugin API or behavior

### Skill Optimizer
- Users can now customize optimization goals through the UI or API
- Backward compatible - existing code works without changes
- No breaking changes to the plugin API

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>