### PR TITLE
fix(plugins): read credentials from settings.json env block and forward it fully

### DIFF
--- a/plugins/skillberry-plugin-anthropic-skill-generator/src/skillberry_plugin_anthropic_skill_generator/plugin.py
+++ b/plugins/skillberry-plugin-anthropic-skill-generator/src/skillberry_plugin_anthropic_skill_generator/plugin.py
@@ -150,75 +150,61 @@ class SkillberryPluginAnthropicSkillGenerator(PluginBase):
         else:
             logger.debug(f"Claude settings file not found at {settings_path}")
     
-    def _check_credentials(self) -> bool:
-        """Check if Anthropic credentials are configured."""
-        # Check for direct API key in environment
-        if os.getenv("ANTHROPIC_API_KEY"):
+    @staticmethod
+    def _has_api_access(source: Any) -> bool:
+        """True if `source` (a mapping) carries Anthropic API credentials."""
+        if source.get("ANTHROPIC_API_KEY"):
             return True
-        
-        # Check for proxy/gateway configuration in environment
-        if os.getenv("ANTHROPIC_BASE_URL") and os.getenv("ANTHROPIC_AUTH_TOKEN"):
+        if source.get("ANTHROPIC_BASE_URL") and source.get("ANTHROPIC_AUTH_TOKEN"):
             return True
-        
-        # Check for credentials in Claude settings file
-        if self._claude_settings:
-            # Check for API key in settings
-            if self._claude_settings.get("apiKey"):
-                return True
-            
-            # Check for proxy configuration in settings
-            if self._claude_settings.get("baseUrl") and self._claude_settings.get("authToken"):
-                return True
-        
         return False
-    
+
+    def _claude_settings_env(self) -> Dict[str, str]:
+        """The ``env`` block from ~/.claude/settings.json (Claude Code schema)."""
+        if not self._claude_settings:
+            return {}
+        settings_env = self._claude_settings.get("env")
+        return settings_env if isinstance(settings_env, dict) else {}
+
+    def _check_credentials(self) -> bool:
+        """Check if Anthropic credentials are configured.
+
+        Credentials may come from the process environment or from the
+        ~/.claude/settings.json ``env`` block. Both use the standard
+        ANTHROPIC_* variable names.
+        """
+        return self._has_api_access(os.environ) or self._has_api_access(self._claude_settings_env())
+
     def _build_claude_env(self, override_env: Optional[Dict[str, str]] = None) -> Dict[str, str]:
-        """Build environment variables for Claude Code agent.
-        
-        Priority order (highest to lowest):
-        1. override_env (request-specific)
-        2. System environment variables
-        3. ~/.claude/settings.json
-        
+        """Build environment variables for the Claude Code agent.
+
+        Priority order (lowest to highest):
+        1. Every key in the ~/.claude/settings.json ``env`` block.
+        2. ANTHROPIC_*/CLAUDE_* variables from the current process environment.
+        3. Request-specific ``override_env``.
+
         Args:
             override_env: Optional environment variables to override defaults
