### PR TITLE
feat(plugins): admin enable/disable toggle (persisted, live)

### DIFF
--- a/src/skillberry_store/fast_api/plugins_api.py
+++ b/src/skillberry_store/fast_api/plugins_api.py
@@ -3,8 +3,14 @@
 import logging
 from typing import List, Dict, Any
 from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
+
+
+class PluginEnabledUpdate(BaseModel):
+    """Body for toggling a plugin's admin enablement."""
+    enabled: bool
 
 
 def register_plugins_api(app: FastAPI, plugin_loader: Any, tags: str = "plugins"):
@@ -81,6 +87,33 @@ def register_plugins_api(app: FastAPI, plugin_loader: Any, tags: str = "plugins"
             raise HTTPException(
                 status_code=500, detail=f"Failed to get plugin info: {str(e)}"
             )
+
+    @app.patch(
+        "/plugins/{plugin_name}",
+        tags=[tags],
+        summary="Enable or disable a plugin",
+        response_model=Dict[str, Any],
+    )
+    async def update_plugin(plugin_name: str, body: PluginEnabledUpdate):
+        """Toggle a plugin's admin enablement (global, persisted, live).
+
+        Args:
+            plugin_name: Name/slug of the plugin
+            body: {"enabled": bool}
+
+        Returns:
+            The updated plugin info dictionary.
+
+        Raises:
+            HTTPException: 404 if plugin not found
+        """
+        if plugin_loader.get_plugin_info(plugin_name) is None:
+            raise HTTPException(status_code=404, detail=f"Plugin '{plugin_name}' not found")
+        try:
+            plugin_loader.set_enabled(plugin_name, body.enabled)
+        except KeyError:
+            raise HTTPException(status_code=404, detail=f"Plugin '{plugin_name}' not found")
+        return plugin_loader.get_plugin_info(plugin_name)
 
 
 # Made with Bob

--- a/src/skillberry_store/fast_api/plugins_api.py
+++ b/src/skillberry_store/fast_api/plugins_api.py
@@ -10,6 +10,7 @@ logger = logging.getLogger(__name__)
 
 class PluginEnabledUpdate(BaseModel):
     """Body for toggling a plugin's admin enablement."""
+
     enabled: bool
 
 
@@ -108,11 +109,15 @@ def register_plugins_api(app: FastAPI, plugin_loader: Any, tags: str = "plugins"
             HTTPException: 404 if plugin not found
         """
         if plugin_loader.get_plugin_info(plugin_name) is None:
-            raise HTTPException(status_code=404, detail=f"Plugin '{plugin_name}' not found")
+            raise HTTPException(
+                status_code=404, detail=f"Plugin '{plugin_name}' not found"
+            )
         try:
             plugin_loader.set_enabled(plugin_name, body.enabled)
         except KeyError:
-            raise HTTPException(status_code=404, detail=f"Plugin '{plugin_name}' not found")
+            raise HTTPException(
+                status_code=404, detail=f"Plugin '{plugin_name}' not found"
+            )
         return plugin_loader.get_plugin_info(plugin_name)
 
 

--- a/src/skillberry_store/plugins/config.py
+++ b/src/skillberry_store/plugins/config.py
@@ -1,0 +1,65 @@
+"""Persisted, default-on enable/disable state for plugins.
+
+The config file records only the plugins that have been explicitly DISABLED.
+A plugin is enabled unless its slug appears in the ``disabled`` list, so a
+missing, empty, or corrupt file means every plugin is enabled.
+"""
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Optional, Set, Union
+
+logger = logging.getLogger(__name__)
+
+
+class PluginConfigStore:
+    """Reads/writes the global plugin enable/disable config (JSON on disk)."""
+
+    def __init__(self, path: Optional[Union[str, Path]] = None):
+        self.path: Path = Path(path) if path is not None else self._default_path()
+        self._disabled: Set[str] = set()
+        self.load()
+
+    @staticmethod
+    def _default_path() -> Path:
+        env = os.getenv("SKILLBERRY_PLUGIN_CONFIG")
+        if env:
+            return Path(env)
+        return Path.home() / ".skillberry" / "plugins.json"
+
+    def load(self) -> None:
+        """Load the disabled set from disk. Any error -> all plugins enabled."""
+        try:
+            data = json.loads(self.path.read_text())
+            disabled = data.get("disabled", [])
+            self._disabled = {str(s) for s in disabled}
+        except FileNotFoundError:
+            self._disabled = set()
+        except (json.JSONDecodeError, OSError, AttributeError, TypeError) as e:
+            logger.warning(
+                f"Could not read plugin config at {self.path}: {e}; "
+                f"treating all plugins as enabled"
+            )
+            self._disabled = set()
+
+    def is_enabled(self, slug: str) -> bool:
+        """A plugin is enabled unless explicitly recorded as disabled."""
+        return slug not in self._disabled
+
+    def set_enabled(self, slug: str, value: bool) -> None:
+        """Enable or disable a plugin and persist immediately."""
+        if value:
+            self._disabled.discard(slug)
+        else:
+            self._disabled.add(slug)
+        self._save()
+
+    def _save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.path.with_name(self.path.name + ".tmp")
+        tmp.write_text(json.dumps({"disabled": sorted(self._disabled)}, indent=2))
+        os.replace(tmp, self.path)
+
+# Made with Bob

--- a/src/skillberry_store/plugins/events.py
+++ b/src/skillberry_store/plugins/events.py
@@ -5,7 +5,7 @@ The store emits these events when content changes occur.
 """
 
 import asyncio
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Optional
 import logging
 
 logger = logging.getLogger(__name__)
@@ -16,6 +16,26 @@ _event_handlers: Dict[str, List[Callable]] = {}
 # Holds strong references to background tasks so they are not garbage-collected
 # before they complete.
 _background_tasks: set = set()
+
+# Maps each registered handler callable to the slug of the plugin that owns it.
+# Populated by the plugin loader via register_handler_owner(); plugins themselves
+# are unchanged. A handler with no recorded owner always runs.
+_handler_owners: Dict[Callable, str] = {}
+
+# Optional resolver injected by the loader: slug -> bool (is the plugin enabled?).
+# When None, every handler runs (default-on / backward compatible).
+_enabled_resolver: Optional[Callable[[str], bool]] = None
+
+
+def register_handler_owner(func: Callable, slug: str) -> None:
+    """Record which plugin owns a handler callable (called by the loader)."""
+    _handler_owners[func] = slug
+
+
+def set_enabled_resolver(resolver: Optional[Callable[[str], bool]]) -> None:
+    """Inject the loader's 'is this plugin enabled?' resolver (or None to clear)."""
+    global _enabled_resolver
+    _enabled_resolver = resolver
 
 
 def on_content_added(content_type: str):
@@ -101,6 +121,9 @@ def emit_event(event_name: str, **kwargs):
     """
     handlers = _event_handlers.get(event_name, [])
     for handler in handlers:
+        owner = _handler_owners.get(handler)
+        if owner is not None and _enabled_resolver is not None and not _enabled_resolver(owner):
+            continue
         task = asyncio.create_task(_run_handler(handler, **kwargs))
         _background_tasks.add(task)
         task.add_done_callback(_background_tasks.discard)

--- a/src/skillberry_store/plugins/loader.py
+++ b/src/skillberry_store/plugins/loader.py
@@ -7,6 +7,8 @@ from fastapi import FastAPI
 
 from skillberry_store.plugins.base import PluginBase
 from skillberry_store.plugins.store_api import StoreAPI
+from skillberry_store.plugins.config import PluginConfigStore
+from skillberry_store.plugins import events as plugin_events
 
 logger = logging.getLogger(__name__)
 
@@ -18,14 +20,19 @@ class PluginLoader:
     Each plugin must be a subclass of PluginBase.
     """
     
-    def __init__(self, store_api: StoreAPI):
+    def __init__(self, store_api: StoreAPI, config_store: Optional[PluginConfigStore] = None):
         """Initialize the plugin loader.
-        
+
         Args:
             store_api: StoreAPI instance to inject into plugins
+            config_store: persisted enable/disable state (defaults to PluginConfigStore())
         """
         self.store_api = store_api
         self.plugins: Dict[str, PluginBase] = {}
+        self.config = config_store or PluginConfigStore()
+        # Event dispatch consults admin enablement only; capability is handled
+        # by each plugin's own internal guard.
+        plugin_events.set_enabled_resolver(self.config.is_enabled)
     
     def discover_plugins(self) -> List[str]:
         """Discover and load all available plugins.
@@ -64,12 +71,16 @@ class PluginLoader:
                     )
                     continue
                 
-                # Instantiate the plugin
+                # Snapshot existing handlers, instantiate, then attribute any
+                # newly-registered handlers to this plugin's slug.
+                before = self._handler_snapshot()
                 plugin = plugin_class()
-                
+                for func in self._handler_snapshot() - before:
+                    plugin_events.register_handler_owner(func, entry_point.name)
+
                 # Inject store API
                 plugin.set_store_api(self.store_api)
-                
+
                 # Store the plugin
                 self.plugins[entry_point.name] = plugin
                 discovered.append(entry_point.name)
@@ -90,6 +101,27 @@ class PluginLoader:
         
         return discovered
     
+    @staticmethod
+    def _handler_snapshot() -> set:
+        """Set of all handler callables currently in the global event registry."""
+        snapshot = set()
+        for handlers in plugin_events._event_handlers.values():
+            snapshot.update(handlers)
+        return snapshot
+
+    def is_active(self, slug: str) -> bool:
+        """Effective enablement: plugin is capable AND admin-enabled."""
+        plugin = self.plugins.get(slug)
+        if plugin is None:
+            return False
+        return plugin.is_enabled() and self.config.is_enabled(slug)
+
+    def set_enabled(self, slug: str, value: bool) -> None:
+        """Admin toggle for a plugin; persists and takes effect live."""
+        if slug not in self.plugins:
+            raise KeyError(slug)
+        self.config.set_enabled(slug, value)
+
     def mount_routers(self, app: FastAPI):
         """Mount plugin routers to the FastAPI app.
         
@@ -144,7 +176,8 @@ class PluginLoader:
             "plugin_type": metadata.plugin_type.value,
             "author": metadata.author,
             "homepage": metadata.homepage,
-            "enabled": plugin.is_enabled(),
+            "enabled": self.is_active(plugin_name),
+            "admin_enabled": self.config.is_enabled(plugin_name),
             "status": plugin.get_status_message(),
             "has_router": plugin.get_router() is not None,
             "has_cli": plugin.get_cli_commands() is not None,

--- a/src/skillberry_store/plugins/loader.py
+++ b/src/skillberry_store/plugins/loader.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Dict, List, Optional, Any
 from importlib.metadata import entry_points
-from fastapi import FastAPI
+from fastapi import FastAPI, Depends, HTTPException
 
 from skillberry_store.plugins.base import PluginBase
 from skillberry_store.plugins.store_api import StoreAPI
@@ -122,35 +122,37 @@ class PluginLoader:
             raise KeyError(slug)
         self.config.set_enabled(slug, value)
 
+    def _make_router_guard(self, slug: str):
+        """Build a dependency that 404s when the plugin is not active."""
+        async def guard():
+            if not self.is_active(slug):
+                raise HTTPException(status_code=404, detail=f"Plugin '{slug}' is disabled")
+        return guard
+
     def mount_routers(self, app: FastAPI):
         """Mount plugin routers to the FastAPI app.
-        
-        Only enabled plugins with routers are mounted.
-        Routers are mounted at /plugins/{plugin_name}/
-        
+
+        Routers are always mounted (so plugins can be toggled live without a
+        restart) but carry a guard dependency that returns 404 while the plugin
+        is disabled or not capable.
+
         Args:
             app: FastAPI application instance
         """
         for plugin_name, plugin in self.plugins.items():
-            # Skip disabled plugins
-            if not plugin.is_enabled():
-                logger.info(f"Plugin '{plugin_name}' is disabled, skipping router mount")
-                continue
-            
-            # Get router
             router = plugin.get_router()
             if router is None:
                 continue
-            
-            # Mount router
+
             prefix = f"/plugins/{plugin_name}"
             app.include_router(
                 router,
                 prefix=prefix,
-                tags=["plugins", plugin_name]
+                tags=["plugins", plugin_name],
+                dependencies=[Depends(self._make_router_guard(plugin_name))],
             )
-            
-            logger.info(f"Mounted router for plugin '{plugin_name}' at {prefix}")
+
+            logger.info(f"Mounted router for plugin '{plugin_name}' at {prefix} (guarded)")
     
     def get_plugin_info(self, plugin_name: str) -> Optional[Dict[str, Any]]:
         """Get information about a specific plugin.

--- a/src/skillberry_store/tests/e2e/test_plugins_api.py
+++ b/src/skillberry_store/tests/e2e/test_plugins_api.py
@@ -143,4 +143,47 @@ async def test_plugins_api_returns_valid_json(run_sbs):
         data = response.json()  # Will raise if not valid JSON
         assert isinstance(data, dict)
 
+
+def test_patch_toggles_plugin_enabled(tmp_path):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from unittest.mock import Mock
+    from skillberry_store.fast_api.plugins_api import register_plugins_api
+    from skillberry_store.plugins.loader import PluginLoader
+    from skillberry_store.plugins.config import PluginConfigStore
+    from skillberry_store.plugins.base import PluginBase, PluginMetadata, PluginType
+    from skillberry_store.plugins.store_api import StoreAPI
+
+    class P(PluginBase):
+        @property
+        def metadata(self):
+            return PluginMetadata(name="p", description="d", version="1.0",
+                                  plugin_type=PluginType.CREATOR)
+        def is_enabled(self):
+            return True
+        def get_router(self):
+            return None
+        def get_cli_commands(self):
+            return None
+        def get_ui_config(self):
+            return None
+
+    cfg = PluginConfigStore(path=tmp_path / "plugins.json")
+    loader = PluginLoader(store_api=Mock(spec=StoreAPI), config_store=cfg)
+    loader.plugins["p"] = P()
+
+    app = FastAPI()
+    register_plugins_api(app, plugin_loader=loader)
+    client = TestClient(app)
+
+    resp = client.patch("/plugins/p", json={"enabled": False})
+    assert resp.status_code == 200
+    assert resp.json()["admin_enabled"] is False
+    assert resp.json()["enabled"] is False
+
+    resp = client.patch("/plugins/p", json={"enabled": True})
+    assert resp.json()["admin_enabled"] is True
+
+    assert client.patch("/plugins/does-not-exist", json={"enabled": False}).status_code == 404
+
 # Made with Bob

--- a/src/skillberry_store/tests/plugins/test_config.py
+++ b/src/skillberry_store/tests/plugins/test_config.py
@@ -1,0 +1,54 @@
+"""Tests for PluginConfigStore (plugin enable/disable persistence)."""
+
+import json
+import pytest
+from skillberry_store.plugins.config import PluginConfigStore
+
+
+def test_default_is_enabled(tmp_path):
+    store = PluginConfigStore(path=tmp_path / "plugins.json")
+    # Nothing recorded yet -> every plugin is enabled by default.
+    assert store.is_enabled("any-plugin") is True
+
+
+def test_disable_then_enable_roundtrip(tmp_path):
+    store = PluginConfigStore(path=tmp_path / "plugins.json")
+    store.set_enabled("plugin-a", False)
+    assert store.is_enabled("plugin-a") is False
+    store.set_enabled("plugin-a", True)
+    assert store.is_enabled("plugin-a") is True
+
+
+def test_persists_across_reload(tmp_path):
+    cfg = tmp_path / "plugins.json"
+    store = PluginConfigStore(path=cfg)
+    store.set_enabled("plugin-a", False)
+
+    reloaded = PluginConfigStore(path=cfg)
+    assert reloaded.is_enabled("plugin-a") is False
+    assert reloaded.is_enabled("plugin-b") is True
+
+
+def test_file_shape_lists_only_disabled(tmp_path):
+    cfg = tmp_path / "plugins.json"
+    store = PluginConfigStore(path=cfg)
+    store.set_enabled("plugin-a", False)
+    store.set_enabled("plugin-b", False)
+    store.set_enabled("plugin-a", True)  # re-enable removes it
+
+    data = json.loads(cfg.read_text())
+    assert data == {"disabled": ["plugin-b"]}
+
+
+def test_corrupt_file_falls_back_to_all_enabled(tmp_path):
+    cfg = tmp_path / "plugins.json"
+    cfg.write_text("{ this is not valid json")
+    store = PluginConfigStore(path=cfg)
+    assert store.is_enabled("plugin-a") is True
+
+
+def test_env_var_overrides_default_path(tmp_path, monkeypatch):
+    cfg = tmp_path / "custom.json"
+    monkeypatch.setenv("SKILLBERRY_PLUGIN_CONFIG", str(cfg))
+    store = PluginConfigStore()
+    assert store.path == cfg

--- a/src/skillberry_store/tests/plugins/test_events.py
+++ b/src/skillberry_store/tests/plugins/test_events.py
@@ -226,4 +226,64 @@ async def test_handler_receives_correct_kwargs():
     assert received_kwargs["uuid"] == "test-uuid"
     assert received_kwargs["extra_data"] == "extra"
 
+
+@pytest.mark.asyncio
+async def test_emit_skips_disabled_owner():
+    from skillberry_store.plugins.events import (
+        emit_event, register_handler_owner, set_enabled_resolver,
+        _event_handlers, _background_tasks, _handler_owners,
+    )
+
+    _event_handlers.clear()
+    _background_tasks.clear()
+    _handler_owners.clear()
+
+    ran = []
+
+    async def enabled_handler(uuid: str):
+        ran.append(("enabled", uuid))
+
+    async def disabled_handler(uuid: str):
+        ran.append(("disabled", uuid))
+
+    _event_handlers["content_added:skill"] = [enabled_handler, disabled_handler]
+    register_handler_owner(enabled_handler, "plugin-on")
+    register_handler_owner(disabled_handler, "plugin-off")
+    set_enabled_resolver(lambda slug: slug != "plugin-off")
+
+    emit_event("content_added:skill", uuid="abc")
+    await asyncio.gather(*list(_background_tasks))
+
+    assert ("enabled", "abc") in ran
+    assert ("disabled", "abc") not in ran
+
+    set_enabled_resolver(None)  # reset global
+
+
+@pytest.mark.asyncio
+async def test_untagged_handler_always_runs():
+    from skillberry_store.plugins.events import (
+        emit_event, set_enabled_resolver,
+        _event_handlers, _background_tasks, _handler_owners,
+    )
+
+    _event_handlers.clear()
+    _background_tasks.clear()
+    _handler_owners.clear()
+
+    ran = []
+
+    async def orphan_handler(uuid: str):
+        ran.append(uuid)
+
+    _event_handlers["content_added:skill"] = [orphan_handler]
+    # No owner recorded; resolver would disable everything if consulted.
+    set_enabled_resolver(lambda slug: False)
+
+    emit_event("content_added:skill", uuid="xyz")
+    await asyncio.gather(*list(_background_tasks))
+
+    assert ran == ["xyz"]
+    set_enabled_resolver(None)  # reset global
+
 # Made with Bob

--- a/src/skillberry_store/tests/plugins/test_loader.py
+++ b/src/skillberry_store/tests/plugins/test_loader.py
@@ -449,7 +449,85 @@ def test_plugin_loader_list_plugins_empty():
     loader = PluginLoader(store_api=mock_store_api)
     
     all_plugins = loader.list_plugins()
-    
+
     assert all_plugins == []
+
+
+def _make_plugin_class(name, capability=True):
+    from skillberry_store.plugins.base import PluginBase, PluginMetadata, PluginType
+    from skillberry_store.plugins.events import _event_handlers
+
+    class _P(PluginBase):
+        def __init__(self):
+            super().__init__()
+            async def _handler(uuid: str):
+                pass
+            _event_handlers.setdefault("content_added:skill", []).append(_handler)
+            self._handler = _handler
+
+        @property
+        def metadata(self):
+            return PluginMetadata(name=name, description="d", version="1.0",
+                                  plugin_type=PluginType.EVALUATOR)
+
+        def is_enabled(self):
+            return capability
+
+        def get_router(self):
+            return None
+
+        def get_cli_commands(self):
+            return None
+
+        def get_ui_config(self):
+            return None
+
+    return _P
+
+
+def test_set_enabled_persists_and_affects_is_active(tmp_path):
+    from skillberry_store.plugins.loader import PluginLoader
+    from skillberry_store.plugins.config import PluginConfigStore
+    from skillberry_store.plugins.store_api import StoreAPI
+
+    cfg = PluginConfigStore(path=tmp_path / "plugins.json")
+    loader = PluginLoader(store_api=Mock(spec=StoreAPI), config_store=cfg)
+    loader.plugins["plugin-a"] = _make_plugin_class("plugin-a")()
+
+    assert loader.is_active("plugin-a") is True
+    loader.set_enabled("plugin-a", False)
+    assert loader.is_active("plugin-a") is False
+    assert cfg.is_enabled("plugin-a") is False  # persisted
+
+
+def test_is_active_false_when_capability_off(tmp_path):
+    from skillberry_store.plugins.loader import PluginLoader
+    from skillberry_store.plugins.config import PluginConfigStore
+    from skillberry_store.plugins.store_api import StoreAPI
+
+    cfg = PluginConfigStore(path=tmp_path / "plugins.json")
+    loader = PluginLoader(store_api=Mock(spec=StoreAPI), config_store=cfg)
+    loader.plugins["plugin-a"] = _make_plugin_class("plugin-a", capability=False)()
+
+    assert loader.is_active("plugin-a") is False  # admin on, capability off
+
+
+def test_get_plugin_info_reports_admin_enabled(tmp_path):
+    from skillberry_store.plugins.loader import PluginLoader
+    from skillberry_store.plugins.config import PluginConfigStore
+    from skillberry_store.plugins.store_api import StoreAPI
+
+    cfg = PluginConfigStore(path=tmp_path / "plugins.json")
+    loader = PluginLoader(store_api=Mock(spec=StoreAPI), config_store=cfg)
+    loader.plugins["plugin-a"] = _make_plugin_class("plugin-a")()
+
+    info = loader.get_plugin_info("plugin-a")
+    assert info["admin_enabled"] is True
+    assert info["enabled"] is True
+
+    loader.set_enabled("plugin-a", False)
+    info = loader.get_plugin_info("plugin-a")
+    assert info["admin_enabled"] is False
+    assert info["enabled"] is False
 
 # Made with Bob

--- a/src/skillberry_store/tests/plugins/test_loader.py
+++ b/src/skillberry_store/tests/plugins/test_loader.py
@@ -219,49 +219,58 @@ def test_plugin_loader_mount_routers_to_app():
     assert call_args[1]["tags"] == ["plugins", "router_plugin"]
 
 
-def test_plugin_loader_mount_routers_skips_disabled():
-    """Test that disabled plugins' routers are not mounted."""
+def test_plugin_loader_mount_routers_mounts_with_guard():
+    """Routers are always mounted (live toggling); a guard dependency enforces state.
+
+    Previously disabled plugins were skipped at mount time. Now every plugin with a
+    router is mounted with a guard dependency so it can be enabled/disabled live;
+    the guard returns 404 while the plugin is inactive (see
+    test_router_guard_404s_when_disabled for the runtime behavior).
+    """
     from skillberry_store.plugins.loader import PluginLoader
     from skillberry_store.plugins.store_api import StoreAPI
     from skillberry_store.plugins.base import PluginBase, PluginMetadata, PluginType
-    
+
     mock_router = APIRouter()
-    
-    class DisabledPluginWithRouter(PluginBase):
+
+    class PluginWithRouter(PluginBase):
         @property
         def metadata(self) -> PluginMetadata:
             return PluginMetadata(
-                name="Disabled Router Plugin",
-                description="Disabled plugin with router",
+                name="Router Plugin",
+                description="Plugin with router",
                 version="1.0.0",
                 plugin_type=PluginType.CREATOR
             )
-        
+
         def is_enabled(self) -> bool:
-            return False
-        
+            return True
+
         def get_router(self) -> Optional[APIRouter]:
             return mock_router
-        
+
         def get_cli_commands(self) -> Optional[Dict[str, Any]]:
             return None
-        
+
         def get_ui_config(self) -> Optional[Dict[str, Any]]:
             return None
-    
+
     mock_store_api = Mock(spec=StoreAPI)
     loader = PluginLoader(store_api=mock_store_api)
-    
-    plugin = DisabledPluginWithRouter()
+
+    plugin = PluginWithRouter()
     plugin.set_store_api(mock_store_api)
-    loader.plugins["disabled_router"] = plugin
-    
+    loader.plugins["routed"] = plugin
+
     mock_app = Mock(spec=FastAPI)
-    
+
     loader.mount_routers(mock_app)
-    
-    # Should not mount disabled plugin's router
-    mock_app.include_router.assert_not_called()
+
+    # Router is mounted, and a guard dependency is attached.
+    mock_app.include_router.assert_called_once()
+    _, kwargs = mock_app.include_router.call_args
+    assert kwargs["prefix"] == "/plugins/routed"
+    assert len(kwargs["dependencies"]) == 1
 
 
 def test_plugin_loader_mount_routers_skips_none():
@@ -529,5 +538,46 @@ def test_get_plugin_info_reports_admin_enabled(tmp_path):
     info = loader.get_plugin_info("plugin-a")
     assert info["admin_enabled"] is False
     assert info["enabled"] is False
+
+
+def test_router_guard_404s_when_disabled(tmp_path):
+    from fastapi import APIRouter, FastAPI
+    from fastapi.testclient import TestClient
+    from skillberry_store.plugins.loader import PluginLoader
+    from skillberry_store.plugins.config import PluginConfigStore
+    from skillberry_store.plugins.base import PluginBase, PluginMetadata, PluginType
+    from skillberry_store.plugins.store_api import StoreAPI
+
+    router = APIRouter()
+
+    @router.get("/ping")
+    async def ping():
+        return {"ok": True}
+
+    class RoutedPlugin(PluginBase):
+        @property
+        def metadata(self):
+            return PluginMetadata(name="routed", description="d", version="1.0",
+                                  plugin_type=PluginType.CREATOR)
+        def is_enabled(self):
+            return True
+        def get_router(self):
+            return router
+        def get_cli_commands(self):
+            return None
+        def get_ui_config(self):
+            return None
+
+    cfg = PluginConfigStore(path=tmp_path / "plugins.json")
+    loader = PluginLoader(store_api=Mock(spec=StoreAPI), config_store=cfg)
+    loader.plugins["routed"] = RoutedPlugin()
+
+    app = FastAPI()
+    loader.mount_routers(app)
+    client = TestClient(app)
+
+    assert client.get("/plugins/routed/ping").status_code == 200
+    loader.set_enabled("routed", False)
+    assert client.get("/plugins/routed/ping").status_code == 404
 
 # Made with Bob

--- a/src/skillberry_store/ui/src/components/PluginCard.test.tsx
+++ b/src/skillberry_store/ui/src/components/PluginCard.test.tsx
@@ -24,4 +24,27 @@ describe('PluginCard toggle', () => {
     fireEvent.click(screen.getByRole('checkbox'));
     expect(onToggle).toHaveBeenCalledWith(basePlugin, false);
   });
+
+  it('dims the card when the plugin is admin-disabled', () => {
+    const { container, rerender } = render(<PluginCard plugin={basePlugin} />);
+    expect(container.querySelector('[data-disabled="true"]')).toBeNull();
+
+    rerender(<PluginCard plugin={{ ...basePlugin, admin_enabled: false }} />);
+    expect(container.querySelector('[data-disabled="true"]')).not.toBeNull();
+  });
+
+  it('keeps the toggle interactive while dimmed', () => {
+    const onToggle = vi.fn();
+    render(
+      <PluginCard
+        plugin={{ ...basePlugin, admin_enabled: false, enabled: false }}
+        onToggleEnabled={onToggle}
+      />
+    );
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(onToggle).toHaveBeenCalledWith(
+      expect.objectContaining({ slug: 'demo' }),
+      true
+    );
+  });
 });

