### PR TITLE
fix: make arg_convert produce JSON-native MCP call arguments

### DIFF
--- a/src/skillberry_store/modules/file_executor.py
+++ b/src/skillberry_store/modules/file_executor.py
@@ -43,49 +43,38 @@ def get_distribution(module_name: str) -> str:
 
 
 def arg_convert(arg_name, arg_type):
-    arg_str = str(arg_name)  # Ensure the argument is treated as a string
-    if arg_type is not None:
-        if arg_type == "str":
-            return f'"{arg_str}"'
-        elif arg_type == "int":
-            try:
-                int_val = int(arg_str)
-                # Check if the string representation matches to avoid float->int conversion
-                if str(int_val) == arg_str:
-                    return int_val
-            except Exception as e:
-                raise ValueError(f"Cannot convert '{arg_str}' to int {e}")
+    """Coerce a parameter value to the JSON-native type declared in the tool schema.
 
-    try:
-        int_val = int(arg_str)
-        # Check if the string representation matches to avoid float->int conversion
-        if str(int_val) == arg_str:
-            return int_val
-    except ValueError:
-        pass
-
-    # Try to convert to float
-    try:
-        float_val = float(arg_str)
-        return float_val
-    except ValueError:
-        pass
-
-    try:
-        return float(arg_str)
-    except ValueError:
-        pass
-
-    try:
-        parts = arg_str.split(":")
-        if len(parts) == 2:
-            return datetime.datetime.strptime(arg_str, "%H:%M").time()
-        elif len(parts) == 3:
-            return datetime.datetime.strptime(arg_str, "%H:%M:%S").time()
-    except ValueError:
-        pass
-
-    return f'"{arg_str}"'
+    This is used to build the ``arguments`` dict for an MCP ``call_tool`` request,
+    so the returned value must be a JSON-serializable Python object
+    (str/int/float/bool/list/dict) — NOT a source-code literal. The accepted type
+    names cover both the JSON-schema vocabulary the store stores and emits in the
+    MCP stub ("string", "integer", "number", "boolean", "array", "object") and the
+    Python-style aliases ("str", "int", "float", "bool"). Unknown types and
+    container types are passed through unchanged, since the value already arrived
+    as a native JSON type in the request body.
+    """
+    if arg_type in ("str", "string"):
+        return str(arg_name)
+    if arg_type in ("int", "integer"):
+        try:
+            return int(arg_name)
+        except (TypeError, ValueError) as e:
+            raise ValueError(f"Cannot convert '{arg_name}' to int: {e}")
+    if arg_type in ("float", "number"):
+        try:
+            return float(arg_name)
+        except (TypeError, ValueError) as e:
+            raise ValueError(f"Cannot convert '{arg_name}' to float: {e}")
+    if arg_type in ("bool", "boolean"):
+        if isinstance(arg_name, bool):
+            return arg_name
+        if isinstance(arg_name, str):
+            return arg_name.strip().lower() in ("true", "1", "yes")
+        return bool(arg_name)
+    # array / object / null / unknown: the value already arrived as a native JSON
+    # type in the request body — pass it through unchanged.
+    return arg_name
 
 
 def extract_function_and_imports(

--- a/src/skillberry_store/modules/file_executor.py
+++ b/src/skillberry_store/modules/file_executor.py
@@ -42,7 +42,7 @@ def get_distribution(module_name: str) -> str:
     )
 
 