-            
+
         Returns:
             Dictionary of environment variables for Claude Code
         """
-        env = {}
-        
-        # Start with Claude settings file (lowest priority)
-        if self._claude_settings:
-            if self._claude_settings.get("apiKey"):
-                env["ANTHROPIC_API_KEY"] = self._claude_settings["apiKey"]
-            
-            if self._claude_settings.get("baseUrl"):
-                env["ANTHROPIC_BASE_URL"] = self._claude_settings["baseUrl"]
-            
-            if self._claude_settings.get("authToken"):
-                env["ANTHROPIC_AUTH_TOKEN"] = self._claude_settings["authToken"]
-            
-            if self._claude_settings.get("model"):
-                env["ANTHROPIC_MODEL"] = self._claude_settings["model"]
-        
-        # Override with system environment variables (medium priority)
-        if os.getenv("ANTHROPIC_API_KEY"):
-            env["ANTHROPIC_API_KEY"] = os.getenv("ANTHROPIC_API_KEY")
-        
-        if os.getenv("ANTHROPIC_BASE_URL"):
-            env["ANTHROPIC_BASE_URL"] = os.getenv("ANTHROPIC_BASE_URL")
-        
-        if os.getenv("ANTHROPIC_AUTH_TOKEN"):
-            env["ANTHROPIC_AUTH_TOKEN"] = os.getenv("ANTHROPIC_AUTH_TOKEN")
-        
-        if os.getenv("ANTHROPIC_MODEL"):
-            env["ANTHROPIC_MODEL"] = os.getenv("ANTHROPIC_MODEL")
-        
-        # Override with request-specific values (highest priority)
+        env: Dict[str, str] = {}
+
+        # 1. Forward the entire settings.json env block as-is (lowest priority).
+        for key, value in self._claude_settings_env().items():
+            if value is not None:
+                env[key] = str(value)
+
+        # 2. Real environment vars take precedence over the settings file.
+        for key, value in os.environ.items():
+            if value and (key.startswith("ANTHROPIC_") or key.startswith("CLAUDE_")):
+                env[key] = value
+
+        # 3. Request-specific overrides win.
         if override_env:
             env.update(override_env)
-        
+
         return env
 
     @property

--- a/plugins/skillberry-plugin-anthropic-skill-generator/src/skillberry_plugin_anthropic_skill_generator/plugin.py
+++ b/plugins/skillberry-plugin-anthropic-skill-generator/src/skillberry_plugin_anthropic_skill_generator/plugin.py
@@ -623,7 +623,13 @@ The skill should be production-ready and well-documented."""
                             },
                             "agent_env": {
                                 "type": "object",
-                                "description": "Optional environment variables for Claude Code (e.g., ANTHROPIC_API_KEY)"
+                                "title": "Environment overrides (optional)",
+                                "description": (
+                                    "Per-run overrides for the Claude Code agent environment. "
+                                    "Your ~/.claude/settings.json env block and the server's "
+                                    "ANTHROPIC_*/CLAUDE_* variables are already loaded automatically; "
+                                    "only set this to override them."
+                                )
                             },
                             "execution_mode": {
                                 "type": "string",

--- a/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/plugin.py
+++ b/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/plugin.py
@@ -145,33 +145,46 @@ class SkillberryPluginSkillOptimizer(PluginBase):
             except Exception as e:
                 logger.warning(f"Failed to load Claude settings: {e}")
 
-    def _check_credentials(self) -> bool:
-        if os.getenv("ANTHROPIC_API_KEY"):
+    @staticmethod
+    def _has_api_access(source: Any) -> bool:
+        """True if `source` (a mapping) carries Anthropic API credentials."""
+        if source.get("ANTHROPIC_API_KEY"):
             return True
-        if os.getenv("ANTHROPIC_BASE_URL") and os.getenv("ANTHROPIC_AUTH_TOKEN"):
+        if source.get("ANTHROPIC_BASE_URL") and source.get("ANTHROPIC_AUTH_TOKEN"):
             return True
-        if self._claude_settings:
-            if self._claude_settings.get("apiKey"):
-                return True
-            if self._claude_settings.get("baseUrl") and self._claude_settings.get("authToken"):
-                return True
         return False
 
+    def _claude_settings_env(self) -> Dict[str, str]:
+        """The ``env`` block from ~/.claude/settings.json (Claude Code schema)."""
+        if not self._claude_settings:
+            return {}
+        settings_env = self._claude_settings.get("env")
+        return settings_env if isinstance(settings_env, dict) else {}
+
+    def _check_credentials(self) -> bool:
+        # Credentials may come from the process environment or from the
+        # ~/.claude/settings.json "env" block. Both use the standard
+        # ANTHROPIC_* variable names.
+        return self._has_api_access(os.environ) or self._has_api_access(self._claude_settings_env())
+
     def _build_claude_env(self, override_env: Optional[Dict[str, str]] = None) -> Dict[str, str]:
-        env = {}
-        if self._claude_settings:
-            if self._claude_settings.get("apiKey"):
-                env["ANTHROPIC_API_KEY"] = self._claude_settings["apiKey"]
-            if self._claude_settings.get("baseUrl"):
-                env["ANTHROPIC_BASE_URL"] = self._claude_settings["baseUrl"]
-            if self._claude_settings.get("authToken"):
-                env["ANTHROPIC_AUTH_TOKEN"] = self._claude_settings["authToken"]
-            if self._claude_settings.get("model"):
-                env["ANTHROPIC_MODEL"] = self._claude_settings["model"]
-        for var in ("ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_MODEL"):
-            val = os.getenv(var)
-            if val:
-                env[var] = val
+        """Build the environment passed to the Claude Code agent.
+
+        Priority (lowest to highest):
+        1. Every key in the ~/.claude/settings.json ``env`` block.
+        2. ANTHROPIC_*/CLAUDE_* variables from the current process environment.
+        3. Request-specific ``override_env``.
+        """
+        env: Dict[str, str] = {}
+        # 1. Forward the entire settings.json env block as-is.
+        for key, value in self._claude_settings_env().items():
+            if value is not None:
+                env[key] = str(value)
+        # 2. Real environment vars take precedence over the settings file.
+        for key, value in os.environ.items():
+            if value and (key.startswith("ANTHROPIC_") or key.startswith("CLAUDE_")):
+                env[key] = value
+        # 3. Request-specific overrides win.
         if override_env:
             env.update(override_env)
         return env

--- a/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/plugin.py
+++ b/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/plugin.py
@@ -696,7 +696,13 @@ class SkillberryPluginSkillOptimizer(PluginBase):
                             },
                             "agent_env": {
                                 "type": "object",
-                                "description": "Credential overrides for Claude Code (e.g., ANTHROPIC_API_KEY)",
+                                "title": "Environment overrides (optional)",
+                                "description": (
+                                    "Per-run overrides for the Claude Code agent environment. "
+                                    "Your ~/.claude/settings.json env block and the server's "
+                                    "ANTHROPIC_*/CLAUDE_* variables are already loaded automatically; "
+                                    "only set this to override them."
+                                ),
                             },
                             "execution_mode": {
                                 "type": "string",

--- a/plugins/skillberry-plugin-skill-optimizer/tests/test_skill_optimizer_plugin.py
+++ b/plugins/skillberry-plugin-skill-optimizer/tests/test_skill_optimizer_plugin.py
@@ -166,7 +166,9 @@ def test_is_enabled_without_credentials():
            if k not in ("ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN")}
     with patch.dict(os.environ, env, clear=True):
         with patch("skillberry_plugin_skill_optimizer.plugin.runspace_agent", new=Mock()):