--- a/src/skillberry_store/ui/src/components/PluginCard.test.tsx
+++ b/src/skillberry_store/ui/src/components/PluginCard.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PluginCard } from './PluginCard';
+import type { Plugin } from '@/types';
+
+const basePlugin: Plugin = {
+  slug: 'demo',
+  name: 'Demo Plugin',
+  description: 'A demo',
+  version: '1.0',
+  plugin_type: 'creator' as Plugin['plugin_type'],
+  enabled: true,
+  admin_enabled: true,
+  status: 'Ready',
+  has_router: false,
+  has_cli: false,
+  has_ui: false,
+};
+
+describe('PluginCard toggle', () => {
+  it('calls onToggleEnabled with the negated admin_enabled value', () => {
+    const onToggle = vi.fn();
+    render(<PluginCard plugin={basePlugin} onToggleEnabled={onToggle} />);
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(onToggle).toHaveBeenCalledWith(basePlugin, false);
+  });
+});

--- a/src/skillberry_store/ui/src/components/PluginCard.tsx
+++ b/src/skillberry_store/ui/src/components/PluginCard.tsx
@@ -24,6 +24,11 @@ interface PluginCardProps {
 }
 
 export function PluginCard({ plugin, onActionClick, onToggleEnabled }: PluginCardProps) {
+  // Visually dim cards the admin has turned off. The toggle and status stay at
+  // full opacity so the plugin can still be re-enabled.
+  const dimmed = !plugin.admin_enabled;
+  const dimStyle = { opacity: dimmed ? 0.5 : 1 };
+
   const getStatusIcon = () => {
     if (plugin.enabled) {
       return <CheckCircleIcon style={{ color: '#3E8635' }} />;
@@ -38,14 +43,16 @@ export function PluginCard({ plugin, onActionClick, onToggleEnabled }: PluginCar
   return (
     <Card
       isCompact
+      data-disabled={dimmed ? 'true' : undefined}
       style={{
         borderLeft: `4px solid ${plugin.ui_config?.color || '#0066CC'}`,
+        backgroundColor: dimmed ? '#FAFAFA' : undefined,
       }}
     >
       <CardTitle>
         <Flex alignItems={{ default: 'alignItemsCenter' }}>
           <FlexItem>
-            <Text component="h3">{plugin.name}</Text>
+            <Text component="h3" style={dimStyle}>{plugin.name}</Text>
           </FlexItem>
           <FlexItem align={{ default: 'alignRight' }}>
             <Flex alignItems={{ default: 'alignItemsCenter' }} spaceItems={{ default: 'spaceItemsSm' }}>
@@ -66,7 +73,7 @@ export function PluginCard({ plugin, onActionClick, onToggleEnabled }: PluginCar
           </FlexItem>
         </Flex>
       </CardTitle>
-      <CardBody>
+      <CardBody style={dimStyle}>
         <Text component="p" style={{ marginBottom: '0.5rem' }}>
           {plugin.description}
         </Text>

--- a/src/skillberry_store/ui/src/components/PluginCard.tsx
+++ b/src/skillberry_store/ui/src/components/PluginCard.tsx
@@ -12,6 +12,7 @@ import {
   Flex,
   FlexItem,
   Tooltip,
+  Switch,
 } from '@patternfly/react-core';
 import { CheckCircleIcon, ExclamationCircleIcon, InfoCircleIcon } from '@patternfly/react-icons';
 import type { Plugin } from '@/types';
@@ -19,9 +20,10 @@ import type { Plugin } from '@/types';
 interface PluginCardProps {
   plugin: Plugin;
   onActionClick?: (action: any) => void;
+  onToggleEnabled?: (plugin: Plugin, enabled: boolean) => void;
 }
 
-export function PluginCard({ plugin, onActionClick }: PluginCardProps) {
+export function PluginCard({ plugin, onActionClick, onToggleEnabled }: PluginCardProps) {
   const getStatusIcon = () => {
     if (plugin.enabled) {
       return <CheckCircleIcon style={{ color: '#3E8635' }} />;
@@ -46,9 +48,21 @@ export function PluginCard({ plugin, onActionClick }: PluginCardProps) {
             <Text component="h3">{plugin.name}</Text>
           </FlexItem>
           <FlexItem align={{ default: 'alignRight' }}>
-            <Tooltip content={plugin.status}>
-              <Label icon={getStatusIcon()}>{getStatusLabel()}</Label>
-            </Tooltip>
+            <Flex alignItems={{ default: 'alignItemsCenter' }} spaceItems={{ default: 'spaceItemsSm' }}>
+              <FlexItem>
+                <Switch
+                  id={`plugin-toggle-${plugin.slug}`}
+                  aria-label={`Toggle ${plugin.name}`}
+                  isChecked={plugin.admin_enabled}
+                  onChange={(_event, checked) => onToggleEnabled?.(plugin, checked)}
+                />
+              </FlexItem>
+              <FlexItem>
+                <Tooltip content={plugin.status}>
+                  <Label icon={getStatusIcon()}>{getStatusLabel()}</Label>
+                </Tooltip>
+              </FlexItem>
+            </Flex>
           </FlexItem>
         </Flex>
       </CardTitle>

--- a/src/skillberry_store/ui/src/pages/PluginsPage.tsx
+++ b/src/skillberry_store/ui/src/pages/PluginsPage.tsx
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 
 import { useState } from 'react';
-import { useQuery, useMutation } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   PageSection,
   Title,
@@ -31,6 +31,20 @@ export function PluginsPage() {
     queryKey: ['plugins'],
     queryFn: pluginsApi.list,
   });
+
+  const queryClient = useQueryClient();
+
+  const toggleEnabledMutation = useMutation({
+    mutationFn: ({ slug, enabled }: { slug: string; enabled: boolean }) =>
+      pluginsApi.setEnabled(slug, enabled),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['plugins'] });
+    },
+  });
+
+  const handleToggleEnabled = (plugin: Plugin, enabled: boolean) => {
+    toggleEnabledMutation.mutate({ slug: plugin.slug, enabled });
+  };
 
   // Execute plugin action mutation
   const executeActionMutation = useMutation({
@@ -114,6 +128,7 @@ export function PluginsPage() {
             key={plugin.name}
             plugin={plugin}
             onActionClick={(action) => handleActionClick(plugin, action)}
+            onToggleEnabled={handleToggleEnabled}
           />
         ))}
       </Gallery>

--- a/src/skillberry_store/ui/src/services/api.ts
+++ b/src/skillberry_store/ui/src/services/api.ts
@@ -430,6 +430,15 @@ export const pluginsApi = {
     return handleResponse<Plugin>(response);
   },
 
+  setEnabled: async (name: string, enabled: boolean): Promise<Plugin> => {
+    const response = await fetch(`${API_BASE}/plugins/${name}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ enabled }),
+    });
+    return handleResponse<Plugin>(response);
+  },
+
   executeAction: async (
     pluginName: string,
     action: string,

--- a/src/skillberry_store/ui/src/types/index.ts
+++ b/src/skillberry_store/ui/src/types/index.ts
@@ -183,6 +183,7 @@ export interface Plugin {
   author?: string;
   homepage?: string;
   enabled: boolean;
+  admin_enabled: boolean;
   status: string;
   has_router: boolean;
   has_cli: boolean;


### PR DESCRIPTION
Closes #236.

## Summary
Adds a global, admin-wide enable/disable toggle per plugin. The choice is persisted and takes effect live (no restart). A disabled plugin becomes fully inert: its event handlers do not run, its routes return 404, and the UI grays it out.

This directly addresses the slowness of content management when many plugins are installed — adding a skill no longer fans out to handlers of plugins the operator has turned off.

## What changed
- **Config**: new `PluginConfigStore` — default-on JSON config (`~/.skillberry/plugins.json`, `SKILLBERRY_PLUGIN_CONFIG` override), atomic writes, corrupt-file fallback to all-enabled.
- **Events**: `events.py` tags each handler with its owning plugin and skips disabled owners in `emit_event`.
- **Loader**: owns the config, tags handler owners via a snapshot-diff at instantiation (zero plugin code changes), exposes `is_active`/`set_enabled`, and always-mounts plugin routers behind a live 404 guard.
- **API**: `PATCH /plugins/{slug}` toggles enablement; `get_plugin_info` now reports `enabled` (effective) and `admin_enabled` (toggle).
- **UI**: per-plugin on/off Switch on the plugin card; admin-disabled cards are grayed out while the toggle/status stay interactive.

## Design decisions
- **Default-on**: a plugin is enabled unless explicitly listed as disabled, so newly installed plugins work without config edits.
- **Owner-tagging via snapshot-diff** rather than a context manager, because plugins append handlers as bare callables directly to the global registry — the diff is robust to that and needs no per-plugin edits.
- **Event gate uses the admin toggle only**; capability (e.g. missing LLM key) is still handled by each plugin's own guard, so the two states stay distinct in the UI.
- **Routes always mount, guarded** since FastAPI cannot cleanly unmount routers at runtime; the guard returns 404 while inactive, enabling live toggling.

## Testing
- Backend: 73 tests pass across `tests/plugins/` (config, events, loader, route guard) plus the new `PATCH` endpoint test.
- UI: all plugin-related component tests pass (PluginCard toggle + dim, PluginNotifications, PluginActionForm). Pre-existing unrelated UI test failures (VMCP pages, test setup) were confirmed present on main and are untouched.

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>