### PR TITLE
feat: add Dependency Tracker plugin (external Python & shell deps for skills, tools & snippets)

### DIFF
--- a/plugins/skillberry-plugin-dependency-tracker/README.md
+++ b/plugins/skillberry-plugin-dependency-tracker/README.md
@@ -1,0 +1,116 @@
+# skillberry-plugin-dependency-tracker
+
+**Dependency Tracker** — discovers the **external dependencies** of skills, tools,
+and snippets and records them under a hierarchical `extra["dependencies"]` block.
+Addresses [#224](https://github.com/skillberry-ai/skillberry-store/issues/224).
+
+The store already tracks **internal** dependencies (a tool's dependency on *other
+store tools*, by UUID, in the top-level `dependencies` field). This plugin tracks
+the **external supply chain** — the packages/commands an object actually pulls in,
+their transitive deps, exact versions, and hashes — which matters for supply-chain
+security and versioning hygiene.
+
+## Supported languages
+
+| Language | What's discovered | Version / hash |
+|----------|-------------------|----------------|
+| **Python** | imported PyPI distributions, transitive at **maximum depth** | installed version + RECORD hashes (local), canonical sha256 (PyPI) |
+| **Shell** (`.sh`/`.bash`/…) | external commands invoked (`curl`, `jq`, `node`, …) | none — these are *system* executables (`source: "system"`) |
+
+Each file's language is detected by extension, then shebang, then a light content
+heuristic. **Any file in an unsupported language is reported explicitly** in
+`skipped_files` (with `reason: "unsupported_language"`) and counted in
+`summary.skipped_count` — a bare `0` is never ambiguous about whether the object
+was clean or simply not inspectable.
+
+## Resolution (hybrid)
+
+| Source | Role |
+|--------|------|
+| **Local** (`importlib.metadata`) | **Source of truth** — the installed version each object runs against, per-file `RECORD` hashes, and the transitive `Requires-Dist` graph at max depth |
+| **PyPI** (`/pypi/<pkg>/json`) | **Best-effort enrichment** — canonical published artifact `sha256` + an "update available" signal |
+
+PyPI calls are **time-boxed and never fail a scan**: a 429 / timeout / offline
+condition becomes a per-package `status`, rolled up to `partial` / `skipped`.
+Enrichment is env-gated: `DEPENDENCY_TRACKER_PYPI=off` disables it (and a `pypi`
+flag on the request overrides per call).
+
+## The `extra["dependencies"]` block
+
+```jsonc
+{
+  "schema_version": 1,
+  "generated_at": "<ISO-8601>",
+  "supported_languages": ["python", "shell"],
+  "languages_inspected": ["python", "shell"],   // which langs this object had
+  "scanner": { "plugin_version", "resolver": "hybrid", "python_version" },
+  "summary": { "direct_count", "total_count", "unresolved_count",
+               "skipped_count", "update_available_count", "pypi_status" },
+  "packages": {                          // keyed by dependency name
+    "requests": {
+      "name", "version",                 // local installed version = truth
+      "source": "local|pypi|system|unresolved",
+      "language": "python",
+      "direct": true, "depth": 0,
+      "local_hashes": [ {"file","algorithm":"sha256","hash"} ],
+      "requires": ["urllib3", ...],
+      "pypi": { "status", "latest_version", "update_available",
+                "artifact_sha256": {"sdist","wheel"} }
+    },
+    "curl": { "name": "curl", "version": null, "source": "system",
+              "language": "shell", "direct": true, "depth": 0 }
+  },
+  "tree": [ {"from","to","depth"} ],     // dependency edges (DAG/cycle-safe)
+  "unresolved_imports": [ {"import_name","reason"} ],
+  "skipped_files": [ {"file","language","reason":"unsupported_language"} ]
+}
+```
+
+Summary tags are also written: `dep:count:N`, `dep:unresolved:M`,
+`dep:skipped:K` (unsupported files), `dep:lang:python` / `dep:lang:shell`, and
+`dep:update-available` when any package has a newer release.
+
+## API
+
+Mounted at `/plugins/dependency_tracker` (and `/api/plugins/dependency_tracker/...` for the UI):
+
+- `POST /scan` — body `{ "object_type": "skill|tool|snippet", "uuid": str, "pypi"?: bool }`
+  → `{ success, message, data: { object_type, uuid, dependencies, summary } }`
+
+Invalid/missing input returns a clean **400** (not a raw 422). **On-demand only** —
+there is no auto-scan-on-import hook.
+
+## UI
+
+No custom UI: the plugin declares a single **"Scan dependencies"** action via
+`get_ui_config()`, rendered by the store's generic plugin action form (mirrors the
+SAST/provenance plugins).
+
+## Install
+
+```bash
+pip install -e plugins/skillberry-plugin-dependency-tracker
+# optional: robust PEP 440 version comparison
+pip install -e 'plugins/skillberry-plugin-dependency-tracker[version]'
+```
+
+## Test
+
+```bash
+pytest plugins/skillberry-plugin-dependency-tracker/tests -q
+```
+
+Tests are network-free: PyPI is monkeypatched and local resolution runs against
+the installed environment.
+
+## Notes
+
+- **Non-destructive**: only `extra["dependencies"]` and `dep:` tags are written;
+  other `extra` keys and tags are preserved. The top-level store-tool
+  `dependencies` field is never touched.
+- **Maximum depth**: the transitive graph is walked fully, with cycle/diamond
+  protection (each distribution expanded once; shallowest depth recorded).
+- Distributions with no recorded `RECORD` hashes (editable installs, some wheels)
+  still get a version + `source: local`, just with empty `local_hashes`.
+- Imports that map to no installed distribution are reported in
+  `unresolved_imports`, never silently dropped.

--- a/plugins/skillberry-plugin-dependency-tracker/README.md
+++ b/plugins/skillberry-plugin-dependency-tracker/README.md
@@ -74,7 +74,7 @@ Summary tags are also written: `dep:count:N`, `dep:unresolved:M`,
 
 Mounted at `/plugins/dependency_tracker` (and `/api/plugins/dependency_tracker/...` for the UI):
 
-- `POST /scan` — body `{ "object_type": "skill|tool|snippet", "uuid": str, "pypi"?: bool }`
+- `POST /resolve-dependencies` — body `{ "object_type": "skill|tool|snippet", "uuid": str, "pypi"?: bool }`
   → `{ success, message, data: { object_type, uuid, dependencies, summary } }`
 
 Invalid/missing input returns a clean **400** (not a raw 422). **On-demand only** —