-            p = SkillberryPluginSkillOptimizer()
+            # Also isolate from any real ~/.claude/settings.json on the dev machine.
+            with patch.object(SkillberryPluginSkillOptimizer, "_load_claude_settings", lambda self: None):
+                p = SkillberryPluginSkillOptimizer()
     assert p.is_enabled() is False
 
 
@@ -186,7 +188,9 @@ def test_status_message_missing_credentials():
            if k not in ("ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN")}
     with patch.dict(os.environ, env, clear=True):
         with patch("skillberry_plugin_skill_optimizer.plugin.runspace_agent", new=Mock()):
-            p = SkillberryPluginSkillOptimizer()
+            # Also isolate from any real ~/.claude/settings.json on the dev machine.
+            with patch.object(SkillberryPluginSkillOptimizer, "_load_claude_settings", lambda self: None):
+                p = SkillberryPluginSkillOptimizer()
     assert "credentials" in p.get_status_message().lower()
 
 
@@ -489,3 +493,56 @@ def test_ui_config_params_schema(plugin):
 
 def test_get_cli_commands_returns_none(plugin):
     assert plugin.get_cli_commands() is None
+
+
+# ---------------------------------------------------------------------------
+# Claude settings.json env handling
+# ---------------------------------------------------------------------------
+
+def _make_plugin_with_settings(settings):
+    """Instantiate the plugin with a stubbed ~/.claude/settings.json payload."""
+    with patch("skillberry_plugin_skill_optimizer.plugin.runspace_agent", new=Mock()):
+        with patch.object(
+            SkillberryPluginSkillOptimizer, "_load_claude_settings", lambda self: None
+        ):
+            p = SkillberryPluginSkillOptimizer()
+    p._claude_settings = settings
+    return p
+
+
+def test_check_credentials_reads_settings_env_block():
+    # Standard Claude Code schema: credentials live under the "env" block.
+    settings = {"env": {"ANTHROPIC_BASE_URL": "https://gw", "ANTHROPIC_AUTH_TOKEN": "tok"}}
+    clean = {k: v for k, v in os.environ.items()
+             if not (k.startswith("ANTHROPIC_") or k.startswith("CLAUDE_"))}
+    with patch.dict(os.environ, clean, clear=True):
+        p = _make_plugin_with_settings(settings)
+        assert p._check_credentials() is True
+
+
+def test_build_claude_env_forwards_entire_settings_env_block():
+    settings = {
+        "env": {
+            "ANTHROPIC_BASE_URL": "https://gw",
+            "ANTHROPIC_AUTH_TOKEN": "tok",
+            "ANTHROPIC_MODEL": "claude-opus-4-8",
+            "ANTHROPIC_SMALL_FAST_MODEL": "claude-sonnet-4-6",
+            "CLAUDE_CODE_SUBAGENT_MODEL": "claude-opus-4-8",
+        }
+    }
+    clean = {k: v for k, v in os.environ.items()
+             if not (k.startswith("ANTHROPIC_") or k.startswith("CLAUDE_"))}
+    with patch.dict(os.environ, clean, clear=True):
+        p = _make_plugin_with_settings(settings)
+        env = p._build_claude_env()
+    # Every key from the settings env block is forwarded, not just a hardcoded subset.
+    for key, value in settings["env"].items():
+        assert env[key] == value
+
+
+def test_build_claude_env_process_env_overrides_settings():
+    settings = {"env": {"ANTHROPIC_MODEL": "from-settings"}}
+    with patch.dict(os.environ, {"ANTHROPIC_MODEL": "from-process"}, clear=False):
+        p = _make_plugin_with_settings(settings)
+        env = p._build_claude_env()
+    assert env["ANTHROPIC_MODEL"] == "from-process"