-def arg_convert(arg_name, arg_type):
+def mcp_arg_convert(arg_name, arg_type):
     """Coerce a parameter value to the JSON-native type declared in the tool schema.
 
     This is used to build the ``arguments`` dict for an MCP ``call_tool`` request,
@@ -407,7 +407,7 @@ class FileExecutor:
                         else:
                             continue
 
-                    converted_arg = arg_convert(
+                    converted_arg = mcp_arg_convert(
                         parameters.get(parameter_definition_name),
                         parameter_definition_type,
                     )

--- a/src/skillberry_store/modules/test_file_executor.py
+++ b/src/skillberry_store/modules/test_file_executor.py
@@ -1,6 +1,37 @@
 import pytest
 
-from skillberry_store.modules.file_executor import FileExecutor
+from skillberry_store.modules.file_executor import FileExecutor, arg_convert
+
+
+@pytest.mark.parametrize(
+    "value,arg_type,expected",
+    [
+        # JSON-schema type names (what the store actually stores & the MCP stub emits)
+        ("sara_doe_496", "string", "sara_doe_496"),  # must NOT be quoted
+        ("496", "string", "496"),  # numeric-looking string must stay a string
+        ("12:30", "string", "12:30"),  # time-looking string must stay a string
+        ("5", "integer", 5),
+        ("5.5", "number", 5.5),
+        ("true", "boolean", True),
+        ("false", "boolean", False),
+        # native values pass through with the right type
+        (5, "integer", 5),
+        (True, "boolean", True),
+        # legacy Python-style aliases still supported
+        ("hello", "str", "hello"),
+        ("7", "int", 7),
+        ("2.5", "float", 2.5),
+        # array / object values are passed through unchanged (JSON-native)
+        ([10, 20, 30], "array", [10, 20, 30]),
+        ({"k": "v"}, "object", {"k": "v"}),
+    ],
+)
+def test_arg_convert_produces_json_native_values(value, arg_type, expected):
+    """arg_convert builds MCP call arguments, so it must return JSON-native
+    values (no source-code quoting, no guess-coercion across types)."""
+    result = arg_convert(value, arg_type)
+    assert result == expected
+    assert type(result) is type(expected)
 
 
 @pytest.fixture

--- a/src/skillberry_store/modules/test_file_executor.py
+++ b/src/skillberry_store/modules/test_file_executor.py
@@ -1,6 +1,6 @@
 import pytest
 
-from skillberry_store.modules.file_executor import FileExecutor, arg_convert
+from skillberry_store.modules.file_executor import FileExecutor, mcp_arg_convert
 
 
 @pytest.mark.parametrize(
@@ -26,10 +26,10 @@ from skillberry_store.modules.file_executor import FileExecutor, arg_convert
         ({"k": "v"}, "object", {"k": "v"}),
     ],
 )
-def test_arg_convert_produces_json_native_values(value, arg_type, expected):
-    """arg_convert builds MCP call arguments, so it must return JSON-native
+def test_mcp_arg_convert_produces_json_native_values(value, arg_type, expected):
+    """mcp_arg_convert builds MCP call arguments, so it must return JSON-native
     values (no source-code quoting, no guess-coercion across types)."""
-    result = arg_convert(value, arg_type)
+    result = mcp_arg_convert(value, arg_type)
     assert result == expected
     assert type(result) is type(expected)
 


### PR DESCRIPTION
Fixes #221

## Problem

Executing an MCP-packaged tool through the store corrupts string arguments. A parameter like `user_id="sara_doe_496"` reaches the backend MCP server as `'"sara_doe_496"'` (literal embedded quotes), so lookups fail with *"user not found"*. The same call issued directly against the backend works, because that path sends raw JSON and never goes through the store's argument conversion.

## Root cause

`arg_convert` (`src/skillberry_store/modules/file_executor.py`) was written to emit **Python source-code literals** (a string becomes a quoted `"value"`). Its only caller is the MCP path (`execute_python_file_in_mcp_server`), which uses the result to build the `arguments` dict for `session.call_tool(...)` — where the value must be a **JSON-native object**, not a source literal. The store also stores parameter types as JSON-schema names (`"string"`, `"integer"`, …), which never matched `arg_convert`'s `"str"`/`"int"` branches, so values fell through to a guess-coercion fallback.

This also produced three latent bugs: numeric-looking string IDs (`"496"`) coerced to `int`, time-looking strings (`"12:30"`) turned into non-JSON-serializable `datetime.time`, and booleans quoted as strings.

## Why it wasn't caught earlier

- `arg_convert` has exactly one caller and had no unit tests.
- Regular (non-simulated) MCP tools are created without a `params` field, so they bypass `arg_convert` entirely via the no-parameter shortcut.
- Simulated tools (Simulate plugin) are the first to carry typed params through this path, which surfaced the bug.

This means the change **cannot regress existing regular-MCP behavior** — no existing regular-MCP tool reaches this function.

## Fix

Rewrite `arg_convert` to be type-driven: map JSON-schema/Python type names to JSON-native values (str/int/float/bool, containers passed through) with no source-quoting and no guess-coercion.

## Testing

- New parametrized unit test `test_arg_convert_produces_json_native_values` (14 cases) — failed 9/14 before, all pass after.
- `test_file_executor.py` under local execution: 42 pass, 1 fail (`test_execute_modes[docker_mode]`, requires Docker — unrelated to this change).
- Dependency / tau2 / env_id suites: 33 pass. Simulate plugin manifest/synth: 8 pass.

Note: the live end-to-end simulation path (Docker + harness + LLM key) was not exercised; the fix is verified at the unit level and by tracing the exact `call_tool` argument construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)