### PR TITLE
fix(skill-optimizer): allow full file/directory restructuring during optimization

### DIFF
--- a/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/plugin.py
+++ b/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/plugin.py
@@ -528,6 +528,24 @@ class SkillberryPluginSkillOptimizer(PluginBase):
                     except Exception as e:
                         logger.error(f"Failed to create snippet '{snippet.name}': {e}", exc_info=True)
 
+                # Compute the actual structural diff from the import results.
+                # Claude's self-reported tools_added/removed/snippets_added/removed in
+                # required_outputs.json is often incomplete — override with ground truth.
+                original_tool_names = {t["name"] for t in tools}
+                imported_tool_names = {t.name for t in imported_tools}
+                original_snippet_names = {s["name"] for s in snippets}
+                imported_snippet_names = {s.name for s in imported_snippets}
+                opt_metadata["tools_removed"] = sorted(original_tool_names - imported_tool_names)
+                opt_metadata["tools_added"] = sorted(imported_tool_names - original_tool_names)
+                opt_metadata["snippets_removed"] = sorted(original_snippet_names - imported_snippet_names)
+                opt_metadata["snippets_added"] = sorted(imported_snippet_names - original_snippet_names)
+                logger.info(
+                    f"Diff — tools added: {opt_metadata['tools_added']}, "
+                    f"removed: {opt_metadata['tools_removed']}; "
+                    f"snippets added: {opt_metadata['snippets_added']}, "
+                    f"removed: {opt_metadata['snippets_removed']}"
+                )
+
                 inherited_tags = [t for t in skill.get("tags", []) if t]
                 # opt_metadata["skill_description"] is the authoritative source — it's what
                 # the optimizer agent explicitly wrote in required_outputs.json. The importer's

--- a/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/prompt.py
+++ b/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/prompt.py
@@ -134,18 +134,23 @@ PYTHON FILE FORMAT RULES:
 - Runtime helpers are INJECTED into execution scope — call them directly,
   do NOT import them.
 
-PRESERVE STRUCTURE:
-- Do NOT rename, move, or delete existing files.
-- Keep the output directory structure the same as the input.
-- Do NOT leave temporary files in the directory — they will be imported.
-- Keep SKILL.md frontmatter valid at all times.
+FILE & DIRECTORY RULES:
+- SKILL.md must remain at the top level of the editable directory — never move it.
+- Do NOT rename the editable directory itself.
+- Do NOT leave temporary or scratch files — every file present will be imported.
+- Everything else is fair game: rename files, move files between directories, create
+  or remove subdirectories, add new files, delete files — as long as the result is
+  correct and store-compatible:
+    * Python files must remain self-contained (no cross-file imports introduced).
+    * All `def` functions you want as tools must still be top-level in their file.
+    * Non-Python files you want as snippets must still be reachable (not lost in an
+      ignored location).
+    * SKILL.md frontmatter must remain valid at all times.
 
 SKILL NAME:
 - If you made meaningful changes, update SKILL.md `name` to a new kebab-case
   name (max 64 characters) that hints at what changed.
 - Put the SAME value in `skill_name` in required_outputs.json.
-- IMPORTANT: only change the NAME VALUE inside SKILL.md — do NOT create
-  subdirectories, do NOT move SKILL.md, do NOT rename the editable directory.
 
 === REQUIRED OUTPUT CONTRACT ===
 The editable directory contains a file named `{REQUIRED_OUTPUTS_FILENAME}`. You MUST

--- a/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/prompt.py
+++ b/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/prompt.py
@@ -164,9 +164,22 @@ Field meanings:
 - skill_description: the skill description from SKILL.md frontmatter.
 - optimization_rationale: a concise explanation of what you changed and why.
 - issues_addressed: list of the failure modes / issues you fixed.
-- tools_added / tools_modified / tools_removed: function names added, changed, removed.
-- snippets_added / snippets_modified / snippets_removed: non-code files changed.
+- tools_added: exact function names (`def` names) of NEW functions you added that did
+  not exist before. Empty list if none.
+- tools_modified: exact function names you changed in place. Empty list if none.
+- tools_removed: exact function names you deleted from any .py file. Empty list if
+  none. THIS MUST BE ACCURATE — if you removed a `def`, list its name here.
+- snippets_added: filenames (relative paths) of NEW non-Python files you created.
+  Empty list if none.
+- snippets_modified: filenames of existing non-Python files whose content you changed.
+  Empty list if none.
+- snippets_removed: filenames (relative paths) of non-Python files you deleted. Empty
+  list if none. THIS MUST BE ACCURATE — if you deleted a file, list it here.
 - ready_for_deployment: true if the skill is valid and ready to upload.
+
+ACCURACY REQUIREMENT: fill tools_removed and snippets_removed as you go — do NOT
+leave them empty if you actually deleted functions or files. The store uses these
+fields to audit what changed; wrong values mislead operators.
 
 `{REQUIRED_OUTPUTS_FILENAME}` is a temporary contract file — the optimizer removes it
 before importing the skill back into the store.


### PR DESCRIPTION
## Summary
- Replaced the `PRESERVE STRUCTURE` block in `prompt.py` with a new `FILE & DIRECTORY RULES` section
- Optimizer can now rename, move, create, and delete files and subdirectories freely
- Hard constraints kept: `SKILL.md` stays at top level, editable directory not renamed, Python files stay self-contained, no temp files left

## Root Cause
The old rule `Do NOT rename, move, or delete existing files` silently blocked the optimizer from ever removing redundant tools or snippets — even though the knowledge base explicitly instructs it to do so. Snippets are files, so deleting a snippet requires deleting a file. The same rule discouraged removing functions from `.py` files, leaving redundant tools in place.

## Test plan
- [ ] Run skill optimizer on a skill with known redundant tools/snippets and verify they are removed in the output
- [ ] Verify optimizer can reorganize files into subdirectories without breaking import
- [ ] Verify `SKILL.md` is always preserved at the top level

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>