--- a/src/skillberry_store/ui/src/components/PluginActionForm.tsx
+++ b/src/skillberry_store/ui/src/components/PluginActionForm.tsx
@@ -330,7 +330,7 @@ export function PluginActionForm({
     return (
       <FormGroup
         key={propertyName}
-        label={propertyName}
+        label={propertySchema.title ?? propertyName}
         isRequired={isRequired}
         fieldId={propertyName}
       >


### PR DESCRIPTION
Closes #228

The `skill-optimizer` and `anthropic-skill-generator` plugins read `~/.claude/settings.json` but looked for non-standard top-level keys (`apiKey`/`baseUrl`/`authToken`). Real Claude Code settings nest these under an `env` block using the standard `ANTHROPIC_*` names, so credentials were never found and the plugins reported "Missing credentials" despite being configured.

## Changes
- Resolve credentials from the `settings.json` `env` block using the standard `ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN` names.
- Forward the **entire** `env` block to the Claude Code agent instead of a hardcoded subset, so models and `CLAUDE_*` flags propagate (`ANTHROPIC_MODEL`, `ANTHROPIC_SMALL_FAST_MODEL`, `CLAUDE_CODE_SUBAGENT_MODEL`, …).
- Process `ANTHROPIC_*` / `CLAUDE_*` environment variables still override the settings file; per-run `agent_env` still wins over both.
- Clarify the `agent_env` UI field: `PluginActionForm` now honors a field `title` for the default input (previously it showed the raw property name), and both plugins relabel the field to "Environment overrides (optional)" with a description noting that `settings.json` + server env are already loaded automatically.
- Isolate the credential tests from the dev machine's real `settings.json`, and add coverage for env-block parsing and full forwarding.

## Testing
- `pytest` for both plugins: **49 passed**.

## Files
- `plugins/skillberry-plugin-skill-optimizer/.../plugin.py`
- `plugins/skillberry-plugin-anthropic-skill-generator/.../plugin.py`
- `plugins/skillberry-plugin-skill-optimizer/tests/test_skill_optimizer_plugin.py`
- `src/skillberry_store/ui/src/components/PluginActionForm.tsx`
