### PR TITLE
chore: gitignore CLAUDE.md and toml update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,6 @@ src/skillberry_store/fast_api/git_version.py
 
 # skills-sh-importer output folders
 src/skillberry_store/contrib/examples/skills-sh-importer/*/
+
+# project-specific Claude Code instructions (kept local, not tracked)
+CLAUDE.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,8 @@ authors = [{ name = "Eran Raichstein", email = "eranra@il.ibm.com" },
             { name = "David Breitgand", email = "davidbr@il.ibm.com" }, 
             { name = "Avi Weit", email = "weit@il.ibm.com" }, 
             { name = "Erez Hadad", email = "erezh@il.ibm.com" },
-            { name = "Osher Elhadad", email = "Osher.Elhadad@ibm.com" }]
+            { name = "Osher Elhadad", email = "Osher.Elhadad@ibm.com" },
+            { name = "Priel Hazan", email = "priel.hazan@ibm.com" }]
 requires-python = ">=3.11"
 dependencies = [
   "annotated-types>=0.7.0",


### PR DESCRIPTION
Two small repo-meta changes:

- **Gitignore `CLAUDE.md`** — keep project-specific Claude Code instructions a local, untracked file (the repo already ignores `**.claude`). Prevents accidental commits of personal instruction files.
- **Add an author entry** to `pyproject.toml`.

No code or behavior changes.