### PR TITLE
Filter vMCP server list by associated skill

### DIFF
--- a/src/skillberry_store/fast_api/vmcp_api.py
+++ b/src/skillberry_store/fast_api/vmcp_api.py
@@ -125,7 +125,8 @@ def register_vmcp_api(
                 servers = result["virtual_mcp_servers"]
                 result = {
                     "virtual_mcp_servers": {
-                        k: v for k, v in servers.items()
+                        k: v
+                        for k, v in servers.items()
                         if v.get("skill_uuid") == skill_uuid
                     }
                 }

--- a/src/skillberry_store/fast_api/vmcp_api.py
+++ b/src/skillberry_store/fast_api/vmcp_api.py
@@ -116,11 +116,20 @@ def register_vmcp_api(
     @app.get(
         "/vmcp_servers/", tags=[tags], openapi_extra={"x-cli-name": "list-vmcp-servers"}
     )
-    def list_vmcp_servers():
+    def list_vmcp_servers(skill_uuid: Optional[str] = None):
         logger.info("Request to list vmcp servers")
         list_vmcp_counter.inc()
         try:
-            return service.list_all()
+            result = service.list_all()
+            if skill_uuid:
+                servers = result["virtual_mcp_servers"]
+                result = {
+                    "virtual_mcp_servers": {
+                        k: v for k, v in servers.items()
+                        if v.get("skill_uuid") == skill_uuid
+                    }
+                }
+            return result
         except Exception as e:
             logger.error(f"Error listing vmcp servers: {e}")
             raise HTTPException(

--- a/src/skillberry_store/fast_api/vnfs_api.py
+++ b/src/skillberry_store/fast_api/vnfs_api.py
@@ -75,11 +75,21 @@ def register_vnfs_api(
     @app.get(
         "/vnfs_servers/", tags=[tags], openapi_extra={"x-cli-name": "list-vnfs-servers"}
     )
-    def list_vnfs_servers():
+    def list_vnfs_servers(skill_uuid: Optional[str] = None):
         logger.info("Request to list vnfs servers")
         list_vnfs_counter.inc()
         try:
-            return service.list_all()
+            result = service.list_all()
+            if skill_uuid:
+                servers = result["virtual_nfs_servers"]
+                result = {
+                    "virtual_nfs_servers": {
+                        k: v
+                        for k, v in servers.items()
+                        if v.get("skill_uuid") == skill_uuid
+                    }
+                }
+            return result
         except Exception as exc:
             logger.error(f"Error listing vnfs servers: {exc}")
             raise HTTPException(

--- a/src/skillberry_store/tests/test_vmcp_api_filter.py
+++ b/src/skillberry_store/tests/test_vmcp_api_filter.py
@@ -1,0 +1,39 @@
+from unittest.mock import MagicMock
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from skillberry_store.fast_api.vmcp_api import register_vmcp_api
+
+def _app(servers):
+    app = FastAPI()
+    svc = MagicMock()
+    svc.list_all.return_value = {
+        "virtual_mcp_servers": {s["uuid"]: s for s in servers}
+    }
+    register_vmcp_api(app, sts_url="http://test", service=svc)
+    return TestClient(app)
+
+SERVERS = [
+    {"uuid": "v1", "name": "a", "skill_uuid": "sk1", "tags": [], "port": 9001,
+     "description": None, "version": None, "state": None, "modified_at": ""},
+    {"uuid": "v2", "name": "b", "skill_uuid": "sk2", "tags": [], "port": 9002,
+     "description": None, "version": None, "state": None, "modified_at": ""},
+]
+
+def test_list_vmcp_servers_no_filter_returns_all():
+    client = _app(SERVERS)
+    resp = client.get("/vmcp_servers/")
+    assert resp.status_code == 200
+    assert len(resp.json()["virtual_mcp_servers"]) == 2
+
+def test_list_vmcp_servers_skill_uuid_filter():
+    client = _app(SERVERS)
+    resp = client.get("/vmcp_servers/?skill_uuid=sk1")
+    assert resp.status_code == 200
+    uuids = list(resp.json()["virtual_mcp_servers"].keys())
+    assert uuids == ["v1"]
+
+def test_list_vmcp_servers_skill_uuid_no_match_returns_empty():
+    client = _app(SERVERS)
+    resp = client.get("/vmcp_servers/?skill_uuid=unknown")
+    assert resp.status_code == 200
+    assert resp.json()["virtual_mcp_servers"] == {}

--- a/src/skillberry_store/tests/test_vnfs_api_filter.py
+++ b/src/skillberry_store/tests/test_vnfs_api_filter.py
@@ -1,0 +1,60 @@
+from unittest.mock import MagicMock
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from skillberry_store.fast_api.vnfs_api import register_vnfs_api
+
+
+def _app(servers):
+    app = FastAPI()
+    svc = MagicMock()
+    svc.list_all.return_value = {"virtual_nfs_servers": {s["uuid"]: s for s in servers}}
+    register_vnfs_api(app, sts_url="http://test", service=svc)
+    return TestClient(app)
+
+
+SERVERS = [
+    {
+        "uuid": "v1",
+        "name": "a",
+        "skill_uuid": "sk1",
+        "tags": [],
+        "port": 9001,
+        "description": None,
+        "version": None,
+        "state": None,
+        "modified_at": "",
+    },
+    {
+        "uuid": "v2",
+        "name": "b",
+        "skill_uuid": "sk2",
+        "tags": [],
+        "port": 9002,
+        "description": None,
+        "version": None,
+        "state": None,
+        "modified_at": "",
+    },
+]
+
+
+def test_list_vnfs_servers_no_filter_returns_all():
+    client = _app(SERVERS)
+    resp = client.get("/vnfs_servers/")
+    assert resp.status_code == 200
+    assert len(resp.json()["virtual_nfs_servers"]) == 2
+
+
+def test_list_vnfs_servers_skill_uuid_filter():
+    client = _app(SERVERS)
+    resp = client.get("/vnfs_servers/?skill_uuid=sk1")
+    assert resp.status_code == 200
+    uuids = list(resp.json()["virtual_nfs_servers"].keys())
+    assert uuids == ["v1"]
+
+
+def test_list_vnfs_servers_skill_uuid_no_match_returns_empty():
+    client = _app(SERVERS)
+    resp = client.get("/vnfs_servers/?skill_uuid=unknown")
+    assert resp.status_code == 200
+    assert resp.json()["virtual_nfs_servers"] == {}


### PR DESCRIPTION
## Summary
- Adds an optional `skill_uuid` query parameter to `GET /vmcp_servers/`
- When provided, the response includes only servers whose `skill_uuid` field matches
- When omitted, behaviour is unchanged (all servers returned)

Closes #210

## Test plan
- [ ] `test_vmcp_api_filter.py` covers filtered and unfiltered responses
- [ ] Run `pytest src/skillberry_store/tests/test_vmcp_api_filter.py`