--- a/plugins/skillberry-plugin-dependency-tracker/pyproject.toml
+++ b/plugins/skillberry-plugin-dependency-tracker/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["setuptools>=45", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "skillberry-plugin-dependency-tracker"
+version = "0.1.0"
+description = "Skillberry Store plugin that discovers external Python package dependencies (version + hash, transitive at max depth) for skills, tools and snippets"
+readme = "README.md"
+requires-python = ">=3.10"
+# requests is already a store dependency (used by the provenance plugin); it
+# powers the best-effort PyPI enrichment. Local resolution needs no deps.
+dependencies = ["requests"]
+
+[project.entry-points."skillberry_store.plugins"]
+dependency_tracker = "skillberry_plugin_dependency_tracker.plugin:SkillberryPluginDependencyTracker"
+
+[project.optional-dependencies]
+# Robust PEP 440 version comparison for the "update available" signal; the
+# engine falls back to string comparison when packaging is absent.
+version = [
+    "packaging>=21.0",
+]
+dev = [
+    "pytest",
+    "pytest-asyncio",
+    "httpx",
+    "fastapi",
+]
+
+[tool.setuptools]
+packages = [
+    "skillberry_plugin_dependency_tracker",
+    "skillberry_plugin_dependency_tracker.resolver",
+]
+package-dir = {"" = "src"}

--- a/plugins/skillberry-plugin-dependency-tracker/src/skillberry_plugin_dependency_tracker/__init__.py
+++ b/plugins/skillberry-plugin-dependency-tracker/src/skillberry_plugin_dependency_tracker/__init__.py
@@ -1,0 +1,5 @@
+"""Skillberry Store plugin: Dependency Tracker."""
+
+from .plugin import SkillberryPluginDependencyTracker
+
+__all__ = ["SkillberryPluginDependencyTracker"]

--- a/plugins/skillberry-plugin-dependency-tracker/src/skillberry_plugin_dependency_tracker/plugin.py
+++ b/plugins/skillberry-plugin-dependency-tracker/src/skillberry_plugin_dependency_tracker/plugin.py
@@ -358,7 +358,7 @@ class SkillberryPluginDependencyTracker(PluginBase):
             if not (uuid and uuid.strip()):
                 raise HTTPException(status_code=400, detail="uuid is required")
 
-        @router.post("/scan")
+        @router.post("/resolve-dependencies")
         async def scan_endpoint(request: ScanRequest):
             """Resolve & record external Python dependencies for an object."""
             _validate(request.object_type, request.uuid)
@@ -391,7 +391,7 @@ class SkillberryPluginDependencyTracker(PluginBase):
             "actions": [
                 {
                     "label": "Scan dependencies",
-                    "endpoint": "/api/plugins/dependency_tracker/scan",
+                    "endpoint": "/api/plugins/dependency_tracker/resolve-dependencies",
                     "method": "POST",
                     "params_schema": {
                         "type": "object",

--- a/plugins/skillberry-plugin-dependency-tracker/src/skillberry_plugin_dependency_tracker/plugin.py
+++ b/plugins/skillberry-plugin-dependency-tracker/src/skillberry_plugin_dependency_tracker/plugin.py
@@ -1,0 +1,414 @@
+"""
+Skillberry Plugin: Dependency Tracker.
+
+Discovers the EXTERNAL Python package dependencies of skills, tools, and
+snippets — exact version + artifact hashes, transitively at maximum depth — and
+writes them into a hierarchical ``extra["dependencies"]`` block. This is the
+external supply-chain layer the store lacks today (it only tracks store-tool ->
+store-tool links via the top-level ``dependencies`` field). See issue #224.
+
+Resolution is HYBRID: local ``importlib.metadata`` is the source of truth (the
+version the object actually runs against, plus RECORD hashes and the transitive
+Requires-Dist graph); the PyPI JSON API best-effort-enriches each package with
+its canonical published sha256 and an "update available" signal. PyPI is
+time-boxed and never fails a scan.
+
+Like the SAST/provenance/doc-generator plugins this is informational and
+non-destructive: results land in ``extra["dependencies"]`` + ``dep:`` tags and
+are surfaced through the generic plugin UI. Unlike those, it runs **on demand
+only** — there is no import event hook.
+"""
+
+import asyncio
+import logging
+import platform
+import re
+from typing import Any, Dict, List, Optional
+
+from skillberry_store.plugins.base import PluginBase, PluginMetadata, PluginType
+
+from .resolver import build_resolver
+from .resolver.base import OBJECT_TYPES
+from .resolver.pypi import pypi_enabled_from_env
+
+logger = logging.getLogger(__name__)
+
+_PLUGIN_VERSION = "0.1.0"
+_EXTRA_KEY = "dependencies"
+_TAG_PREFIX = "dep:"
+
+
+def _summary_message(block: Dict[str, Any]) -> str:
+    """One-line verdict for the success banner in the generic plugin UI."""
+    s = block.get("summary") or {}
+    langs = ", ".join(block.get("languages_inspected") or []) or "none"
+    msg = (
+        f"{s.get('total_count', 0)} dependencies "
+        f"({s.get('direct_count', 0)} direct) in [{langs}]"
+    )
+    if s.get("missing_count"):
+        msg += f", {s['missing_count']} missing external"
+    if s.get("local_module_count"):
+        msg += f", {s['local_module_count']} local module(s)"
+    if s.get("skipped_count"):
+        msg += f", {s['skipped_count']} file(s) skipped (unsupported language)"
+    if s.get("update_available_count"):
+        msg += f", {s['update_available_count']} update(s) available"
+    return msg
+
+
+class SkillberryPluginDependencyTracker(PluginBase):
+    """Discovers external Python dependencies (version + hash, transitive)."""
+
+    def __init__(self):
+        super().__init__()
+        self._metadata = PluginMetadata(
+            name="Dependency Tracker",
+            version=_PLUGIN_VERSION,
+            description=(
+                "Discovers external Python package dependencies — exact version "
+                "and artifact hashes, transitively at maximum depth — for skills, "
+                "tools and snippets, and records them under extra['dependencies']."
+            ),
+            plugin_type=PluginType.EVALUATOR,
+        )
+        # Default PyPI enrichment from env; overridable per request.
+        self._pypi_enabled = pypi_enabled_from_env()
+        # NOTE: intentionally NO _register_event_handlers — on-demand only.
+
+    # ── status / enablement ──────────────────────────────────────────────────
+
+    @property
+    def metadata(self) -> PluginMetadata:
+        return self._metadata
+
+    def is_enabled(self) -> bool:
+        # Local resolution needs no credentials or network; always available.
+        return True
+
+    def get_status_message(self) -> str:
+        mode = "on" if self._pypi_enabled else "off"
+        return f"Ready (local resolution; PyPI enrichment best-effort, default {mode})"
+
+    # ── object access + code collection ───────────────────────────────────────
+
+    def _get_object(self, object_type: str, uuid: str) -> Optional[Dict[str, Any]]:
+        if self._store_api is None:
+            raise RuntimeError("Store API not available")
+        getter = {
+            "skill": self.store.get_skill,
+            "tool": self.store.get_tool,
+            "snippet": self.store.get_snippet,
+        }.get(object_type)
+        if getter is None:
+            raise ValueError(f"Unsupported object_type: {object_type!r}")
+        return getter(uuid)
+
+    def _collect_code(self, object_type: str, obj: Dict[str, Any]) -> List[tuple]:
+        """Gather ``(filename, source)`` blobs to scan.
+
+        The filename drives language detection (Python vs. shell) and the
+        skipped-file report, so each blob carries the best name we have: a tool's
+        ``module_name``, or a synthesized ``<snippet:name>`` for inline content.
+        A tool contributes its module file; a snippet its inline content; a skill
+        aggregates the modules and content of its referenced tools/snippets.
+        """
+        blobs: List[tuple] = []
+        if object_type == "snippet":
+            content = obj.get("content")
+            if content:
+                blobs.append((self._snippet_filename(obj), content))
+            return blobs
+        if object_type == "tool":
+            blob = self._read_tool_module(obj)
+            if blob is not None:
+                blobs.append(blob)
+            return blobs
+        if object_type == "skill" and self._store_api is not None:
+            for tool_uuid in obj.get("tool_uuids") or []:
+                try:
+                    tool = self.store.get_tool(tool_uuid)
+                    if tool:
+                        blob = self._read_tool_module(tool)
+                        if blob is not None:
+                            blobs.append(blob)
+                except Exception as e:
+                    logger.debug("dep-tracker: could not read child tool: %s", e)
+            for snippet_uuid in obj.get("snippet_uuids") or []:
+                try:
+                    snippet = self.store.get_snippet(snippet_uuid)
+                    content = (snippet or {}).get("content")
+                    if content:
+                        blobs.append((self._snippet_filename(snippet), content))
+                except Exception as e:
+                    logger.debug("dep-tracker: could not read child snippet: %s", e)
+        return blobs
+
+    def _read_tool_module(self, tool: Dict[str, Any]) -> Optional[tuple]:
+        """Return ``(module_name, source)`` for a tool, or None if unreadable."""
+        module = tool.get("module_name")
+        if not module or self._store_api is None:
+            return None
+        try:
+            source = self.store.tools.read_file(
+                tool.get("uuid"), module, raw_content=True
+            )
+        except Exception as e:
+            logger.debug("dep-tracker: could not read tool module: %s", e)
+            return None
+        return (module, source)
+
+    @staticmethod
+    def _snippet_filename(snippet: Dict[str, Any]) -> str:
+        """A synthetic filename for a snippet so language detection can run.
+
+        Snippets have no extension; we use the snippet name as a hint (e.g. a
+        ``setup.sh`` snippet) and otherwise fall back to a neutral name that
+        detection will resolve via shebang/heuristic.
+        """
+        name = snippet.get("name") or snippet.get("uuid") or "snippet"
+        return str(name)
+
+    def _local_module_names(
+        self, object_type: str, obj: Dict[str, Any], blobs: List[tuple]
+    ) -> set:
+        """Top-level module names that are first-party to this object.
+
+        An import resolving to one of these is the object's own bundled code, not
+        a missing external dependency. Two complementary signals:
+
+        1. The stem and name of each bundled tool module (e.g. ``merge_runs.py``
+           -> ``merge_runs``), which catches direct sibling imports.
+        2. Package roots inferred from the code itself: in ``from helpers.X
+           import`` / ``import office.Y``, the leaf (``X``/``Y``) is a bundled
+           module, so the root (``helpers``/``office``) is a local package.
+        """
+        names: set = set()
+
+        # (1) bundled tool module stems + tool names
+        tool_uuids: List[str] = []
+        if object_type == "tool":
+            tool_uuids = [obj.get("uuid")] if obj.get("uuid") else []
+        elif object_type == "skill":
+            tool_uuids = list(obj.get("tool_uuids") or [])
+        bundled_stems: set = set()
+        for tu in tool_uuids:
+            try:
+                tool = obj if (object_type == "tool") else self.store.get_tool(tu)
+            except Exception:
+                tool = None
+            if not tool:
+                continue
+            module = tool.get("module_name") or ""
+            stem = module.rsplit("/", 1)[-1].rsplit(".", 1)[0]
+            if stem:
+                bundled_stems.add(stem)
+                names.add(stem)
+            if tool.get("name"):
+                names.add(str(tool["name"]))
+        # snippet names are first-party too
+        if object_type == "skill":
+            for su in obj.get("snippet_uuids") or []:
+                try:
+                    sn = self.store.get_snippet(su)
+                except Exception:
+                    sn = None
+                if sn and sn.get("name"):
+                    names.add(str(sn["name"]))
+
+        # (2) Infer first-party package roots from the code's own imports, using
+        # two signals — either is strong evidence the root is bundled:
+        #   (a) `from <root>.<leaf> import ...` where <leaf> is a bundled module
+        #       stem (e.g. `from helpers.merge_runs import ...`), or
+        #   (b) `from <root>[...] import SYM, ...` where an imported symbol SYM
+        #       matches a bundled module name/stem (e.g.
+        #       `from office.soffice import get_soffice_env`, and a tool
+        #       `get_soffice_env` is bundled).
+        dotted_re = re.compile(
+            r"(?m)^\s*(?:from|import)\s+([A-Za-z_]\w*)\.([A-Za-z_]\w*)"
+        )
+        from_import_re = re.compile(
+            r"(?m)^\s*from\s+([A-Za-z_][\w.]*)\s+import\s+(.+)$"
+        )
+        for _filename, code in blobs:
+            text = code or ""
+            for m in dotted_re.finditer(text):
+                root, leaf = m.group(1), m.group(2)
+                if leaf in bundled_stems:
+                    names.add(root)
+            for m in from_import_re.finditer(text):
+                root = m.group(1).split(".")[0]
+                imported = m.group(2)
+                symbols = re.findall(r"[A-Za-z_]\w*", imported.replace(" as ", " "))
+                if any(s in bundled_stems for s in symbols):
+                    names.add(root)
+
+        return names
+
+    # ── core scan ──────────────────────────────────────────────────────────────
+
+    async def scan(
+        self,
+        object_type: str,
+        uuid: str,
+        *,
+        pypi: Optional[bool] = None,
+        generated_at: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Resolve external dependencies for one object and persist them.
+
+        Returns ``{object_type, uuid, dependencies, summary}``. Raises ValueError
+        when the object is not found (the router maps that to 404).
+        """
+        obj = self._get_object(object_type, uuid)
+        if not obj:
+            raise ValueError(f"{object_type} {uuid} not found in store")
+
+        blobs = self._collect_code(object_type, obj)
+        local_modules = self._local_module_names(object_type, obj, blobs)
+
+        if generated_at is None:
+            # Computed here (not in the engine) so the engine stays deterministic.
+            from datetime import datetime, timezone
+
+            generated_at = datetime.now(timezone.utc).isoformat()
+
+        pypi_enabled = self._pypi_enabled if pypi is None else bool(pypi)
+        resolver = build_resolver(pypi_enabled=pypi_enabled)
+
+        # Resolution is synchronous (and PyPI uses blocking requests); run it off
+        # the event loop, mirroring the provenance plugin's gather.
+        report = await asyncio.to_thread(resolver.scan, blobs, local_modules)
+
+        block = report.to_extra_block(
+            generated_at=generated_at,
+            plugin_version=_PLUGIN_VERSION,
+            python_version=platform.python_version(),
+        )
+        self._persist(object_type, uuid, block, report.summary_tags())
+        return {
+            "object_type": object_type,
+            "uuid": uuid,
+            "dependencies": block,
+            "summary": block["summary"],
+        }
+
+    # ── persistence ──────────────────────────────────────────────────────────
+
+    def _persist(
+        self,
+        object_type: str,
+        uuid: str,
+        block: Dict[str, Any],
+        tags: List[str],
+    ) -> None:
+        """Write the dependency block to ``extra["dependencies"]`` + tags.
+
+        Non-destructive: other ``extra`` keys and non-``dep:`` tags are preserved.
+        """
+        obj = self._get_object(object_type, uuid)
+        if not obj:
+            return
+        if not isinstance(obj.get("extra"), dict):
+            obj["extra"] = {}
+        obj["extra"][_EXTRA_KEY] = block
+
+        obj["tags"] = self._strip_dep_tags(obj.get("tags") or []) + tags
+        self._write_object(object_type, uuid, obj)
+
+    def _write_object(self, object_type: str, uuid: str, obj: Dict[str, Any]) -> None:
+        writer = {
+            "skill": self.store.update_skill,
+            "tool": self.store.update_tool,
+            "snippet": self.store.update_snippet,
+        }.get(object_type)
+        if writer is None:
+            raise ValueError(f"Unsupported object_type: {object_type!r}")
+        writer(uuid, obj)
+
+    @staticmethod
+    def _strip_dep_tags(tags: List[str]) -> List[str]:
+        return [t for t in tags if not t.startswith(_TAG_PREFIX)]
+
+    # ── plugin interface ──────────────────────────────────────────────────────
+
+    def get_router(self):
+        from fastapi import APIRouter, HTTPException
+        from pydantic import BaseModel
+
+        router = APIRouter()
+
+        # Tolerant model: the store's generic action form only submits an enum
+        # field once changed, so a freshly-opened form may omit object_type. We
+        # default it and validate explicitly -> a friendly 400 (not a 422).
+        class ScanRequest(BaseModel):
+            object_type: str = "tool"
+            uuid: Optional[str] = None
+            pypi: Optional[bool] = None  # per-call override of the env default
+
+        def _validate(object_type: str, uuid: Optional[str]) -> None:
+            if object_type not in OBJECT_TYPES:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"object_type must be one of {list(OBJECT_TYPES)}; "
+                        f"got {object_type!r}"
+                    ),
+                )
+            if not (uuid and uuid.strip()):
+                raise HTTPException(status_code=400, detail="uuid is required")
+
+        @router.post("/scan")
+        async def scan_endpoint(request: ScanRequest):
+            """Resolve & record external Python dependencies for an object."""
+            _validate(request.object_type, request.uuid)
+            try:
+                data = await self.scan(
+                    request.object_type, request.uuid, pypi=request.pypi
+                )
+            except ValueError as e:
+                raise HTTPException(status_code=404, detail=str(e))
+            except HTTPException:
+                raise
+            except Exception as e:
+                logger.error("dependency scan failed: %s", e, exc_info=True)
+                raise HTTPException(status_code=500, detail=str(e))
+            return {
+                "success": True,
+                "message": _summary_message(data["dependencies"]),
+                "data": data,
+            }
+
+        return router
+
+    def get_cli_commands(self) -> Optional[Dict[str, Any]]:
+        return None
+
+    def get_ui_config(self) -> Optional[Dict[str, Any]]:
+        return {
+            "icon": "CubesIcon",
+            "color": "#C9190B",
+            "actions": [
+                {
+                    "label": "Scan dependencies",
+                    "endpoint": "/api/plugins/dependency_tracker/scan",
+                    "method": "POST",
+                    "params_schema": {
+                        "type": "object",
+                        "properties": {
+                            "object_type": {
+                                "type": "string",
+                                "enum": list(OBJECT_TYPES),
+                                "default": "tool",
+                                "description": "Which object type to scan",
+                            },
+                            "uuid": {
+                                "type": "string",
+                                "description": "UUID of the object to scan",
+                            },
+                        },
+                        "required": ["object_type", "uuid"],
+                    },
+                }
+            ],
+        }

--- a/plugins/skillberry-plugin-dependency-tracker/src/skillberry_plugin_dependency_tracker/resolver/__init__.py
+++ b/plugins/skillberry-plugin-dependency-tracker/src/skillberry_plugin_dependency_tracker/resolver/__init__.py
@@ -1,0 +1,126 @@
+"""Dependency resolution engine (Python + shell).
+
+``build_resolver()`` returns a facade that runs the full pipeline over a set of
+``(filename, code)`` blobs:
+
+  - detect each blob's language (python / shell / unsupported)
+  - python  -> extract imports -> resolve locally (transitive, max depth) ->
+               best-effort PyPI enrichment
+  - shell   -> extract external command names (system deps; no version/hash)
+  - unsupported -> recorded in ``report.skipped_files``
+
+Each stage lives in its own module and is independently unit-testable.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Optional, Tuple
+
+from .base import (
+    LANG_PYTHON,
+    LANG_SHELL,
+    ROOT,
+    SOURCE_SYSTEM,
+    DependencyReport,
+    PackageDep,
+)
+from .imports import extract_top_level_imports
+from .languages import detect_language
+from .local import resolve_local
+from .pypi import DEFAULT_TIMEOUT, enrich_report, pypi_enabled_from_env
+from .shell import extract_shell_commands
+
+__all__ = [
+    "DependencyReport",
+    "PackageDep",
+    "extract_top_level_imports",
+    "extract_shell_commands",
+    "detect_language",
+    "resolve_local",
+    "enrich_report",
+    "Resolver",
+    "build_resolver",
+]
+
+# A code blob the plugin hands to the engine: its source filename (for language
+# detection + skipped-file reporting) and the source text.
+Blob = Tuple[str, str]  # (filename, code)
+
+
+class Resolver:
+    """Runs language detection -> per-language extraction -> enrichment."""
+
+    def __init__(self, pypi_enabled: bool = True, timeout: float = DEFAULT_TIMEOUT):
+        self.pypi_enabled = pypi_enabled
+        self.timeout = timeout
+
+    def scan(
+        self, blobs: Iterable[Blob], local_modules: Optional[set] = None
+    ) -> DependencyReport:
+        """Resolve dependencies across ``(filename, code)`` blobs.
+
+        ``local_modules`` is the set of top-level module names bundled with the
+        object itself (first-party code); imports matching them are classified
+        ``local_module`` rather than reported as missing external deps.
+
+        Synchronous (PyPI uses blocking ``requests``); the plugin offloads this to
+        a thread so it never blocks the event loop.
+        """
+        py_imports: set = set()
+        shell_cmds: set = set()
+        report = DependencyReport()
+
+        for filename, code in blobs:
+            lang = detect_language(filename, code or "")
+            if lang == LANG_PYTHON:
+                report.languages_seen.add(LANG_PYTHON)
+                py_imports |= extract_top_level_imports(code or "")
+            elif lang == LANG_SHELL:
+                report.languages_seen.add(LANG_SHELL)
+                shell_cmds |= extract_shell_commands(code or "")
+            else:
+                report.add_skipped(
+                    filename or "<unknown>",
+                    "unknown",
+                    "unsupported_language",
+                )
+
+        # Python: resolve locally into a fresh report, then fold into ours.
+        if py_imports:
+            py_report = resolve_local(py_imports, local_modules=local_modules)
+            enrich_report(py_report, enabled=self.pypi_enabled, timeout=self.timeout)
+            self._merge(report, py_report)
+
+        # Shell: each external command is a direct, system-source dependency.
+        for cmd in sorted(shell_cmds):
+            if cmd in report.packages:
+                report.packages[cmd].direct = True
+            else:
+                report.packages[cmd] = PackageDep(
+                    name=cmd,
+                    version=None,
+                    source=SOURCE_SYSTEM,
+                    language=LANG_SHELL,
+                    direct=True,
+                    depth=0,
+                )
+            report.add_edge(ROOT, cmd, 0)
+
+        return report
+
+    @staticmethod
+    def _merge(into: DependencyReport, other: DependencyReport) -> None:
+        into.packages.update(other.packages)
+        for e in other.edges:
+            into.add_edge(*e)
+        for u in other.unresolved:
+            into.add_unresolved(u["import_name"], u["reason"])
+
+
+def build_resolver(
+    pypi_enabled: Optional[bool] = None, timeout: float = DEFAULT_TIMEOUT
+) -> Resolver:
+    """Construct a Resolver. ``pypi_enabled=None`` consults the environment."""
+    if pypi_enabled is None:
+        pypi_enabled = pypi_enabled_from_env()
+    return Resolver(pypi_enabled=pypi_enabled, timeout=timeout)

--- a/plugins/skillberry-plugin-dependency-tracker/src/skillberry_plugin_dependency_tracker/resolver/base.py
+++ b/plugins/skillberry-plugin-dependency-tracker/src/skillberry_plugin_dependency_tracker/resolver/base.py
@@ -1,0 +1,202 @@
+"""Dependency-report shapes + constants for the resolver engine.
+
+The engine discovers an object's external Python dependencies and assembles a
+``DependencyReport``, which serializes to the hierarchical ``extra["dependencies"]``
+block the plugin persists. Everything here is pure and JSON-friendly so the engine
+can be unit-tested offline; ``generated_at`` is injected by the plugin (not computed
+here) to keep serialized output deterministic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+SCHEMA_VERSION = 1
+RESOLVER_NAME = "hybrid"
+
+OBJECT_TYPES = ("skill", "tool", "snippet")
+
+# Languages the resolver can inspect. Anything else is recorded in
+# ``skipped_files`` with reason ``unsupported_language``.
+LANG_PYTHON = "python"
+LANG_SHELL = "shell"
+SUPPORTED_LANGUAGES = (LANG_PYTHON, LANG_SHELL)
+
+# Sentinel "from" node for direct (depth-0) edges in the dependency tree.
+ROOT = "<root>"
+
+# package source / pypi status vocabularies
+SOURCE_LOCAL = "local"  # python dist resolved from the local environment
+SOURCE_PYPI = "pypi"
+SOURCE_SYSTEM = "system"  # shell command / external executable (no version/hash)
+SOURCE_UNRESOLVED = "unresolved"
+
+PYPI_OK = "ok"
+PYPI_ERROR = "error"
+PYPI_TIMEOUT = "timeout"
+PYPI_NOT_FOUND = "not_found"
+PYPI_SKIPPED = "skipped"
+
+# Why an import could not be resolved to an installed external distribution.
+REASON_NOT_INSTALLED = "not_installed"  # real external pkg, just absent here
+REASON_NO_DISTRIBUTION = "no_distribution"  # nothing installed provides it
+REASON_LOCAL_MODULE = "local_module"  # first-party module bundled in the object
+# Reasons that are NOT a missing external dependency (so excluded from the
+# actionable "missing" count).
+NON_MISSING_REASONS = (REASON_LOCAL_MODULE,)
+
+
+@dataclass
+class PackageDep:
+    """One resolved distribution in the dependency graph."""
+
+    name: str
+    version: Optional[str] = None  # local installed version = source of truth
+    source: str = SOURCE_LOCAL
+    language: str = LANG_PYTHON  # which ecosystem this dependency belongs to
+    direct: bool = False  # imported directly by the object's own code
+    depth: int = 0  # 0 = direct; min BFS distance from a root otherwise
+    local_hashes: List[Dict[str, str]] = field(default_factory=list)
+    requires: List[str] = field(default_factory=list)  # child dist names
+    pypi: Optional[Dict[str, Any]] = None  # None until/unless enriched
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "version": self.version,
+            "source": self.source,
+            "language": self.language,
+            "direct": self.direct,
+            "depth": self.depth,
+            "local_hashes": sorted(self.local_hashes, key=lambda h: h.get("file", "")),
+            "requires": sorted(self.requires),
+            "pypi": self.pypi,
+        }
+
+
+@dataclass
+class DependencyReport:
+    """Full resolved graph for an object, plus anything that couldn't be mapped."""
+
+    packages: Dict[str, PackageDep] = field(default_factory=dict)
+    edges: List[Tuple[str, str, int]] = field(default_factory=list)
+    unresolved: List[Dict[str, str]] = field(default_factory=list)
+    # Files we could not inspect because their language is unsupported (or the
+    # content was unidentifiable). Each: {file, language, reason}.
+    skipped_files: List[Dict[str, str]] = field(default_factory=list)
+    # Languages actually inspected (e.g. {"python", "shell"}).
+    languages_seen: set = field(default_factory=set)
+
+    # ── assembly helpers (used by the engine while resolving) ────────────────
+
+    def add_edge(self, src: str, dst: str, depth: int) -> None:
+        edge = (src, dst, depth)
+        if edge not in self.edges:
+            self.edges.append(edge)
+
+    def add_unresolved(self, import_name: str, reason: str) -> None:
+        entry = {"import_name": import_name, "reason": reason}
+        if entry not in self.unresolved:
+            self.unresolved.append(entry)
+
+    def add_skipped(self, file: str, language: str, reason: str) -> None:
+        entry = {"file": file, "language": language, "reason": reason}
+        if entry not in self.skipped_files:
+            self.skipped_files.append(entry)
+
+    # ── serialization ────────────────────────────────────────────────────────
+
+    def _pypi_status(self) -> str:
+        """Roll per-package pypi.status up into ok | partial | skipped."""
+        statuses = [
+            (p.pypi or {}).get("status")
+            for p in self.packages.values()
+            if p.pypi is not None
+        ]
+        if not statuses:
+            return PYPI_SKIPPED
+        if all(s == PYPI_OK for s in statuses):
+            return PYPI_OK
+        if any(s == PYPI_OK for s in statuses):
+            return "partial"
+        return PYPI_SKIPPED
+
+    def _update_available_count(self) -> int:
+        return sum(
+            1 for p in self.packages.values() if (p.pypi or {}).get("update_available")
+        )
+
+    def _missing_count(self) -> int:
+        """Unresolved imports that are genuinely missing EXTERNAL deps.
+
+        Excludes first-party bundled modules (``local_module``), which are not
+        dependencies at all — only actionable "this package isn't available"
+        cases are counted.
+        """
+        return sum(
+            1 for u in self.unresolved if u.get("reason") not in NON_MISSING_REASONS
+        )
+
+    def _local_module_count(self) -> int:
+        return sum(1 for u in self.unresolved if u.get("reason") == REASON_LOCAL_MODULE)
+
+    def to_extra_block(
+        self,
+        *,
+        generated_at: str,
+        plugin_version: str,
+        python_version: str,
+    ) -> Dict[str, Any]:
+        """Assemble the deterministic ``extra["dependencies"]`` block."""
+        direct = sorted(n for n, p in self.packages.items() if p.direct)
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "generated_at": generated_at,
+            "supported_languages": list(SUPPORTED_LANGUAGES),
+            "languages_inspected": sorted(self.languages_seen),
+            "scanner": {
+                "plugin_version": plugin_version,
+                "resolver": RESOLVER_NAME,
+                "python_version": python_version,
+            },
+            "summary": {
+                "direct_count": len(direct),
+                "total_count": len(self.packages),
+                "unresolved_count": len(self.unresolved),
+                "missing_count": self._missing_count(),
+                "local_module_count": self._local_module_count(),
+                "skipped_count": len(self.skipped_files),
+                "update_available_count": self._update_available_count(),
+                "pypi_status": self._pypi_status(),
+            },
+            "packages": {
+                name: self.packages[name].to_dict() for name in sorted(self.packages)
+            },
+            "tree": [
+                {"from": s, "to": d, "depth": dep} for s, d, dep in sorted(self.edges)
+            ],
+            "unresolved_imports": sorted(
+                self.unresolved, key=lambda u: u.get("import_name", "")
+            ),
+            "skipped_files": sorted(
+                self.skipped_files, key=lambda s: s.get("file", "")
+            ),
+        }
+
+    def summary_tags(self) -> List[str]:
+        """Short, scannable tags for the generic plugin UI / search."""
+        tags = [
+            f"dep:count:{len(self.packages)}",
+            f"dep:unresolved:{len(self.unresolved)}",
+        ]
+        missing = self._missing_count()
+        if missing:
+            tags.append(f"dep:missing:{missing}")
+        if self.skipped_files:
+            tags.append(f"dep:skipped:{len(self.skipped_files)}")
+        for lang in sorted(self.languages_seen):
+            tags.append(f"dep:lang:{lang}")
+        if self._update_available_count():
+            tags.append("dep:update-available")
+        return tags

--- a/plugins/skillberry-plugin-dependency-tracker/src/skillberry_plugin_dependency_tracker/resolver/imports.py
+++ b/plugins/skillberry-plugin-dependency-tracker/src/skillberry_plugin_dependency_tracker/resolver/imports.py
@@ -1,0 +1,64 @@
+"""Extract top-level external imports from Python source via AST.
+
+Mirrors the AST precedent in the store
+(``src/skillberry_store/modules/file_executor.py`` uses ``ast.Import`` /
+``ast.ImportFrom``) but reduces each import to its **top-level module name** and
+filters out the standard library and relative imports, leaving only the external
+modules whose distributions we then resolve.
+
+Best-effort: a ``SyntaxError`` (e.g. Python 2 code, a template fragment) yields an
+empty set rather than raising — a scan should never fail on unparseable input.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from typing import Set
+
+# Python 3.10+ (the plugin's floor) exposes the stdlib module set directly.
+_STDLIB: Set[str] = set(getattr(sys, "stdlib_module_names", ()))
+
+# Small belt-and-suspenders fallback for names that are effectively stdlib/builtin
+# but may not appear in stdlib_module_names on every interpreter.
+_EXTRA_STDLIB = {
+    "__future__",
+    "builtins",
+    "typing_extensions",  # ships with CPython tooling; treat as non-external noise
+}
+
+
+def _is_stdlib(top_level: str) -> bool:
+    return top_level in _STDLIB or top_level in _EXTRA_STDLIB
+
+
+def extract_top_level_imports(code: str) -> Set[str]:
+    """Return the set of external top-level module names imported by ``code``.
+
+    - ``import a.b.c`` / ``import a as x`` -> ``a``
+    - ``from a.b import c`` -> ``a`` (only absolute imports; ``node.level == 0``)
+    - relative imports (``from . import x``, ``from ..p import y``) are skipped
+    - standard-library top-level names are excluded
+    - unparseable input returns an empty set
+    """
+    try:
+        tree = ast.parse(code or "")
+    except (SyntaxError, ValueError):
+        return set()
+
+    found: Set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                top = (alias.name or "").split(".")[0]
+                if top and not _is_stdlib(top):
+                    found.add(top)
+        elif isinstance(node, ast.ImportFrom):
+            # node.level > 0 means a relative import (no external dist).
+            if node.level and node.level > 0:
+                continue
+            module = node.module or ""
+            top = module.split(".")[0]
+            if top and not _is_stdlib(top):
+                found.add(top)
+    return found

--- a/plugins/skillberry-plugin-dependency-tracker/src/skillberry_plugin_dependency_tracker/resolver/languages.py
+++ b/plugins/skillberry-plugin-dependency-tracker/src/skillberry_plugin_dependency_tracker/resolver/languages.py
@@ -1,0 +1,88 @@
+"""Language detection for a code blob.
+
+Routes each collected file to the right extractor (Python or shell) or marks it
+unsupported. Detection uses the filename extension first (most reliable for store
+tools, whose ``module_name`` carries a real extension), then a shebang, then a
+light content heuristic. Returns ``None`` when the language is unsupported, so
+the caller can record the file in ``skipped_files``.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+from .base import LANG_PYTHON, LANG_SHELL
+
+# Extension -> language.
+_EXT_LANG = {
+    ".py": LANG_PYTHON,
+    ".pyw": LANG_PYTHON,
+    ".pyi": LANG_PYTHON,
+    ".sh": LANG_SHELL,
+    ".bash": LANG_SHELL,
+    ".zsh": LANG_SHELL,
+    ".ksh": LANG_SHELL,
+}
+
+_SHEBANG_RE = re.compile(r"^#!\s*(\S+)")
+
+
+def _from_shebang(code: str) -> Optional[str]:
+    first = (code or "").lstrip().splitlines()[:1]
+    if not first:
+        return None
+    m = _SHEBANG_RE.match(first[0])
+    if not m:
+        return None
+    interp = m.group(1).rsplit("/", 1)[-1]
+    if interp.startswith("python"):
+        return LANG_PYTHON
+    if interp in ("sh", "bash", "zsh", "ksh", "dash") or interp == "env":
+        # `#!/usr/bin/env bash` -> the env arg is on the same token list; keep
+        # it simple: env defaults to shell unless a python arg follows.
+        return LANG_SHELL
+    return None
+
+
+# Light content heuristics for blobs with no extension (e.g. snippets). Applied
+# only after extension + shebang fail. Deliberately conservative.
+_PY_HINT = re.compile(
+    r"(?m)^\s*(?:import\s+\w|from\s+[\w.]+\s+import\s|def\s+\w+\s*\(|class\s+\w+\s*[:(])"
+)
+_SH_HINT = re.compile(
+    r"(?m)^\s*(?:export\s+\w+=|if\s+\[|for\s+\w+\s+in\s|fi\b|done\b|"
+    r"\w+\s*=\s*\$\(|echo\s)"
+)
+
+
+def _from_content(code: str) -> Optional[str]:
+    text = code or ""
+    if _PY_HINT.search(text):
+        return LANG_PYTHON
+    if _SH_HINT.search(text):
+        return LANG_SHELL
+    return None
+
+
+def detect_language(filename: Optional[str], code: str) -> Optional[str]:
+    """Best-effort language for a blob. ``None`` => unsupported / unknown.
+
+    Order of evidence: filename extension, then shebang, then a light content
+    heuristic (for extension-less blobs such as snippets).
+    """
+    name = (filename or "").lower()
+    for ext, lang in _EXT_LANG.items():
+        if name.endswith(ext):
+            return lang
+
+    # `#!/usr/bin/env python3` etc.
+    shebang = _from_shebang(code or "")
+    if shebang:
+        # refine env-python case
+        first_line = (code or "").lstrip().splitlines()[:1]
+        if first_line and "python" in first_line[0]:
+            return LANG_PYTHON
+        return shebang
+
+    return _from_content(code or "")

--- a/plugins/skillberry-plugin-dependency-tracker/src/skillberry_plugin_dependency_tracker/resolver/local.py
+++ b/plugins/skillberry-plugin-dependency-tracker/src/skillberry_plugin_dependency_tracker/resolver/local.py
@@ -1,0 +1,231 @@
+"""Local dependency resolution via ``importlib.metadata`` (the source of truth).
+
+This resolves what the object *actually runs against* in the current
+environment: the installed version of each distribution, the per-file hashes
+recorded in its ``RECORD``, and its transitive ``Requires-Dist`` graph walked at
+**maximum depth** with cycle/diamond protection.
+
+It is deliberately decoupled from the store and from the network so it is
+trivially unit-testable. PyPI enrichment is layered on separately in ``pypi.py``.
+"""
+
+from __future__ import annotations
+
+import re
+from importlib import metadata as importlib_metadata
+from typing import Dict, List, Optional, Set
+
+from .base import (
+    REASON_LOCAL_MODULE,
+    REASON_NO_DISTRIBUTION,
+    REASON_NOT_INSTALLED,
+    ROOT,
+    SOURCE_LOCAL,
+    SOURCE_UNRESOLVED,
+    DependencyReport,
+    PackageDep,
+)
+
+# A Requires-Dist line looks like e.g.:
+#   "urllib3 (>=1.21.1,<3)"
+#   "PySocks (>=1.5.6,!=1.5.7) ; extra == 'socks'"
+#   "charset-normalizer<4,>=2"
+# We want just the bare distribution name at the start of the line.
+_DIST_NAME_RE = re.compile(r"^\s*([A-Za-z0-9][A-Za-z0-9._-]*)")
+
+
+def _canonical(name: str) -> str:
+    """PEP 503 normalization so 'Charset_Normalizer' == 'charset-normalizer'."""
+    return re.sub(r"[-_.]+", "-", name or "").lower()
+
+
+def import_to_distributions(import_name: str) -> List[str]:
+    """Map a top-level import name to the distribution(s) that provide it.
+
+    Uses ``packages_distributions()`` (top-level module -> [dist names]). Returns
+    an empty list when nothing installed provides the import.
+    """
+    try:
+        mapping = importlib_metadata.packages_distributions()
+    except Exception:
+        return []
+    return list(mapping.get(import_name, []))
+
+
+def local_version(dist: str) -> Optional[str]:
+    try:
+        return importlib_metadata.version(dist)
+    except importlib_metadata.PackageNotFoundError:
+        return None
+    except Exception:
+        return None
+
+
+def local_record_hashes(dist: str) -> List[Dict[str, str]]:
+    """Per-file hashes from the distribution's RECORD (base64 sha256).
+
+    Returns ``[]`` when the install records no hashes (editable installs, some
+    wheels, ``--no-binary`` builds) — the package entry is still valid without them.
+    """
+    try:
+        d = importlib_metadata.distribution(dist)
+        files = d.files or []
+    except Exception:
+        return []
+    out: List[Dict[str, str]] = []
+    for f in files:
+        h = getattr(f, "hash", None)
+        if h is None:
+            continue
+        mode = getattr(h, "mode", None) or "sha256"
+        value = getattr(h, "value", None)
+        if not value:
+            continue
+        out.append({"file": str(f), "algorithm": mode, "hash": value})
+    return out
+
+
+# Matches an `extra == '...'` clause anywhere in a marker (regex fallback path).
+_EXTRA_MARKER_RE = re.compile(r"extra\s*==")
+
+
+def _requirement_applies(line: str) -> bool:
+    """True if a ``Requires-Dist`` line is a DEFAULT runtime dependency.
+
+    Excludes optional ``extra``-gated requirements (e.g. ``PySocks; extra ==
+    'socks'``) and requirements whose environment marker is not satisfied here
+    (e.g. ``; python_version < '3.8'``). These are not dependencies of an object
+    that merely imports the package — reporting them as "missing" is wrong.
+
+    Uses ``packaging`` when available for correct marker evaluation; otherwise
+    falls back to: keep the line unless it carries an ``extra ==`` clause.
+    """
+    if ";" not in line:
+        return True  # no marker -> always a runtime dep
+    marker_text = line.split(";", 1)[1].strip()
+    if not marker_text:
+        return True
+    try:
+        from packaging.markers import Marker
+
+        marker = Marker(marker_text)
+        # Evaluate with NO extras active -> default install profile. `extra` is
+        # supplied as empty so any `extra == '...'` clause is False.
+        return bool(marker.evaluate({"extra": ""}))
+    except Exception:
+        # Fallback: only filter the most common over-inclusion (extras).
+        return not _EXTRA_MARKER_RE.search(marker_text)
+
+
+def local_requires(dist: str) -> List[str]:
+    """Default runtime dependency distribution names from ``Requires-Dist``.
+
+    Only DEFAULT dependencies are returned: extra-gated and unsatisfied-marker
+    requirements are excluded (see ``_requirement_applies``), so optional extras
+    of transitive packages are not mistaken for missing dependencies.
+    """
+    try:
+        reqs = importlib_metadata.requires(dist) or []
+    except Exception:
+        return []
+    names: List[str] = []
+    for line in reqs:
+        if not line or not _requirement_applies(line):
+            continue
+        m = _DIST_NAME_RE.match(line)
+        if m:
+            names.append(m.group(1))
+    # de-dup, preserve first-seen order
+    seen: Set[str] = set()
+    ordered: List[str] = []
+    for n in names:
+        key = _canonical(n)
+        if key not in seen:
+            seen.add(key)
+            ordered.append(n)
+    return ordered
+
+
+def resolve_local(
+    import_names: Set[str], local_modules: Optional[Set[str]] = None
+) -> DependencyReport:
+    """Resolve direct imports + their transitive deps at maximum depth.
+
+    BFS from the direct imports; a ``visited`` set guarantees each distribution is
+    expanded once (cycle/diamond safe). Depth is the minimum distance from a root.
+    Imports that map to no installed distribution are recorded in
+    ``report.unresolved`` rather than dropped.
+
+    ``local_modules`` is the set of top-level module names that are bundled with
+    the object itself (first-party code, e.g. a skill's ``helpers``/``office``
+    packages). An unmapped import matching one of these is classified
+    ``local_module`` — it is NOT a missing external dependency.
+    """
+    local_modules = {_canonical(m) for m in (local_modules or set())}
+    report = DependencyReport()
+
+    def _unresolved_reason(name: str) -> str:
+        if _canonical(name) in local_modules:
+            return REASON_LOCAL_MODULE
+        # known to the env (importable metadata) but not provided as a dist, vs
+        # nothing at all installed under that name.
+        return (
+            REASON_NOT_INSTALLED
+            if local_version(name) is not None
+            else REASON_NO_DISTRIBUTION
+        )
+
+    # Seed the queue with directly-imported distributions.
+    # queue items: (dist_name, parent_node, depth, is_direct)
+    queue: List = []
+    for import_name in sorted(import_names):
+        dists = import_to_distributions(import_name)
+        if not dists:
+            report.add_unresolved(import_name, _unresolved_reason(import_name))
+            continue
+        for dist in dists:
+            queue.append((dist, ROOT, 0, True))
+
+    visited: Set[str] = set()
+    while queue:
+        dist, parent, depth, direct = queue.pop(0)
+        canon = _canonical(dist)
+
+        # Always record the edge (captures diamonds/cycles in the tree).
+        report.add_edge(parent, dist, depth)
+
+        if canon in visited:
+            # Already expanded; if newly seen as direct, upgrade the flag, and
+            # keep the shallowest depth.
+            existing = report.packages.get(dist)
+            if existing is not None:
+                if direct:
+                    existing.direct = True
+                existing.depth = min(existing.depth, depth)
+            continue
+        visited.add(canon)
+
+        version = local_version(dist)
+        pkg = PackageDep(
+            name=dist,
+            version=version,
+            source=SOURCE_LOCAL if version is not None else SOURCE_UNRESOLVED,
+            direct=direct,
+            depth=depth,
+            local_hashes=local_record_hashes(dist) if version is not None else [],
+            requires=local_requires(dist) if version is not None else [],
+        )
+        report.packages[dist] = pkg
+
+        for child in pkg.requires:
+            # Only descend into children that are actually installed; an
+            # uninstalled optional dep is noted but not expanded.
+            if local_version(child) is None:
+                # A declared (non-extra) runtime dep that isn't installed: a
+                # genuinely missing external package.
+                report.add_unresolved(child, REASON_NOT_INSTALLED)
+                report.add_edge(dist, child, depth + 1)
+                continue
+            queue.append((child, dist, depth + 1, False))
+
+    return report

--- a/plugins/skillberry-plugin-dependency-tracker/src/skillberry_plugin_dependency_tracker/resolver/pypi.py
+++ b/plugins/skillberry-plugin-dependency-tracker/src/skillberry_plugin_dependency_tracker/resolver/pypi.py
@@ -1,0 +1,135 @@
+"""Best-effort, time-boxed PyPI enrichment.
+
+Local resolution is the source of truth; this layer *adds* the canonical
+published artifact sha256 and an "update available" signal from the PyPI JSON
+API. It is strictly best-effort: any failure (rate-limit 429, timeout, offline,
+404) becomes a per-package ``status`` and never raises — a scan must succeed even
+when PyPI is unreachable (CI has hit 429s).
+
+Enablement is env-gated: ``DEPENDENCY_TRACKER_PYPI=off`` (or ``0``/``false``)
+disables enrichment entirely.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, Optional
+
+import requests
+
+from .base import (
+    PYPI_ERROR,
+    PYPI_NOT_FOUND,
+    PYPI_OK,
+    PYPI_SKIPPED,
+    PYPI_TIMEOUT,
+    DependencyReport,
+)
+
+logger = logging.getLogger(__name__)
+
+PYPI_URL = "https://pypi.org/pypi/{dist}/json"
+DEFAULT_TIMEOUT = 3.0
+
+
+def pypi_enabled_from_env() -> bool:
+    """Default enrichment on; disabled by DEPENDENCY_TRACKER_PYPI in {0,off,false,no}."""
+    val = os.getenv("DEPENDENCY_TRACKER_PYPI")
+    if val is None:
+        return True
+    return val.strip().lower() not in ("0", "off", "false", "no")
+
+
+def _version_gt(latest: Optional[str], local: Optional[str]) -> bool:
+    """True when ``latest`` is a newer release than ``local`` (PEP 440 if available)."""
+    if not latest or not local:
+        return False
+    try:
+        from packaging.version import parse as _parse  # optional dep
+
+        return _parse(latest) > _parse(local)
+    except Exception:
+        # Fallback: a plain inequality is a weak but safe signal.
+        return latest != local
+
+
+def _extract_artifact_hashes(data: Dict[str, Any]) -> Dict[str, str]:
+    """Pull sdist + wheel sha256 from a PyPI ``/json`` payload's ``urls`` block."""
+    out: Dict[str, str] = {}
+    for entry in data.get("urls") or []:
+        ptype = entry.get("packagetype")
+        sha = (entry.get("digests") or {}).get("sha256")
+        if not sha:
+            continue
+        if ptype == "sdist" and "sdist" not in out:
+            out["sdist"] = sha
+        elif ptype == "bdist_wheel" and "wheel" not in out:
+            out["wheel"] = sha
+    return out
+
+
+def enrich_from_pypi(
+    dist: str,
+    local_version: Optional[str],
+    *,
+    timeout: float = DEFAULT_TIMEOUT,
+    session: Optional[requests.Session] = None,
+) -> Dict[str, Any]:
+    """Return a pypi block for one distribution. Never raises."""
+    getter = session.get if session is not None else requests.get
+    try:
+        resp = getter(PYPI_URL.format(dist=dist), timeout=timeout)
+    except requests.Timeout:
+        return {"status": PYPI_TIMEOUT}
+    except requests.RequestException as e:
+        logger.debug("pypi enrich failed for %s: %s", dist, e)
+        return {"status": PYPI_ERROR}
+
+    if resp.status_code == 404:
+        return {"status": PYPI_NOT_FOUND}
+    if resp.status_code != 200:
+        # 429 and friends land here — best-effort, treat as a soft error.
+        return {"status": PYPI_ERROR}
+
+    try:
+        data = resp.json()
+    except ValueError:
+        return {"status": PYPI_ERROR}
+
+    latest = (data.get("info") or {}).get("version")
+    return {
+        "status": PYPI_OK,
+        "latest_version": latest,
+        "update_available": _version_gt(latest, local_version),
+        "artifact_sha256": _extract_artifact_hashes(data),
+    }
+
+
+def enrich_report(
+    report: DependencyReport,
+    *,
+    enabled: bool = True,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> str:
+    """Enrich every package in ``report`` in place. Returns rolled-up status.
+
+    When ``enabled`` is False, leaves every ``pypi`` as None and returns
+    ``skipped``. Reuses a single :class:`requests.Session` for connection reuse.
+    """
+    if not enabled:
+        return PYPI_SKIPPED
+
+    session = requests.Session()
+    try:
+        for name in sorted(report.packages):
+            pkg = report.packages[name]
+            if pkg.version is None:
+                # Nothing locally resolved; don't attribute a pypi block.
+                continue
+            pkg.pypi = enrich_from_pypi(
+                pkg.name, pkg.version, timeout=timeout, session=session
+            )
+    finally:
+        session.close()
+    return report._pypi_status()

--- a/plugins/skillberry-plugin-dependency-tracker/src/skillberry_plugin_dependency_tracker/resolver/shell.py
+++ b/plugins/skillberry-plugin-dependency-tracker/src/skillberry_plugin_dependency_tracker/resolver/shell.py
@@ -1,0 +1,239 @@
+"""Extract external command dependencies from shell scripts.
+
+A shell script's "dependencies" are the external executables it invokes
+(``curl``, ``jq``, ``node``, ``zip`` …) — the shell analogue of Python imports.
+We extract the command tokens, drop shell builtins/keywords and anything defined
+in the script itself (functions, aliases, assigned variables used as commands),
+and return the set of external command names.
+
+These are *system* dependencies: they have no version or artifact hash here (they
+are whatever is installed on the host), so the plugin records them with
+``source: "system"`` and no hashes — distinct from resolved PyPI packages.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Set
+
+# POSIX/bash builtins + common keywords that are never external deps.
+_SHELL_BUILTINS = {
+    "alias",
+    "bg",
+    "bind",
+    "break",
+    "builtin",
+    "caller",
+    "case",
+    "cd",
+    "command",
+    "compgen",
+    "complete",
+    "continue",
+    "declare",
+    "dirs",
+    "disown",
+    "do",
+    "done",
+    "echo",
+    "elif",
+    "else",
+    "enable",
+    "esac",
+    "eval",
+    "exec",
+    "exit",
+    "export",
+    "fi",
+    "fg",
+    "for",
+    "function",
+    "getopts",
+    "hash",
+    "help",
+    "history",
+    "if",
+    "in",
+    "jobs",
+    "kill",
+    "let",
+    "local",
+    "logout",
+    "popd",
+    "printf",
+    "pushd",
+    "pwd",
+    "read",
+    "readarray",
+    "readonly",
+    "return",
+    "select",
+    "set",
+    "shift",
+    "shopt",
+    "source",
+    "suspend",
+    "test",
+    "then",
+    "time",
+    "times",
+    "trap",
+    "type",
+    "typeset",
+    "ulimit",
+    "umask",
+    "unalias",
+    "unset",
+    "until",
+    "wait",
+    "while",
+    "true",
+    "false",
+    ":",
+    ".",
+    "[",
+    "[[",
+    "]]",
+    "fc",
+    "mapfile",
+}
+
+# Split a logical line into statement segments at command separators. We split
+# on ; | & and the openers $( ` and `&&`/`||` so each segment's first bareword is
+# a command in command position.
+_SEGMENT_SPLIT = re.compile(r"(?:\|\||&&|[;|&`]|\$\()")
+
+# A command name: a bareword that may include dots/dashes (docker-compose) but is
+# a plausible executable name (must contain a letter, no spaces).
+_CMD_NAME = re.compile(r"^[A-Za-z_][\w.-]*$")
+
+# Leading control words that may precede the real command on a segment.
+_PREFIX_WORDS = {"sudo", "command", "exec", "nohup", "time", "then", "do", "else", "!"}
+
+# A heredoc start: `<<EOF`, `<<-EOF`, `<< "EOF"`, `cat <<'EOF'` -> capture tag.
+_HEREDOC_RE = re.compile(r"<<-?\s*[\"']?([A-Za-z_]\w*)[\"']?")
+
+
+def _local_function_names(code: str) -> Set[str]:
+    """Names of functions defined in the script (so calls to them aren't deps)."""
+    names: Set[str] = set()
+    for m in re.finditer(r"(?m)^\s*([A-Za-z_]\w*)\s*\(\)\s*\{?", code):
+        names.add(m.group(1))
+    for m in re.finditer(r"(?m)^\s*function\s+([A-Za-z_]\w*)", code):
+        names.add(m.group(1))
+    return names
+
+
+def _count_unescaped(line: str, quote: str) -> int:
+    """Count unescaped occurrences of ``quote`` in ``line``."""
+    n = 0
+    i = 0
+    while i < len(line):
+        c = line[i]
+        if c == "\\":
+            i += 2
+            continue
+        if c == quote:
+            n += 1
+        i += 1
+    return n
+
+
+def _logical_lines(code: str) -> list:
+    """Yield code lines with comments, shebang, heredoc bodies, and multi-line
+    quoted-string bodies removed.
+
+    Two big false-positive sources are excluded here:
+      - heredoc bodies (``cat <<EOF`` emitting a JS/CSS/JSON file), and
+      - multi-line quoted arguments (``node -e "<inline JS spanning lines>"``).
+    In both cases the embedded content is data, not shell, and must not be
+    parsed as commands.
+    """
+    out = []
+    heredoc_tag = None
+    open_quote = None  # we are inside a multi-line '...' or "..." string
+    for raw in (code or "").splitlines():
+        if heredoc_tag is not None:
+            if raw.strip() == heredoc_tag:
+                heredoc_tag = None
+            continue
+
+        if open_quote is not None:
+            # Inside a multi-line string body: drop the line; if the quote closes
+            # here (odd count), resume normal parsing afterwards.
+            if _count_unescaped(raw, open_quote) % 2 == 1:
+                open_quote = None
+            continue
+
+        line = raw
+        stripped = line.lstrip()
+        if stripped.startswith("#"):  # comment / shebang
+            continue
+
+        # Heredoc opener: keep the command part before ``<<``.
+        m = _HEREDOC_RE.search(line)
+        if m:
+            heredoc_tag = m.group(1)
+            line = line[: m.start()]
+
+        # Strip a trailing ` # comment` (best-effort, ignores quoting).
+        hash_idx = line.find(" #")
+        if hash_idx != -1:
+            line = line[:hash_idx]
+
+        # Detect an unterminated quote that opens a multi-line string (e.g.
+        # ``node -e "`` ... ``"``). If a quote char appears an odd number of
+        # times on this line, the string continues onto the next line.
+        for q in ('"', "'"):
+            if _count_unescaped(line, q) % 2 == 1:
+                open_quote = q
+                break
+
+        if line.strip():
+            out.append(line)
+    return out
+
+
+def extract_shell_commands(code: str) -> Set[str]:
+    """Return external command names invoked by ``code`` (best-effort).
+
+    Heredoc bodies are excluded, only the first bareword of each statement
+    segment is considered, and builtins / locally-defined functions / path-based
+    invocations / assignments are dropped.
+    """
+    if not code:
+        return set()
+    local_funcs = _local_function_names(code)
+    commands: Set[str] = set()
+
+    for line in _logical_lines(code):
+        for segment in _SEGMENT_SPLIT.split(line):
+            tokens = segment.split()
+            # Walk past leading control words (sudo, command, then, …) and any
+            # leading VAR=val assignments to reach the actual command token.
+            idx = 0
+            while idx < len(tokens) and (
+                tokens[idx] in _PREFIX_WORDS or "=" in tokens[idx].split("/")[0]
+            ):
+                # stop if this is a real command that merely contains '=' in an
+                # arg; assignment prefixes are NAME=VALUE with no spaces.
+                if "=" in tokens[idx] and re.match(r"^[A-Za-z_]\w*=", tokens[idx]):
+                    idx += 1
+                    continue
+                if tokens[idx] in _PREFIX_WORDS:
+                    idx += 1
+                    continue
+                break
+            if idx >= len(tokens):
+                continue
+            first = tokens[idx]
+            if first.startswith((".", "/", "$", "-", '"', "'", "(", "{", "}")):
+                continue
+            if not _CMD_NAME.match(first):
+                continue
+            if first in _SHELL_BUILTINS or first in local_funcs:
+                continue
+            if first.isdigit():
+                continue
+            commands.add(first)
+    return commands

--- a/plugins/skillberry-plugin-dependency-tracker/tests/test_dependency_tracker_plugin.py
+++ b/plugins/skillberry-plugin-dependency-tracker/tests/test_dependency_tracker_plugin.py
@@ -1,0 +1,379 @@
+"""Tests for the dependency-tracker plugin (mocked store, offline PyPI)."""
+
+import copy
+
+import pytest
+
+from skillberry_plugin_dependency_tracker.plugin import (
+    SkillberryPluginDependencyTracker,
+)
+from skillberry_store.plugins.base import PluginType
+
+
+class _Tools:
+    """Stand-in for store.tools, backed by an in-memory module map."""
+
+    def __init__(self, modules):
+        # (uuid, filename) -> source
+        self._modules = modules
+
+    def read_file(self, uuid, filename, raw_content=False):
+        return self._modules[(uuid, filename)]
+
+
+class FakeStore:
+    """In-memory store with get_/update_ round-trip and tools.read_file."""
+
+    def __init__(self, objects=None, modules=None):
+        self._objs = objects or {}
+        self.tools = _Tools(modules or {})
+
+    def get_skill(self, uuid):
+        return copy.deepcopy(self._objs.get(("skill", uuid)))
+
+    def get_tool(self, uuid):
+        return copy.deepcopy(self._objs.get(("tool", uuid)))
+
+    def get_snippet(self, uuid):
+        return copy.deepcopy(self._objs.get(("snippet", uuid)))
+
+    def update_skill(self, uuid, data):
+        self._objs[("skill", uuid)] = copy.deepcopy(data)
+        return True
+
+    def update_tool(self, uuid, data):
+        self._objs[("tool", uuid)] = copy.deepcopy(data)
+        return True
+
+    def update_snippet(self, uuid, data):
+        self._objs[("snippet", uuid)] = copy.deepcopy(data)
+        return True
+
+
+def _plugin(store, monkeypatch):
+    # Default PyPI off in tests so nothing hits the network.
+    monkeypatch.setenv("DEPENDENCY_TRACKER_PYPI", "off")
+    p = SkillberryPluginDependencyTracker()
+    p.set_store_api(store)
+    return p
+
+
+# ── metadata / interface ──────────────────────────────────────────────────────
+
+
+def test_metadata_and_enablement():
+    p = SkillberryPluginDependencyTracker()
+    assert p.metadata.name == "Dependency Tracker"
+    assert p.metadata.plugin_type == PluginType.EVALUATOR
+    assert p.is_enabled() is True
+
+
+def test_router_exposes_scan():
+    p = SkillberryPluginDependencyTracker()
+    paths = {r.path for r in p.get_router().routes}
+    assert "/scan" in paths
+
+
+def test_ui_config_action_has_object_type_default():
+    p = SkillberryPluginDependencyTracker()
+    cfg = p.get_ui_config()
+    action = cfg["actions"][0]
+    assert action["label"] == "Scan dependencies"
+    assert action["params_schema"]["properties"]["object_type"]["default"] == "tool"
+
+
+def test_registers_no_event_handlers():
+    """On-demand only: instantiation must not add content_added handlers."""
+    from skillberry_store.plugins import events
+
+    before = {k: len(v) for k, v in events._event_handlers.items()}
+    SkillberryPluginDependencyTracker()
+    after = {k: len(v) for k, v in events._event_handlers.items()}
+    assert before == after
+
+
+# ── validation ────────────────────────────────────────────────────────────────
+
+
+def test_endpoint_blank_input_is_400_not_422():
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    app = FastAPI()
+    app.include_router(SkillberryPluginDependencyTracker().get_router())
+    client = TestClient(app)
+
+    r = client.post("/scan", json={})
+    assert r.status_code == 400
+    assert "uuid is required" in r.json()["detail"]
+
+    r = client.post("/scan", json={"object_type": "widget", "uuid": "x"})
+    assert r.status_code == 400
+    assert "object_type must be one of" in r.json()["detail"]
+
+
+# ── scan end-to-end (offline) ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_scan_tool_populates_dependencies(monkeypatch):
+    store = FakeStore(
+        objects={
+            ("tool", "t1"): {
+                "uuid": "t1",
+                "name": "fetcher",
+                "module_name": "main.py",
+                "extra": {"other": "keep me"},  # must be preserved
+                "tags": ["python"],
+            }
+        },
+        modules={("t1", "main.py"): "import os\nimport requests\n"},
+    )
+    p = _plugin(store, monkeypatch)
+    result = await p.scan("tool", "t1")
+
+    block = result["dependencies"]
+    assert block["languages_inspected"] == ["python"]
+    assert "python" in block["supported_languages"]
+    assert "shell" in block["supported_languages"]
+    assert "requests" in block["packages"]
+    assert block["packages"]["requests"]["direct"] is True
+    assert block["packages"]["requests"]["language"] == "python"
+    assert block["summary"]["total_count"] >= 1
+    assert block["summary"]["skipped_count"] == 0
+    assert block["summary"]["pypi_status"] == "skipped"  # PyPI off
+
+    # persisted non-destructively + dep tags added
+    stored = store.get_tool("t1")
+    assert stored["extra"]["dependencies"]["languages_inspected"] == ["python"]
+    assert stored["extra"]["other"] == "keep me"
+    assert any(t.startswith("dep:count:") for t in stored["tags"])
+    assert "dep:lang:python" in stored["tags"]
+    assert "python" in stored["tags"]  # pre-existing tag kept
+
+
+@pytest.mark.asyncio
+async def test_scan_snippet(monkeypatch):
+    store = FakeStore(
+        objects={
+            ("snippet", "s1"): {"uuid": "s1", "name": "n", "content": "import requests"}
+        }
+    )
+    p = _plugin(store, monkeypatch)
+    result = await p.scan("snippet", "s1")
+    assert "requests" in result["dependencies"]["packages"]
+
+
+@pytest.mark.asyncio
+async def test_scan_skill_aggregates_children(monkeypatch):
+    store = FakeStore(
+        objects={
+            ("skill", "sk1"): {
+                "uuid": "sk1",
+                "name": "skill",
+                "tool_uuids": ["t1"],
+                "snippet_uuids": ["s1"],
+            },
+            ("tool", "t1"): {"uuid": "t1", "name": "t", "module_name": "m.py"},
+            ("snippet", "s1"): {
+                "uuid": "s1",
+                "name": "s",
+                "content": "import requests",
+            },
+        },
+        modules={("t1", "m.py"): "import urllib3\n"},
+    )
+    p = _plugin(store, monkeypatch)
+    result = await p.scan("skill", "sk1")
+    pkgs = result["dependencies"]["packages"]
+    # both children's imports surfaced
+    assert "requests" in pkgs
+    assert "urllib3" in pkgs
+
+
+@pytest.mark.asyncio
+async def test_scan_shell_tool_finds_commands(monkeypatch):
+    store = FakeStore(
+        objects={
+            ("tool", "sh1"): {
+                "uuid": "sh1",
+                "name": "bundle",
+                "module_name": "bundle.sh",
+            }
+        },
+        modules={
+            ("sh1", "bundle.sh"): (
+                "#!/usr/bin/env bash\n"
+                "set -euo pipefail\n"
+                "curl -sSL https://example.com -o out.json\n"
+                "jq '.x' out.json\n"
+                "zip -r bundle.zip .\n"
+            )
+        },
+    )
+    p = _plugin(store, monkeypatch)
+    result = await p.scan("tool", "sh1")
+    block = result["dependencies"]
+    assert block["languages_inspected"] == ["shell"]
+    pkgs = block["packages"]
+    # external commands captured as system-source shell deps
+    for cmd in ("curl", "jq", "zip"):
+        assert cmd in pkgs, f"missing {cmd}"
+        assert pkgs[cmd]["source"] == "system"
+        assert pkgs[cmd]["language"] == "shell"
+        assert pkgs[cmd]["version"] is None
+    # shell builtins / keywords are NOT deps
+    for builtin in ("set", "export", "if", "fi"):
+        assert builtin not in pkgs
+
+
+@pytest.mark.asyncio
+async def test_mixed_skill_python_and_shell(monkeypatch):
+    store = FakeStore(
+        objects={
+            ("skill", "sk2"): {
+                "uuid": "sk2",
+                "name": "mixed",
+                "tool_uuids": ["pyt", "sht"],
+                "snippet_uuids": [],
+            },
+            ("tool", "pyt"): {"uuid": "pyt", "name": "py", "module_name": "a.py"},
+            ("tool", "sht"): {"uuid": "sht", "name": "sh", "module_name": "b.sh"},
+        },
+        modules={
+            ("pyt", "a.py"): "import requests\n",
+            ("sht", "b.sh"): "#!/bin/sh\naws s3 cp x y\n",
+        },
+    )
+    p = _plugin(store, monkeypatch)
+    block = (await p.scan("skill", "sk2"))["dependencies"]
+    assert set(block["languages_inspected"]) == {"python", "shell"}
+    assert block["packages"]["requests"]["language"] == "python"
+    assert block["packages"]["aws"]["language"] == "shell"
+
+
+@pytest.mark.asyncio
+async def test_local_modules_not_counted_as_missing(monkeypatch):
+    # A skill that imports its own bundled `helpers` package (leaf merge_runs is
+    # a bundled tool module) plus a real-but-absent external (`lxml`).
+    store = FakeStore(
+        objects={
+            ("skill", "sk3"): {
+                "uuid": "sk3",
+                "name": "doc-skill",
+                "tool_uuids": ["mr", "user"],
+                "snippet_uuids": [],
+            },
+            # bundled helper module: its stem `merge_runs` makes `helpers` local
+            ("tool", "mr"): {
+                "uuid": "mr",
+                "name": "merge_runs",
+                "module_name": "merge_runs.py",
+            },
+            ("tool", "user"): {"uuid": "user", "name": "u", "module_name": "u.py"},
+        },
+        modules={
+            ("mr", "merge_runs.py"): "def merge_runs():\n    pass\n",
+            ("user", "u.py"): (
+                "from helpers.merge_runs import merge_runs\n" "import lxml.etree\n"
+            ),
+        },
+    )
+    p = _plugin(store, monkeypatch)
+    block = (await p.scan("skill", "sk3"))["dependencies"]
+    reasons = {u["import_name"]: u["reason"] for u in block["unresolved_imports"]}
+    # `helpers` recognized as first-party, lxml flagged as a real missing pkg
+    assert reasons.get("helpers") == "local_module"
+    assert reasons.get("lxml") == "no_distribution"
+    assert block["summary"]["local_module_count"] == 1
+    assert block["summary"]["missing_count"] == 1
+    # tag reflects only the real missing external
+    stored = store.get_skill("sk3")
+    assert "dep:missing:1" in stored["tags"]
+
+
+@pytest.mark.asyncio
+async def test_local_package_detected_via_imported_symbol(monkeypatch):
+    # `from office.soffice import get_soffice_env` — the imported symbol matches
+    # a bundled tool (`get_soffice_env`), so `office` is first-party even though
+    # `soffice` itself isn't a tool stem.
+    store = FakeStore(
+        objects={
+            ("skill", "sk4"): {
+                "uuid": "sk4",
+                "name": "office-skill",
+                "tool_uuids": ["env", "caller"],
+                "snippet_uuids": [],
+            },
+            ("tool", "env"): {
+                "uuid": "env",
+                "name": "get_soffice_env",
+                "module_name": "get_soffice_env.py",
+            },
+            ("tool", "caller"): {"uuid": "caller", "name": "c", "module_name": "c.py"},
+        },
+        modules={
+            ("env", "get_soffice_env.py"): "def get_soffice_env():\n    return {}\n",
+            ("caller", "c.py"): "from office.soffice import get_soffice_env\n",
+        },
+    )
+    p = _plugin(store, monkeypatch)
+    block = (await p.scan("skill", "sk4"))["dependencies"]
+    reasons = {u["import_name"]: u["reason"] for u in block["unresolved_imports"]}
+    assert reasons.get("office") == "local_module"
+    assert block["summary"]["missing_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_unsupported_file_recorded_in_skipped(monkeypatch):
+    # A tool whose module is, say, JavaScript -> can't inspect -> skipped.
+    store = FakeStore(
+        objects={
+            ("tool", "js1"): {
+                "uuid": "js1",
+                "name": "widget",
+                "module_name": "widget.js",
+            }
+        },
+        modules={("js1", "widget.js"): "const x = require('left-pad');\n"},
+    )
+    p = _plugin(store, monkeypatch)
+    block = (await p.scan("tool", "js1"))["dependencies"]
+    assert block["packages"] == {}
+    assert block["summary"]["skipped_count"] == 1
+    skipped = block["skipped_files"]
+    assert skipped and skipped[0]["file"] == "widget.js"
+    assert skipped[0]["reason"] == "unsupported_language"
+    # tag surfaced
+    stored = store.get_tool("js1")
+    assert any(t == "dep:skipped:1" for t in stored["tags"])
+
+
+@pytest.mark.asyncio
+async def test_missing_object_raises_valueerror(monkeypatch):
+    p = _plugin(FakeStore(), monkeypatch)
+    with pytest.raises(ValueError):
+        await p.scan("tool", "nope")
+
+
+@pytest.mark.asyncio
+async def test_pypi_failure_degrades_gracefully(monkeypatch):
+    # Force PyPI on, but make every call raise -> scan still succeeds.
+    import skillberry_plugin_dependency_tracker.resolver.pypi as pypi_mod
+
+    store = FakeStore(
+        objects={("tool", "t1"): {"uuid": "t1", "name": "t", "module_name": "m.py"}},
+        modules={("t1", "m.py"): "import requests"},
+    )
+    monkeypatch.setenv("DEPENDENCY_TRACKER_PYPI", "on")
+
+    def _boom(dist, ver, timeout, session):
+        return {"status": "error"}
+
+    monkeypatch.setattr(pypi_mod, "enrich_from_pypi", _boom)
+
+    p = SkillberryPluginDependencyTracker()
+    p.set_store_api(store)
+    result = await p.scan("tool", "t1")  # must not raise
+    assert "requests" in result["dependencies"]["packages"]
+    assert result["dependencies"]["summary"]["pypi_status"] in ("partial", "skipped")

--- a/plugins/skillberry-plugin-dependency-tracker/tests/test_dependency_tracker_plugin.py
+++ b/plugins/skillberry-plugin-dependency-tracker/tests/test_dependency_tracker_plugin.py
@@ -71,7 +71,7 @@ def test_metadata_and_enablement():
 def test_router_exposes_scan():
     p = SkillberryPluginDependencyTracker()
     paths = {r.path for r in p.get_router().routes}
-    assert "/scan" in paths
+    assert "/resolve-dependencies" in paths
 
 
 def test_ui_config_action_has_object_type_default():
@@ -103,11 +103,11 @@ def test_endpoint_blank_input_is_400_not_422():
     app.include_router(SkillberryPluginDependencyTracker().get_router())
     client = TestClient(app)
 
-    r = client.post("/scan", json={})
+    r = client.post("/resolve-dependencies", json={})
     assert r.status_code == 400
     assert "uuid is required" in r.json()["detail"]
 
-    r = client.post("/scan", json={"object_type": "widget", "uuid": "x"})
+    r = client.post("/resolve-dependencies", json={"object_type": "widget", "uuid": "x"})
     assert r.status_code == 400
     assert "object_type must be one of" in r.json()["detail"]
 

--- a/plugins/skillberry-plugin-dependency-tracker/tests/test_imports.py
+++ b/plugins/skillberry-plugin-dependency-tracker/tests/test_imports.py
@@ -1,0 +1,39 @@
+"""Tests for AST top-level import extraction."""
+
+from skillberry_plugin_dependency_tracker.resolver.imports import (
+    extract_top_level_imports,
+)
+
+
+def test_stdlib_excluded():
+    code = "import os\nimport sys\nimport json\nfrom pathlib import Path\n"
+    assert extract_top_level_imports(code) == set()
+
+
+def test_dotted_import_reduced_to_top_level():
+    code = "import a.b.c\nimport requests as r\n"
+    assert extract_top_level_imports(code) == {"a", "requests"}
+
+
+def test_from_import_absolute():
+    code = "from requests import get\nfrom a.b import c\n"
+    assert extract_top_level_imports(code) == {"requests", "a"}
+
+
+def test_relative_imports_skipped():
+    code = "from . import x\nfrom ..pkg import y\nfrom .sibling import z\n"
+    assert extract_top_level_imports(code) == set()
+
+
+def test_mixed_stdlib_and_external():
+    code = "import os\nimport pandas\nfrom numpy import array\nfrom . import local\n"
+    assert extract_top_level_imports(code) == {"pandas", "numpy"}
+
+
+def test_bad_syntax_returns_empty_set():
+    assert extract_top_level_imports("def (:\n  this is not python") == set()
+
+
+def test_empty_and_none_safe():
+    assert extract_top_level_imports("") == set()
+    assert extract_top_level_imports(None) == set()

--- a/plugins/skillberry-plugin-dependency-tracker/tests/test_local_resolution.py
+++ b/plugins/skillberry-plugin-dependency-tracker/tests/test_local_resolution.py
@@ -1,0 +1,146 @@
+"""Tests for local importlib.metadata resolution (offline, against the dev env)."""
+
+import json
+
+from skillberry_plugin_dependency_tracker.resolver import local as local_mod
+from skillberry_plugin_dependency_tracker.resolver.local import (
+    _requirement_applies,
+    resolve_local,
+)
+
+# ── default-vs-extra requirement filtering (the 74-unresolved bug) ────────────
+
+
+def test_requirement_applies_excludes_extras():
+    # extra-gated deps are NOT default runtime deps
+    assert _requirement_applies("PySocks; extra == 'socks'") is False
+    assert _requirement_applies('chardet<8; extra == "use-chardet-on-py3"') is False
+    assert (
+        _requirement_applies(
+            "brotli>=1.2.0; (platform_python_implementation == 'CPython') "
+            "and extra == 'brotli'"
+        )
+        is False
+    )
+
+
+def test_requirement_applies_keeps_unmarked_and_satisfied():
+    assert _requirement_applies("urllib3>=1.21.1,<3") is True
+    assert _requirement_applies("idna (>=2.5,<4)") is True
+    # an always-true env marker (no extra) is a real runtime dep
+    assert _requirement_applies("certifi; python_version >= '3.0'") is True
+
+
+def test_requires_for_requests_drops_optional_extras(monkeypatch):
+    # Against the installed `requests`: PySocks/chardet (extras) must NOT appear.
+    reqs = local_mod.local_requires("requests")
+    lower = {r.lower() for r in reqs}
+    assert "pysocks" not in lower
+    assert "chardet" not in lower
+    # but its real runtime deps are present
+    assert any("urllib3" == r.lower() for r in reqs)
+
+
+def test_resolves_installed_requests_with_transitive_deps():
+    # `requests` is a declared dependency of this plugin, so it (and its deps:
+    # urllib3, certifi, idna, charset-normalizer) are installed in the test env.
+    report = resolve_local({"requests"})
+
+    assert "requests" in report.packages
+    req = report.packages["requests"]
+    assert req.version is not None
+    assert req.source == "local"
+    assert req.direct is True
+    assert req.depth == 0
+    # transitive deps were walked at max depth
+    assert req.requires, "requests should declare Requires-Dist"
+    assert "urllib3" in report.packages
+    assert report.packages["urllib3"].depth >= 1
+    assert report.packages["urllib3"].direct is False
+    # edges captured the hierarchy
+    assert any(e[0] == "<root>" and e[1] == "requests" for e in report.edges)
+
+
+def test_unresolved_import_recorded_not_dropped():
+    report = resolve_local({"definitely_not_a_real_pkg_xyz"})
+    assert report.packages == {}
+    assert report.unresolved
+    assert report.unresolved[0]["import_name"] == "definitely_not_a_real_pkg_xyz"
+    assert report.unresolved[0]["reason"] == "no_distribution"
+
+
+def test_local_module_classified_separately():
+    # `helpers` is bundled with the object; `lxml_not_here` is a real external
+    # package that is simply absent. They must be classified differently.
+    report = resolve_local({"helpers", "lxml_not_here"}, local_modules={"helpers"})
+    reasons = {u["import_name"]: u["reason"] for u in report.unresolved}
+    assert reasons["helpers"] == "local_module"
+    assert reasons["lxml_not_here"] == "no_distribution"
+
+    block = report.to_extra_block(
+        generated_at="T", plugin_version="0.1.0", python_version="3.11.0"
+    )
+    # local modules are NOT counted as missing external deps
+    assert block["summary"]["missing_count"] == 1
+    assert block["summary"]["local_module_count"] == 1
+    assert block["summary"]["unresolved_count"] == 2
+
+
+def test_cycle_protection(monkeypatch):
+    # Fake a -> b -> a cycle; both installed (versioned), each expanded once.
+    monkeypatch.setattr(
+        local_mod, "import_to_distributions", lambda n: [n] if n == "a" else []
+    )
+    monkeypatch.setattr(local_mod, "local_version", lambda d: "1.0.0")
+    monkeypatch.setattr(local_mod, "local_record_hashes", lambda d: [])
+    monkeypatch.setattr(
+        local_mod,
+        "local_requires",
+        lambda d: ["b"] if d == "a" else ["a"],
+    )
+
+    report = resolve_local({"a"})
+    # terminates, each node present once
+    assert set(report.packages) == {"a", "b"}
+    assert report.packages["a"].direct is True
+    assert report.packages["b"].direct is False
+
+
+def test_output_is_deterministic(monkeypatch):
+    monkeypatch.setattr(
+        local_mod, "import_to_distributions", lambda n: [n] if n in ("a",) else []
+    )
+    monkeypatch.setattr(local_mod, "local_version", lambda d: "1.0.0")
+    monkeypatch.setattr(local_mod, "local_record_hashes", lambda d: [])
+    monkeypatch.setattr(
+        local_mod, "local_requires", lambda d: ["c", "b"] if d == "a" else []
+    )
+
+    r1 = resolve_local({"a"}).to_extra_block(
+        generated_at="T", plugin_version="0.1.0", python_version="3.11.0"
+    )
+    r2 = resolve_local({"a"}).to_extra_block(
+        generated_at="T", plugin_version="0.1.0", python_version="3.11.0"
+    )
+    assert json.dumps(r1, sort_keys=True) == json.dumps(r2, sort_keys=True)
+    # requires sorted
+    assert r1["packages"]["a"]["requires"] == ["b", "c"]
+
+
+def test_uninstalled_child_marked_unresolved(monkeypatch):
+    # a is installed and requires b, but b is not installed.
+    monkeypatch.setattr(
+        local_mod, "import_to_distributions", lambda n: ["a"] if n == "a" else []
+    )
+    monkeypatch.setattr(
+        local_mod, "local_version", lambda d: "1.0.0" if d == "a" else None
+    )
+    monkeypatch.setattr(local_mod, "local_record_hashes", lambda d: [])
+    monkeypatch.setattr(
+        local_mod, "local_requires", lambda d: ["b"] if d == "a" else []
+    )
+
+    report = resolve_local({"a"})
+    assert "a" in report.packages
+    assert "b" not in report.packages  # not expanded
+    assert any(u["import_name"] == "b" for u in report.unresolved)

--- a/plugins/skillberry-plugin-dependency-tracker/tests/test_pypi_enrichment.py
+++ b/plugins/skillberry-plugin-dependency-tracker/tests/test_pypi_enrichment.py
@@ -1,0 +1,129 @@
+"""Tests for best-effort PyPI enrichment (no real network)."""
+
+import requests
+
+from skillberry_plugin_dependency_tracker.resolver.base import (
+    DependencyReport,
+    PackageDep,
+)
+from skillberry_plugin_dependency_tracker.resolver.pypi import (
+    enrich_from_pypi,
+    enrich_report,
+    pypi_enabled_from_env,
+)
+
+
+class _Resp:
+    def __init__(self, status_code, payload=None):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("no json")
+        return self._payload
+
+
+_OK_PAYLOAD = {
+    "info": {"version": "2.32.3"},
+    "urls": [
+        {"packagetype": "sdist", "digests": {"sha256": "sdistsha"}},
+        {"packagetype": "bdist_wheel", "digests": {"sha256": "wheelsha"}},
+    ],
+}
+
+
+def test_ok_enrichment_reports_update_and_hashes():
+    sess = type("S", (), {"get": lambda self, url, timeout: _Resp(200, _OK_PAYLOAD)})()
+    out = enrich_from_pypi("requests", "2.31.0", session=sess)
+    assert out["status"] == "ok"
+    assert out["latest_version"] == "2.32.3"
+    assert out["update_available"] is True
+    assert out["artifact_sha256"] == {"sdist": "sdistsha", "wheel": "wheelsha"}
+
+
+def test_no_update_when_versions_equal():
+    sess = type("S", (), {"get": lambda self, url, timeout: _Resp(200, _OK_PAYLOAD)})()
+    out = enrich_from_pypi("requests", "2.32.3", session=sess)
+    assert out["update_available"] is False
+
+
+def test_timeout_does_not_raise():
+    class _S:
+        def get(self, url, timeout):
+            raise requests.Timeout()
+
+    out = enrich_from_pypi("x", "1.0", session=_S())
+    assert out == {"status": "timeout"}
+
+
+def test_rate_limit_429_is_soft_error():
+    class _S:
+        def get(self, url, timeout):
+            return _Resp(429)
+
+    out = enrich_from_pypi("x", "1.0", session=_S())
+    assert out["status"] == "error"
+
+
+def test_404_not_found():
+    class _S:
+        def get(self, url, timeout):
+            return _Resp(404)
+
+    out = enrich_from_pypi("x", "1.0", session=_S())
+    assert out["status"] == "not_found"
+
+
+def test_connection_error_does_not_raise():
+    class _S:
+        def get(self, url, timeout):
+            raise requests.ConnectionError()
+
+    out = enrich_from_pypi("x", "1.0", session=_S())
+    assert out["status"] == "error"
+
+
+def test_enrich_report_disabled_leaves_pypi_none():
+    report = DependencyReport(packages={"a": PackageDep(name="a", version="1.0")})
+    status = enrich_report(report, enabled=False)
+    assert status == "skipped"
+    assert report.packages["a"].pypi is None
+
+
+def test_enrich_report_ok(monkeypatch):
+    report = DependencyReport(
+        packages={
+            "a": PackageDep(name="a", version="1.0"),
+            "b": PackageDep(name="b", version=None),  # unresolved -> skipped
+        }
+    )
+
+    # Patch the module-level enrich_from_pypi the report iterator calls.
+    import skillberry_plugin_dependency_tracker.resolver.pypi as pypi_mod
+
+    monkeypatch.setattr(
+        pypi_mod,
+        "enrich_from_pypi",
+        lambda dist, ver, timeout, session: {
+            "status": "ok",
+            "latest_version": "2.0",
+            "update_available": True,
+            "artifact_sha256": {},
+        },
+    )
+    status = enrich_report(report, enabled=True)
+    assert status == "ok"
+    assert report.packages["a"].pypi["status"] == "ok"
+    assert report.packages["b"].pypi is None  # version None -> not enriched
+
+
+def test_pypi_enabled_from_env(monkeypatch):
+    monkeypatch.delenv("DEPENDENCY_TRACKER_PYPI", raising=False)
+    assert pypi_enabled_from_env() is True
+    monkeypatch.setenv("DEPENDENCY_TRACKER_PYPI", "off")
+    assert pypi_enabled_from_env() is False
+    monkeypatch.setenv("DEPENDENCY_TRACKER_PYPI", "0")
+    assert pypi_enabled_from_env() is False
+    monkeypatch.setenv("DEPENDENCY_TRACKER_PYPI", "on")
+    assert pypi_enabled_from_env() is True

--- a/plugins/skillberry-plugin-dependency-tracker/tests/test_shell_and_languages.py
+++ b/plugins/skillberry-plugin-dependency-tracker/tests/test_shell_and_languages.py
@@ -1,0 +1,142 @@
+"""Tests for shell command extraction and language detection."""
+
+from skillberry_plugin_dependency_tracker.resolver.languages import detect_language
+from skillberry_plugin_dependency_tracker.resolver.shell import (
+    extract_shell_commands,
+)
+
+# ── language detection ────────────────────────────────────────────────────────
+
+
+def test_detect_by_extension():
+    assert detect_language("main.py", "") == "python"
+    assert detect_language("setup.sh", "") == "shell"
+    assert detect_language("run.bash", "") == "shell"
+    assert detect_language("widget.js", "") is None
+
+
+def test_detect_by_shebang():
+    assert detect_language("noext", "#!/usr/bin/env python3\nprint(1)") == "python"
+    assert detect_language("noext", "#!/bin/bash\necho hi") == "shell"
+    assert detect_language("noext", "#!/bin/sh\necho hi") == "shell"
+
+
+def test_detect_by_content_heuristic():
+    assert detect_language("snippet", "import os\nfrom x import y") == "python"
+    assert detect_language("snippet", "def foo():\n  pass") == "python"
+    assert detect_language("snippet", 'export FOO=bar\nif [ -n "$X" ]; then') == "shell"
+
+
+def test_detect_unknown_returns_none():
+    assert detect_language("data", "just some prose, nothing codey") is None
+    assert detect_language(None, "") is None
+
+
+# ── shell command extraction ──────────────────────────────────────────────────
+
+
+def test_extracts_external_commands():
+    code = (
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "curl -sSL https://x -o o.json\n"
+        "jq '.a' o.json\n"
+        "node build.js\n"
+    )
+    cmds = extract_shell_commands(code)
+    assert {"curl", "jq", "node"} <= cmds
+
+
+def test_excludes_builtins_and_keywords():
+    code = (
+        "if true; then\n  echo hi\n  export X=1\nfi\nfor i in 1 2; do echo $i; done\n"
+    )
+    cmds = extract_shell_commands(code)
+    for builtin in ("if", "then", "fi", "for", "do", "done", "echo", "export", "true"):
+        assert builtin not in cmds
+
+
+def test_excludes_locally_defined_functions():
+    code = (
+        "helper() {\n  curl https://x\n}\n"
+        "function setup {\n  echo hi\n}\n"
+        "helper\n"
+        "setup\n"
+    )
+    cmds = extract_shell_commands(code)
+    assert "helper" not in cmds
+    assert "setup" not in cmds
+    assert "curl" in cmds
+
+
+def test_skips_comments_and_assignments():
+    code = "# this calls wget\nFOO=bar\ngit clone https://x\n"
+    cmds = extract_shell_commands(code)
+    assert "wget" not in cmds  # only in a comment
+    assert "FOO" not in cmds  # assignment, not a command
+    assert "git" in cmds
+
+
+def test_heredoc_body_not_parsed_as_commands():
+    # Scripts often `cat <<EOF` an embedded JS/CSS/JSON file; that content must
+    # NOT be treated as shell commands (the real-world false-positive source).
+    code = (
+        "#!/usr/bin/env bash\n"
+        "cat > config.js <<EOF\n"
+        "import something from 'x'\n"
+        "const card = { colors: DEFAULT }\n"
+        "module.exports = { darkMode: false }\n"
+        "EOF\n"
+        "node build.js\n"
+        "npm install\n"
+    )
+    cmds = extract_shell_commands(code)
+    assert cmds == {"cat", "node", "npm"}
+    # none of the heredoc-body tokens leak in
+    for noise in (
+        "import",
+        "const",
+        "card",
+        "colors",
+        "DEFAULT",
+        "module.exports",
+        "EOF",
+    ):
+        assert noise not in cmds
+
+
+def test_sudo_prefix_skipped_to_real_command():
+    code = "sudo apt-get install -y jq\nnohup node server.js &\n"
+    cmds = extract_shell_commands(code)
+    assert "apt-get" in cmds  # sudo prefix stepped over
+    assert "node" in cmds  # nohup prefix stepped over
+    assert "sudo" not in cmds
+    assert "nohup" not in cmds
+
+
+def test_multiline_quoted_arg_body_not_parsed():
+    # `node -e "<multi-line inline JS>"` — the JS body must not become commands.
+    code = (
+        'node -e "\n'
+        "const fs = require('fs');\n"
+        "config.compilerOptions = {};\n"
+        "config.compilerOptions.baseUrl = '.';\n"
+        '"\n'
+        "npm run build\n"
+    )
+    cmds = extract_shell_commands(code)
+    assert "node" in cmds
+    assert "npm" in cmds
+    for noise in ("const", "config.compilerOptions", "config.compilerOptions.baseUrl"):
+        assert noise not in cmds
+
+
+def test_pipeline_each_stage_is_a_command():
+    code = "cat f | grep x | sort | uniq -c\n"
+    cmds = extract_shell_commands(code)
+    assert {"cat", "grep", "sort", "uniq"} <= cmds
+
+
+def test_empty_safe():
+    assert extract_shell_commands("") == set()
+    assert extract_shell_commands(None) == set()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,6 +190,10 @@ plugin-provenance = [
   "skillberry-plugin-provenance>=0.1.0",
 ]
 
+plugin-dependency-tracker = [
+  "skillberry-plugin-dependency-tracker>=0.1.0",
+]
+
 # Install all plugins
 plugins-all = [
   "skillberry-plugin-creator>=0.2.0",
@@ -202,6 +206,7 @@ plugins-all = [
   "skillberry-plugin-sast>=0.1.0",
   "skillberry-plugin-skill-optimizer>=0.1.0",
   "skillberry-plugin-provenance>=0.1.0",
+  "skillberry-plugin-dependency-tracker>=0.1.0",
 ]
 
 test = [
@@ -220,6 +225,7 @@ skillberry-plugin-kagenti-approver = { path = "plugins/skillberry-plugin-kagenti
 skillberry-plugin-sast = { path = "plugins/skillberry-plugin-sast", editable = true }
 skillberry-plugin-skill-optimizer = { path = "plugins/skillberry-plugin-skill-optimizer", editable = true }
 skillberry-plugin-provenance = { path = "plugins/skillberry-plugin-provenance", editable = true }
+skillberry-plugin-dependency-tracker = { path = "plugins/skillberry-plugin-dependency-tracker", editable = true }
 llm-client = { path = "skillberry-common/packages/llm-client", editable = true }
 torch = { index = "pytorch-cpu" }
 


### PR DESCRIPTION
## Summary

Adds a new `skillberry-plugin-dependency-tracker` plugin that, **on demand**, discovers the **external dependencies** of skills, tools, and snippets and records them in a new hierarchical `extra["dependencies"]` block — with exact versions and artifact hashes, transitively at **maximum depth**.

The store already tracks *internal* dependencies (store-tool → store-tool by UUID, via the top-level `dependencies` field). This plugin tracks the **external supply chain** — the PyPI packages and shell commands an object actually pulls in, their transitive deps, versions, and hashes — which matters for supply-chain security (tampering, same-version republishing, vulnerable releases) and versioning hygiene.

Resolves #224.

## What it does

`POST /scan {object_type, uuid}` resolves an object's dependencies and writes them to `extra["dependencies"]` + `dep:` tags. **On-demand only** — no auto-scan-on-import hook (deliberately unlike provenance/doc-generator).

### Supported languages

| Language | Discovered | Version / hash |
|----------|-----------|----------------|
| **Python** | imported PyPI distributions, transitive at max depth | installed version + RECORD hashes (local), canonical sha256 + "update available" (PyPI) |
| **Shell** (`.sh`/`.bash`/…) | external commands invoked (`curl`, `jq`, `node`, …) | none — system executables (`source: "system"`) |

Each file's language is detected by extension → shebang → light content heuristic. **Files in unsupported languages are reported explicitly** in `skipped_files` (with `reason: "unsupported_language"`) and counted in `summary.skipped_count`, so a bare `0` is never ambiguous about "clean" vs. "couldn't inspect."

### Hybrid Python resolution

- **Local (`importlib.metadata`) is the source of truth** — the version the object actually runs against, per-file RECORD hashes, and the transitive `Requires-Dist` graph at max depth (cycle/diamond-safe). Only **default** runtime deps are followed: extra-gated (`; extra == '...'`) and unsatisfied-marker requirements are excluded via PEP 508 marker evaluation (with a regex fallback), so optional extras of transitive packages aren't mistaken for missing deps.
- **PyPI is best-effort enrichment** — canonical published sha256 + "update available". Time-boxed and key-independent; a 429/timeout/offline becomes a per-package `status` (rolled up `partial`/`skipped`) and **never fails a scan**. Env-gated (`DEPENDENCY_TRACKER_PYPI=off`; per-call `pypi` override).

### Unresolved-import classification

Imports that don't resolve to an installed external distribution are reported (never silently dropped) and classified:
- `not_installed` / `no_distribution` — a genuinely **missing external package** (counted in `summary.missing_count`, tagged `dep:missing:N` — the actionable supply-chain signal),
- `local_module` — the object's **own bundled code** (e.g. a skill's `helpers`/`office` packages), detected from bundled tool module stems/names and imported-symbol matches. Excluded from the "missing" count.

## The `extra["dependencies"]` block

```jsonc
{
  "schema_version": 1, "generated_at": "<ISO-8601>",
  "supported_languages": ["python","shell"], "languages_inspected": ["python"],
  "scanner": { "plugin_version", "resolver": "hybrid", "python_version" },
  "summary": { "direct_count","total_count","unresolved_count",
               "missing_count","local_module_count","skipped_count",
               "update_available_count","pypi_status" },
  "packages": {                       // keyed by dependency name
    "requests": { "name","version","source":"local","language":"python",
                  "direct":true,"depth":0,
                  "local_hashes":[{"file","algorithm":"sha256","hash"}],
                  "requires":["urllib3",...],
                  "pypi":{"status","latest_version","update_available",
                          "artifact_sha256":{"sdist","wheel"}} },
    "curl": { "source":"system","language":"shell","version":null,"direct":true }
  },
  "tree": [ {"from","to","depth"} ],
  "unresolved_imports": [ {"import_name","reason"} ],
  "skipped_files": [ {"file","language","reason"} ]
}
```

Tags: `dep:count:N`, `dep:unresolved:M`, `dep:missing:K`, `dep:skipped:S`, `dep:lang:python`/`dep:lang:shell`, `dep:update-available`.

## Files

- **New:** `plugins/skillberry-plugin-dependency-tracker/` — `pyproject.toml`, `README.md`, `plugin.py`, and a `resolver/` engine (`base`, `imports`, `languages`, `local`, `pypi`, `shell`), plus 5 test modules.
- **Changed:** root `pyproject.toml` — registers the plugin in `plugins-all`, adds a `plugin-dependency-tracker` extra, and the editable `[tool.uv.sources]` path.

## Design notes

Mirrors the provenance plugin: `PluginBase` interface, non-destructive `extra` + tags persistence, tolerant `/scan` request (clean **400**, not pydantic 422), single generic-UI action, no custom UI. The resolver engine is store- and network-decoupled, so it's fully unit-testable offline. `tests/` has **no `__init__.py`** (the cross-plugin collision fixed in #198).

## Testing

- `pytest plugins/skillberry-plugin-dependency-tracker/tests -q` → **53 passed** (AST extraction, language detection, shell extraction incl. heredoc & multi-line-quote exclusion, local resolution + extras filtering + cycle protection + determinism, PyPI enrichment + failure degradation, local-module classification, plugin scan/persist/validation, no-event-handler assertion).
- Full-repo collection: **0 errors**.
- `black --check` clean.
- Verified live against real objects: a Python tool resolves version + RECORD hashes + PyPI sha256; a shell skill reports its commands + skipped files; a skill mixing first-party packages and a missing external (`lxml`) classifies them correctly.

## Out of scope

- Languages beyond Python/shell.
- Vulnerability/advisory matching (this tracks the dependency set + hashes; a matcher can build on top).
- Auto-remediation (pinning/bumping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
