### PR TITLE
fix(ui): constrain table column widths and truncate descriptions

### DIFF
--- a/src/skillberry_store/ui/src/components/SkillListView.tsx
+++ b/src/skillberry_store/ui/src/components/SkillListView.tsx
@@ -34,12 +34,12 @@ export function SkillListView({
               isSelected: selectedSkills.length === skills.length && skills.length > 0,
             }}
           />
-          <Th sort={getSortParams(0)}>Name</Th>
-          <Th sort={getSortParams(1)}>Description</Th>
-          <Th>Tags</Th>
-          <Th>Tools</Th>
-          <Th>Snippets</Th>
-          <Th sort={getSortParams(2)}>Version</Th>
+          <Th sort={getSortParams(0)} width={20}>Name</Th>
+          <Th sort={getSortParams(1)} width={35} modifier="truncate">Description</Th>
+          <Th width={15}>Tags</Th>
+          <Th width={10}>Tools</Th>
+          <Th width={10}>Snippets</Th>
+          <Th sort={getSortParams(2)} width={10}>Version</Th>
         </Tr>
       </Thead>
       <Tbody>
@@ -61,6 +61,7 @@ export function SkillListView({
             </Td>
             <Td
               dataLabel="Description"
+              modifier="truncate"
               onClick={() => navigate(`/skills/${skill.uuid}`)}
               style={{ cursor: 'pointer' }}
             >

--- a/src/skillberry_store/ui/src/pages/SnippetsPage.tsx
+++ b/src/skillberry_store/ui/src/pages/SnippetsPage.tsx
@@ -450,12 +450,12 @@ export function SnippetsPage() {
                     isSelected: selectedSnippets.length === filteredSnippets.length && filteredSnippets.length > 0,
                   }}
                 />
-                <Th sort={getSortParams(0)}>Name</Th>
-                <Th sort={getSortParams(1)}>Description</Th>
-                <Th sort={getSortParams(2)}>State</Th>
-                <Th>Tags</Th>
-                <Th sort={getSortParams(3)}>Content Type</Th>
-                <Th sort={getSortParams(4)}>Version</Th>
+                <Th sort={getSortParams(0)} width={20}>Name</Th>
+                <Th sort={getSortParams(1)} width={35} modifier="truncate">Description</Th>
+                <Th sort={getSortParams(2)} width={10}>State</Th>
+                <Th width={15}>Tags</Th>
+                <Th sort={getSortParams(3)} width={10}>Content Type</Th>
+                <Th sort={getSortParams(4)} width={10}>Version</Th>
               </Tr>
             </Thead>
             <Tbody>
@@ -477,6 +477,7 @@ export function SnippetsPage() {
                   </Td>
                   <Td
                     dataLabel="Description"
+                    modifier="truncate"
                     onClick={() => navigate(`/snippets/${snippet.uuid}`)}
                     style={{ cursor: 'pointer' }}
                   >

--- a/src/skillberry_store/ui/src/pages/ToolDetailPage.tsx
+++ b/src/skillberry_store/ui/src/pages/ToolDetailPage.tsx
@@ -338,12 +338,12 @@ export function ToolDetailPage() {
                         <Table aria-label="Dependencies table" variant="compact">
                           <Thead>
                             <Tr>
-                              <Th>Name</Th>
-                              <Th>Description</Th>
-                              <Th>State</Th>
-                              <Th>Tags</Th>
-                              <Th>Module Name</Th>
-                              <Th>Version</Th>
+                              <Th width={20}>Name</Th>
+                              <Th width={40} modifier="truncate">Description</Th>
+                              <Th width={10}>State</Th>
+                              <Th width={10}>Tags</Th>
+                              <Th width={10}>Module Name</Th>
+                              <Th width={10}>Version</Th>
                             </Tr>
                           </Thead>
                           <Tbody>
@@ -371,6 +371,7 @@ export function ToolDetailPage() {
                                   </Td>
                                   <Td
                                     dataLabel="Description"
+                                    modifier="truncate"
                                     onClick={() => navigate(`/tools/${depUuid}`)}
                                     style={{ cursor: 'pointer' }}
                                   >

--- a/src/skillberry_store/ui/src/pages/ToolsPage.tsx
+++ b/src/skillberry_store/ui/src/pages/ToolsPage.tsx
@@ -418,12 +418,12 @@ export function ToolsPage() {
                     isSelected: selectedTools.length === filteredTools.length && filteredTools.length > 0,
                   }}
                 />
-                <Th sort={getSortParams(0)}>Name</Th>
-                <Th sort={getSortParams(1)}>Description</Th>
-                <Th sort={getSortParams(2)}>State</Th>
-                <Th>Tags</Th>
-                <Th sort={getSortParams(3)}>Module Name</Th>
-                <Th sort={getSortParams(4)}>Version</Th>
+                <Th sort={getSortParams(0)} width={20}>Name</Th>
+                <Th sort={getSortParams(1)} width={40} modifier="truncate">Description</Th>
+                <Th sort={getSortParams(2)} width={10}>State</Th>
+                <Th width={10}>Tags</Th>
+                <Th sort={getSortParams(3)} width={10}>Module Name</Th>
+                <Th sort={getSortParams(4)} width={10}>Version</Th>
               </Tr>
             </Thead>
             <Tbody>
@@ -445,6 +445,7 @@ export function ToolsPage() {
                   </Td>
                   <Td
                     dataLabel="Description"
+                    modifier="truncate"
                     onClick={() => navigate(`/tools/${tool.uuid}`)}
                     style={{ cursor: 'pointer' }}
                   >

--- a/src/skillberry_store/ui/src/pages/VMCPServersPage.tsx
+++ b/src/skillberry_store/ui/src/pages/VMCPServersPage.tsx
@@ -468,13 +468,13 @@ export function VMCPServersPage() {
                     isSelected: selectedServers.length === filteredServers.length && filteredServers.length > 0,
                   }}
                 />
-                <Th sort={getSortParams(0)}>Name</Th>
-                <Th sort={getSortParams(1)}>Description</Th>
-                <Th sort={getSortParams(2)}>State</Th>
-                <Th>Tags</Th>
-                <Th sort={getSortParams(3)}>Port</Th>
-                <Th>Status</Th>
-                <Th sort={getSortParams(4)}>Version</Th>
+                <Th sort={getSortParams(0)} width={15}>Name</Th>
+                <Th sort={getSortParams(1)} width={30} modifier="truncate">Description</Th>
+                <Th sort={getSortParams(2)} width={10}>State</Th>
+                <Th width={15}>Tags</Th>
+                <Th sort={getSortParams(3)} width={10}>Port</Th>
+                <Th width={10}>Status</Th>
+                <Th sort={getSortParams(4)} width={10}>Version</Th>
               </Tr>
             </Thead>
             <Tbody>
@@ -496,6 +496,7 @@ export function VMCPServersPage() {
                   </Td>
                   <Td
                     dataLabel="Description"
+                    modifier="truncate"
                     onClick={() => navigate(`/vmcp-servers/${server.uuid}`)}
                     style={{ cursor: 'pointer' }}
                   >

--- a/src/skillberry_store/ui/src/pages/VNFSServersPage.tsx
+++ b/src/skillberry_store/ui/src/pages/VNFSServersPage.tsx
@@ -342,14 +342,14 @@ export function VNFSServersPage() {
             <Thead>
               <Tr>
                 <Th select={{ onSelect: (_e, isSelected) => handleSelectAll(isSelected), isSelected: selectedServers.length === filteredServers.length && filteredServers.length > 0 }} />
-                <Th sort={getSortParams(0)}>Name</Th>
-                <Th sort={getSortParams(1)}>Description</Th>
-                <Th sort={getSortParams(2)}>State</Th>
-                <Th>Tags</Th>
-                <Th sort={getSortParams(3)}>Port</Th>
-                <Th>Protocol</Th>
-                <Th>Status</Th>
-                <Th sort={getSortParams(4)}>Version</Th>
+                <Th sort={getSortParams(0)} width={15}>Name</Th>
+                <Th sort={getSortParams(1)} width={25} modifier="truncate">Description</Th>
+                <Th sort={getSortParams(2)} width={10}>State</Th>
+                <Th width={10}>Tags</Th>
+                <Th sort={getSortParams(3)} width={10}>Port</Th>
+                <Th width={10}>Protocol</Th>
+                <Th width={10}>Status</Th>
+                <Th sort={getSortParams(4)} width={10}>Version</Th>
               </Tr>
             </Thead>
             <Tbody>
@@ -357,7 +357,7 @@ export function VNFSServersPage() {
                 <Tr key={server.uuid}>
                   <Td select={{ rowIndex: index, onSelect: (_e, isSelected) => handleSelectServer(server.name, isSelected), isSelected: selectedServers.includes(server.name) }} />
                   <Td dataLabel="Name" onClick={() => navigate(`/vnfs-servers/${server.uuid}`)} style={{ cursor: 'pointer' }}>{server.name}</Td>
-                  <Td dataLabel="Description" onClick={() => navigate(`/vnfs-servers/${server.uuid}`)} style={{ cursor: 'pointer' }}>{server.description || 'No description'}</Td>
+                  <Td dataLabel="Description" modifier="truncate" onClick={() => navigate(`/vnfs-servers/${server.uuid}`)} style={{ cursor: 'pointer' }}>{server.description || 'No description'}</Td>
                   <Td dataLabel="State" onClick={() => navigate(`/vnfs-servers/${server.uuid}`)} style={{ cursor: 'pointer' }}>{server.state || '-'}</Td>
                   <Td dataLabel="Tags" onClick={() => navigate(`/vnfs-servers/${server.uuid}`)} style={{ cursor: 'pointer' }}>
                     {server.tags && server.tags.length > 0 ? (


### PR DESCRIPTION
## Summary

List tables relied on the browser's content-driven auto-layout with no column widths or text-overflow rules, so a long Description column wrapped over many lines and ballooned row height, making tables hard to scan.

This change assigns explicit PatternFly column `width` percentages and applies `modifier="truncate"` to the Description column. Descriptions now render on a single line with an ellipsis and a native hover tooltip for the full text; rows stay uniform height and other columns are no longer starved. No custom CSS — uses built-in PatternFly props only.

Fixes #226

## Affected tables

- `/tools` — `ToolsPage.tsx`
- `/skills` — `SkillListView.tsx`
- `/snippets` — `SnippetsPage.tsx`
- `/vmcp-servers` — `VMCPServersPage.tsx`
- `/vnfs-servers` — `VNFSServersPage.tsx`
- Tool detail dependencies table — `ToolDetailPage.tsx`

## Testing

- `npm run typecheck`: 150 errors before and after — all pre-existing (test files / unused imports), **zero** new errors introduced by this change.
- Manual: open the list pages, find an entity with a long description, confirm the row stays single-height with an ellipsis and the full text shows on hover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)