### PR TITLE
feat: add DAST Scanner plugin (dynamic, detect-and-report)

### DIFF
--- a/plugins/skillberry-plugin-dast/README.md
+++ b/plugins/skillberry-plugin-dast/README.md
@@ -1,0 +1,115 @@
+# skillberry-plugin-dast
+
+**DAST** (Dynamic Application Security Testing) — dynamically tests a **skill** by
+discovering its externally-invocable entry points, exercising each with
+adversarial inputs, and **observing the effects** (MCP calls, network egress,
+subprocess spawns, filesystem access). Results are recorded under
+`extra["dast"]` + `dast:` tags.
+
+This is the **dynamic** counterpart to the store's static analyzers (SAST,
+provenance, dependency-tracker): instead of reading code, it *runs* it with
+hostile inputs and watches what it actually does.
+
+## Threat model
+
+A skill is reusable **code**, not just its agent-mediated behavior — any external
+component (an agent, a developer, another tool) can load it and call its functions
+directly. So DAST targets **all enumerable entry points**, not just agent usage.
+
+## Entry points exercised (Phase 1)
+
+| Tier | What | Source |
+|------|------|--------|
+| **Tier 1** | registered tools (name + parameter schema) | tool metadata |
+| **Tier 2** | public top-level functions / classes / `__main__` | AST of the skill's modules |
+
+Tier 2 functions that shadow a registered tool are de-duped into Tier 1.
+
+## How it works
+
+1. **Discover** entry points (Tier 1 from tool metadata, Tier 2 via AST).
+2. **Generate inputs** for each via the optional Hypothesis engine — strategies
+   mapped from each parameter's declared type, plus missing-required cases
+   (deterministic; requires the engine, see below).
+3. **Exercise** each case via the store's `FileExecutor` (Docker exec sandbox),
+   with a pass-through-and-log **observe-shim** prepended to the code that
+   records `socket`/`requests`/`httpx`/`urllib`/`subprocess`/`os.system`/`open`.
+4. **Observe MCP** via a **benign vMCP twin** (`VirtualMcpServer`) the skill calls
+   instead of the real server — faithful execution + per-call logging.
+5. **Report** findings + coverage to `extra["dast"]`.
+
+## Honest ceilings (in every report's `coverage`)
+
+- **Discovery is static** → dynamically-dispatched entry points (Tier 3) may be
+  missed → `coverage.exercised = N/M`.
+- **Observation is detect-and-report, not prevent** → egress/effects *happen* and
+  are recorded, not blocked → `coverage.observation = "detected, not prevented"`.
+  **Run only against an operator-accepted network/sandbox.** True network lockdown
+  is a follow-up gated on a runspace capability request.
+
+## Live vs. dry-run
+
+Real Docker + vMCP execution is gated behind **`DAST_LIVE=1`** (keeps the default
+and CI inert). Without it, `scan` performs discovery + fuzzing through the full
+pipeline with an inert executor — useful for inspecting entry points/coverage
+offline. Set `DAST_LIVE=1` (with Docker available) to actually exercise code.
+
+## The `extra["dast"]` block
+
+```jsonc
+{
+  "schema_version": 1, "generated_at": "<ISO-8601>",
+  "scanner": { "plugin_version", "mode": "detect-and-report", "live": false },
+  "coverage": { "entry_points_discovered": M, "exercised": N, "skipped": ..,
+                "by_tier": {"tool":..,"function":..,"class":..,"main":..},
+                "discovery": "static (Tier-3 dynamic dispatch may be missed)",
+                "observation": "detected, not prevented" },
+  "entry_points": [ {"name","kind","module","params_or_signature","exercised"} ],
+  "findings": [ {"entry_point","kind":"crash|leak|network-egress|subprocess|filesystem|mcp-call",
+                 "severity":"high|medium|low|info","case","evidence","target"} ],
+  "skipped_entry_points": [ {"name","reason"} ],
+  "summary": { "findings","high","medium","egress_attempts","subprocess_attempts",
+               "crashes","mcp_calls" }
+}
+```
+
+Tags: `dast:findings:K`, `dast:coverage:N/M`, `dast:high:H`, `dast:egress:E`.
+
+## API
+
+Mounted at `/plugins/dast` (and `/api/plugins/dast/...`):
+
+- `POST /scan` — `{ "object_type": "skill|tool|snippet", "uuid": str }` → `{ success, message, data }`. Invalid input → clean **400**.
+
+**On-demand only** — no auto-scan-on-import hook.
+
+## Input generator — an OPTIONAL open-source engine
+
+Like the SAST plugin (which treats **bandit** as an optional engine), the DAST
+scanner does **not** bundle an input generator. The supported engine is
+**[Hypothesis](https://hypothesis.readthedocs.io)** (property-based testing).
+
+- If Hypothesis is **not installed**, the scanner reports **disabled**
+  (`is_enabled() == False`) and `POST /scan` returns **503** — there is no
+  proprietary fallback generator.
+- Install it to enable scanning:
+  `pip install 'skillberry-plugin-dast[hypothesis]'`
+
+All adversarial inputs are drawn from Hypothesis strategies mapped from each
+parameter's declared type (string/int/float/bool/array/object, with a
+type-confusion mix for unknown), plus missing-required cases. Draws are
+deterministic for CI via a fixed seed.
+
+- **Phase 2** (deferred): agent-mediated adversarial-prompt red-teaming, intended
+  to wrap **garak** (NVIDIA). **mcp-scan/snyk-agent-scan** is a complementary
+  static MCP taxonomy reference.
+
+## Install / Test
+
+```bash
+pip install -e 'plugins/skillberry-plugin-dast[hypothesis]'   # engine enables scanning
+pytest plugins/skillberry-plugin-dast/tests -q   # offline; real runs need DAST_LIVE=1 + Docker
+```
+
+Tests that generate inputs are skipped when the Hypothesis engine is absent; the
+disabled-state path is always tested.

--- a/plugins/skillberry-plugin-dast/pyproject.toml
+++ b/plugins/skillberry-plugin-dast/pyproject.toml
@@ -1,0 +1,43 @@
+[build-system]
+requires = ["setuptools>=45", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "skillberry-plugin-dast"
+version = "0.1.0"
+description = "Skillberry Store plugin for dynamic application security testing (DAST) of skills: discovers entry points, exercises them with adversarial inputs, and observes effects (detect-and-report)"
+readme = "README.md"
+requires-python = ">=3.10"
+# Core install is light. The input-generator engine is an OPTIONAL extra (like
+# the SAST plugin + bandit): without it the DAST scanner reports disabled and
+# does not run. `requests` is only for vMCP-twin reachability and is already a
+# store dependency.
+dependencies = [
+    "requests",
+]
+
+[project.entry-points."skillberry_store.plugins"]
+dast = "skillberry_plugin_dast.plugin:SkillberryPluginDast"
+
+[project.optional-dependencies]
+# Pluggable input-generator engines (each optional; install one to enable
+# scanning). Add a new engine's extra here alongside its registry entry.
+# e.g. `pip install 'skillberry-plugin-dast[hypothesis]'`
+hypothesis = [
+    "hypothesis>=6.0",
+]
+dev = [
+    "pytest",
+    "pytest-asyncio",
+    "httpx",
+    "fastapi",
+    "hypothesis>=6.0",
+]
+
+[tool.setuptools]
+packages = [
+    "skillberry_plugin_dast",
+    "skillberry_plugin_dast.engine",
+    "skillberry_plugin_dast.engine.generators",
+]
+package-dir = {"" = "src"}

--- a/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/__init__.py
+++ b/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/__init__.py
@@ -1,0 +1,5 @@
+"""Skillberry Store plugin: DAST (dynamic application security testing)."""
+
+from .plugin import SkillberryPluginDast
+
+__all__ = ["SkillberryPluginDast"]

--- a/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/engine/__init__.py
+++ b/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/engine/__init__.py
@@ -1,0 +1,46 @@
+"""DAST engine: discover -> fuzz -> execute -> observe -> report.
+
+Each stage is an independently testable module. The plugin wires them to the
+store (FileExecutor + benign vMCP twin); the engine itself is store-decoupled.
+"""
+
+from __future__ import annotations
+
+from .base import (
+    DastReport,
+    EntryPoint,
+    Finding,
+)
+from . import progress, scope
+from .discover import discover_entry_points
+from .fuzz import (
+    GENERATOR_NAME,
+    cases_from_signature,
+    generate_cases,
+    generator_available,
+    generator_status,
+)
+from .observe import EVENT_SINK_ENV, SHIM_SOURCE, findings_from_output, parse_events
+from .runner import run_dast
+from .twin import BenignMcpTwin, host_address_for_container
+
+__all__ = [
+    "DastReport",
+    "EntryPoint",
+    "Finding",
+    "discover_entry_points",
+    "generate_cases",
+    "cases_from_signature",
+    "generator_available",
+    "generator_status",
+    "GENERATOR_NAME",
+    "SHIM_SOURCE",
+    "EVENT_SINK_ENV",
+    "parse_events",
+    "findings_from_output",
+    "run_dast",
+    "BenignMcpTwin",
+    "host_address_for_container",
+    "progress",
+    "scope",
+]

--- a/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/engine/base.py
+++ b/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/engine/base.py
@@ -1,0 +1,211 @@
+"""Shapes + vocabulary for the DAST engine.
+
+The engine discovers a skill's invocable entry points, exercises each with
+adversarial inputs, observes the effects, and assembles a ``DastReport`` that
+serializes to the ``extra["dast"]`` block the plugin persists. Everything here is
+pure and JSON-friendly so the engine can be unit-tested offline; ``generated_at``
+is injected by the plugin (not computed here) to keep output deterministic.
+
+Honest framing baked into the vocabulary:
+  - discovery is STATIC (Tier-3 dynamic dispatch may be missed) -> reported in
+    ``coverage.discovery``;
+  - observation is DETECT-AND-REPORT (effects happen, are not prevented) ->
+    reported in ``coverage.observation``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+SCHEMA_VERSION = 1
+MODE = "detect-and-report"
+
+OBJECT_TYPES = ("skill", "tool", "snippet")
+
+# Entry-point tiers / kinds.
+KIND_TOOL = "tool"  # Tier 1: a registered store tool
+KIND_FUNCTION = "function"  # Tier 2: AST-discovered public function
+KIND_CLASS = "class"  # Tier 2: AST-discovered public class
+KIND_MAIN = "main"  # Tier 2: a module __main__ entry point
+
+# Finding kinds (effect classes the observer / twin surface).
+FINDING_CRASH = "crash"
+FINDING_LEAK = "leak"
+FINDING_NETWORK = "network-egress"
+FINDING_SUBPROCESS = "subprocess"
+FINDING_FILESYSTEM = "filesystem"
+FINDING_MCP = "mcp-call"
+
+# Severities.
+SEV_HIGH = "high"
+SEV_MEDIUM = "medium"
+SEV_LOW = "low"
+SEV_INFO = "info"
+_SEV_ORDER = {SEV_INFO: 0, SEV_LOW: 1, SEV_MEDIUM: 2, SEV_HIGH: 3}
+
+
+@dataclass
+class EntryPoint:
+    """One externally-invocable surface of a skill."""
+
+    name: str
+    kind: str  # KIND_*
+    module: str = ""  # module file the entry point lives in
+    # Tier-1 tools carry a param schema; Tier-2 callables carry a signature.
+    params: Optional[Dict[str, Any]] = None  # {properties, required, optional}
+    signature: List[str] = field(default_factory=list)  # param names (Tier-2)
+    tool_uuid: Optional[str] = None
+    exercised: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "kind": self.kind,
+            "module": self.module,
+            "params_or_signature": (
+                self.params if self.params is not None else self.signature
+            ),
+            "exercised": self.exercised,
+        }
+
+
+@dataclass
+class Finding:
+    """One thing observed while exercising an entry point."""
+
+    entry_point: str
+    kind: str  # FINDING_*
+    severity: str  # SEV_*
+    case: str = ""  # short label of the adversarial input that triggered it
+    evidence: str = ""  # excerpt (traceback line, leaked token, etc.)
+    target: Optional[str] = None  # host/path/command, when applicable
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "entry_point": self.entry_point,
+            "kind": self.kind,
+            "severity": self.severity,
+            "case": self.case,
+            "evidence": self.evidence,
+            "target": self.target,
+        }
+
+
+@dataclass
+class DastReport:
+    """Full result for one scanned object."""
+
+    entry_points: List[EntryPoint] = field(default_factory=list)
+    findings: List[Finding] = field(default_factory=list)
+    # entry points discovered but not run (e.g. unreadable module), for honesty.
+    skipped: List[Dict[str, str]] = field(default_factory=list)
+    # Calls actually executed (exercised), by surface. A "call" is one
+    # input-case run against an entry point. These count ALL executions, not
+    # just the ones that surfaced a problem.
+    direct_calls_exercised: int = 0
+    mcp_calls_exercised: int = 0
+
+    # ── helpers ──────────────────────────────────────────────────────────────
+
+    def _by_tier(self) -> Dict[str, int]:
+        out: Dict[str, int] = {}
+        for ep in self.entry_points:
+            out[ep.kind] = out.get(ep.kind, 0) + 1
+        return out
+
+    def _exercised_count(self) -> int:
+        return sum(1 for ep in self.entry_points if ep.exercised)
+
+    def _sev_count(self, severity: str) -> int:
+        return sum(1 for f in self.findings if f.severity == severity)
+
+    def _kind_count(self, kind: str) -> int:
+        return sum(1 for f in self.findings if f.kind == kind)
+
+    def _mcp_tools_count(self) -> int:
+        """Distinct tools exercised via the MCP twin (mcp-call findings)."""
+        return len({f.entry_point for f in self.findings if f.kind == FINDING_MCP})
+
+    # ``mcp-call`` is an observation (info), not a problem. Every other finding
+    # kind is an actual problem (crash/leak/egress/subprocess/filesystem).
+    def _problems(self) -> List[Finding]:
+        return [f for f in self.findings if f.kind != FINDING_MCP]
+
+    def _problem_count(self) -> int:
+        return len(self._problems())
+
+    # ── serialization ──────────────────────────────────────────────────────────
+
+    def to_extra_block(
+        self, *, generated_at: str, plugin_version: str
+    ) -> Dict[str, Any]:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "generated_at": generated_at,
+            "scanner": {"plugin_version": plugin_version, "mode": MODE},
+            "coverage": {
+                "entry_points_discovered": len(self.entry_points),
+                "exercised": self._exercised_count(),
+                "skipped": len(self.skipped),
+                "by_tier": self._by_tier(),
+                # MCP surface (driven via the benign twin) is separate from the
+                # direct-invocation entry points above, so it gets its own count
+                # — otherwise an mcp-scope scan misleadingly reads "0/0".
+                "mcp_tools_exercised": self._mcp_tools_count(),
+                "discovery": "static (Tier-3 dynamic dispatch may be missed)",
+                "observation": "detected, not prevented",
+            },
+            "entry_points": [
+                ep.to_dict() for ep in sorted(self.entry_points, key=lambda e: e.name)
+            ],
+            "findings": [
+                f.to_dict()
+                for f in sorted(
+                    self.findings,
+                    key=lambda f: (
+                        -_SEV_ORDER.get(f.severity, 0),
+                        f.entry_point,
+                        f.kind,
+                    ),
+                )
+            ],
+            "skipped_entry_points": sorted(
+                self.skipped, key=lambda s: s.get("name", "")
+            ),
+            "summary": {
+                # Calls actually executed (exercised), by surface.
+                "exercised": {
+                    "direct_calls": self.direct_calls_exercised,
+                    "mcp_calls": self.mcp_calls_exercised,
+                    "total": self.direct_calls_exercised + self.mcp_calls_exercised,
+                },
+                # Actual findings (real issues, NOT mere observations), by surface.
+                "findings": {
+                    "direct": sum(
+                        1 for f in self._problems() if f.severity != SEV_INFO
+                    ),
+                    "mcp": 0,  # MCP-path observations are info, not findings
+                    "total": self._problem_count(),
+                    "high": self._sev_count(SEV_HIGH),
+                    "medium": self._sev_count(SEV_MEDIUM),
+                },
+                # Effect breakdown among findings.
+                "egress_attempts": self._kind_count(FINDING_NETWORK),
+                "subprocess_attempts": self._kind_count(FINDING_SUBPROCESS),
+                "crashes": self._kind_count(FINDING_CRASH),
+            },
+        }
+
+    def summary_tags(self) -> List[str]:
+        tags = [
+            f"dast:findings:{len(self.findings)}",
+            f"dast:coverage:{self._exercised_count()}/{len(self.entry_points)}",
+        ]
+        high = self._sev_count(SEV_HIGH)
+        if high:
+            tags.append(f"dast:high:{high}")
+        egress = self._kind_count(FINDING_NETWORK)
+        if egress:
+            tags.append(f"dast:egress:{egress}")
+        return tags

--- a/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/engine/discover.py
+++ b/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/engine/discover.py
@@ -1,0 +1,145 @@
+"""Entry-point discovery — Tier 1 (registered tools) + Tier 2 (AST public API).
+
+Pure and store-decoupled: the plugin gathers a skill's tool dicts and module
+sources from the store and hands them here. Tier 1 comes from tool metadata
+(name + param schema). Tier 2 walks each module's AST for public top-level
+functions/classes and ``__main__`` blocks — the surfaces an external component
+could import and call directly.
+
+Discovery is STATIC: dynamically-registered/dispatched entry points (Tier 3) are
+not guaranteed; the report flags this in its coverage note.
+"""
+
+from __future__ import annotations
+
+import ast
+from typing import Any, Dict, List, Tuple
+
+from .base import (
+    KIND_CLASS,
+    KIND_FUNCTION,
+    KIND_MAIN,
+    KIND_TOOL,
+    EntryPoint,
+)
+
+# (module_name, source) blob pairs, like the dependency-tracker plugin uses.
+Blob = Tuple[str, str]
+
+
+def _tier1_from_tools(tools: List[Dict[str, Any]]) -> List[EntryPoint]:
+    """Tier-1 entry points from registered tool dicts."""
+    out: List[EntryPoint] = []
+    for tool in tools:
+        name = tool.get("name")
+        if not name:
+            continue
+        params = tool.get("params")
+        # ToolParamsSchema may arrive as a model-dump dict or already a dict.
+        if hasattr(params, "model_dump"):
+            params = params.model_dump()
+        if not isinstance(params, dict):
+            params = {"properties": {}, "required": [], "optional": []}
+        out.append(
+            EntryPoint(
+                name=name,
+                kind=KIND_TOOL,
+                module=tool.get("module_name") or "",
+                params={
+                    "properties": params.get("properties") or {},
+                    "required": list(params.get("required") or []),
+                    "optional": list(params.get("optional") or []),
+                },
+                tool_uuid=tool.get("uuid"),
+            )
+        )
+    return out
+
+
+def _is_main_block(node: ast.AST) -> bool:
+    """True for ``if __name__ == "__main__":``."""
+    if not isinstance(node, ast.If):
+        return False
+    test = node.test
+    if not isinstance(test, ast.Compare) or len(test.comparators) != 1:
+        return False
+    left, right = test.left, test.comparators[0]
+    left_is_name = isinstance(left, ast.Name) and left.id == "__name__"
+    right_is_main = isinstance(right, ast.Constant) and right.value == "__main__"
+    return left_is_name and right_is_main
+
+
+def _signature(node: ast.AST) -> List[str]:
+    """Positional + keyword parameter names of a function/class __init__."""
+    if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        return []
+    args = node.args
+    names = [a.arg for a in (args.posonlyargs + args.args + args.kwonlyargs)]
+    return [n for n in names if n not in ("self", "cls")]
+
+
+def _tier2_from_module(module: str, source: str) -> List[EntryPoint]:
+    """Tier-2 public functions/classes + __main__ from one module's AST."""
+    try:
+        tree = ast.parse(source or "")
+    except (SyntaxError, ValueError):
+        return []
+    out: List[EntryPoint] = []
+    # Only TOP-LEVEL defs (module body), not nested ones.
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.name.startswith("_"):
+                continue
+            out.append(
+                EntryPoint(
+                    name=node.name,
+                    kind=KIND_FUNCTION,
+                    module=module,
+                    signature=_signature(node),
+                )
+            )
+        elif isinstance(node, ast.ClassDef):
+            if node.name.startswith("_"):
+                continue
+            # use __init__ signature if present for fuzzing the constructor
+            init_sig: List[str] = []
+            for sub in node.body:
+                if isinstance(sub, ast.FunctionDef) and sub.name == "__init__":
+                    init_sig = _signature(sub)
+                    break
+            out.append(
+                EntryPoint(
+                    name=node.name,
+                    kind=KIND_CLASS,
+                    module=module,
+                    signature=init_sig,
+                )
+            )
+        elif _is_main_block(node):
+            out.append(EntryPoint(name="__main__", kind=KIND_MAIN, module=module))
+    return out
+
+
+def discover_entry_points(
+    tools: List[Dict[str, Any]], blobs: List[Blob]
+) -> List[EntryPoint]:
+    """Discover Tier-1 + Tier-2 entry points; de-dup Tier-2 against Tier-1.
+
+    A tool's own function (Tier-1) shadows the same-named Tier-2 function in its
+    module, so we keep the richer Tier-1 entry and drop the duplicate.
+    """
+    tier1 = _tier1_from_tools(tools)
+    tool_names = {ep.name for ep in tier1}
+
+    tier2: List[EntryPoint] = []
+    for module, source in blobs:
+        for ep in _tier2_from_module(module, source):
+            # de-dup: a Tier-2 function matching a registered tool name is the
+            # tool's own entry point, already covered by Tier-1.
+            if ep.kind == KIND_FUNCTION and ep.name in tool_names:
+                continue
+            tier2.append(ep)
+
+    # Stable order: tools first, then Tier-2 by (module, name).
+    tier2.sort(key=lambda e: (e.module, e.name))
+    return tier1 + tier2

--- a/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/engine/fuzz.py
+++ b/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/engine/fuzz.py
@@ -1,0 +1,65 @@
+"""Adversarial input generation — delegates to a pluggable, optional engine.
+
+This module is a thin facade over the generator registry in ``generators/``. The
+actual fuzzing/input-generation is done by whichever :class:`InputGenerator`
+engine is registered + available (Hypothesis ships as the first one). A different
+fuzzer is plugged in by adding an engine to ``GENERATOR_REGISTRY`` — nothing here
+or in the plugin core changes.
+
+If no engine is available the scanner is disabled (the plugin gates on
+``generator_available()``); there is no proprietary fallback generator.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from .generators import (
+    any_generator_available,
+    registered_generator_names,
+    resolve_generator,
+    status_message,
+)
+
+# Kept for back-compat / status display: the set of engines the build knows of.
+GENERATOR_NAMES = registered_generator_names()
+# Historic single-name constant (first registered engine).
+GENERATOR_NAME = GENERATOR_NAMES[0] if GENERATOR_NAMES else ""
+
+
+def generator_available() -> bool:
+    """True iff some registered input-generator engine is installed/usable."""
+    return any_generator_available()
+
+
+def generator_status() -> str:
+    """Human-readable engine status for the plugin's status message."""
+    return status_message()
+
+
+def generate_cases(
+    params: Dict[str, Any], *, seed: int = 1729, max_cases: int = 24
+) -> List[Dict[str, Any]]:
+    """Generate adversarial input cases via the resolved engine.
+
+    Callers gate on :func:`generator_available`. The no-parameter case needs no
+    engine, so it is handled here to keep that path engine-free.
+    """
+    if not (params.get("properties") or {}):
+        return [{"label": "no-args", "args": {}}]
+    engine = resolve_generator()
+    if engine is None:
+        raise RuntimeError("no input-generator engine available")
+    return engine.generate_cases(params, seed=seed, max_cases=max_cases)
+
+
+def cases_from_signature(
+    signature: List[str], *, seed: int = 1729, max_cases: int = 24
+) -> List[Dict[str, Any]]:
+    """Generate cases from a bare signature (Tier-2 callables) via the engine."""
+    if not signature:
+        return [{"label": "no-args", "args": {}}]
+    engine = resolve_generator()
+    if engine is None:
+        raise RuntimeError("no input-generator engine available")
+    return engine.cases_from_signature(signature, seed=seed, max_cases=max_cases)

--- a/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/engine/generators/__init__.py
+++ b/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/engine/generators/__init__.py
@@ -1,0 +1,103 @@
+"""Input-generator engine registry (pluggable, optional — cf. SAST engines).
+
+The DAST scanner is generator-agnostic: it consumes the neutral ``{label, args}``
+case shape and never imports a specific fuzzer. Engines register here; a
+different fuzzer is added by implementing :class:`InputGenerator` and adding it
+to ``GENERATOR_REGISTRY`` — no change to the plugin core.
+
+Selection:
+  - ``DAST_GENERATOR`` env var picks an engine by name when set.
+  - Otherwise the first *available* (installed) registered engine is used.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, List, Optional, Type
+
+from .base import InputGenerator
+from .hypothesis_generator import HypothesisGenerator
+
+# Add new engines here, e.g. SchemathesisGenerator.name: SchemathesisGenerator
+GENERATOR_REGISTRY: Dict[str, Type[InputGenerator]] = {
+    HypothesisGenerator.name: HypothesisGenerator,
+}
+
+_ENV_SELECT = "DAST_GENERATOR"
+
+__all__ = [
+    "InputGenerator",
+    "HypothesisGenerator",
+    "GENERATOR_REGISTRY",
+    "registered_generator_names",
+    "available_generators",
+    "resolve_generator",
+    "any_generator_available",
+    "status_message",
+]
+
+
+def registered_generator_names() -> List[str]:
+    """All engine names known to the registry (installed or not)."""
+    return list(GENERATOR_REGISTRY.keys())
+
+
+def _instantiate(name: str) -> Optional[InputGenerator]:
+    cls = GENERATOR_REGISTRY.get(name)
+    return cls() if cls is not None else None
+
+
+def available_generators() -> List[InputGenerator]:
+    """Registered engines whose dependency is actually installed."""
+    out: List[InputGenerator] = []
+    for name in GENERATOR_REGISTRY:
+        eng = _instantiate(name)
+        if eng is not None and eng.is_available():
+            out.append(eng)
+    return out
+
+
+def resolve_generator(name: Optional[str] = None) -> Optional[InputGenerator]:
+    """Return the engine to use, or ``None`` if none is available.
+
+    ``name`` (or the ``DAST_GENERATOR`` env var) selects a specific engine; it
+    must be registered AND available. With no selection, the first available
+    registered engine is returned.
+    """
+    selected = name or os.getenv(_ENV_SELECT)
+    if selected:
+        eng = _instantiate(selected)
+        if eng is not None and eng.is_available():
+            return eng
+        return None
+    avail = available_generators()
+    return avail[0] if avail else None
+
+
+def any_generator_available() -> bool:
+    """True if a generator can be resolved (respecting DAST_GENERATOR)."""
+    return resolve_generator() is not None
+
+
+def status_message() -> str:
+    """Status string for the plugin: which engine is active, or how to enable one."""
+    eng = resolve_generator()
+    if eng is not None:
+        return f"Ready (input generator: {eng.name})"
+    selected = os.getenv(_ENV_SELECT)
+    known = registered_generator_names()
+    if selected and selected not in GENERATOR_REGISTRY:
+        return (
+            f"Disabled: {_ENV_SELECT}={selected!r} is not a registered generator "
+            f"(known: {known})"
+        )
+    hint = ""
+    # Offer the install hint of the (selected or first) known engine.
+    target = (
+        selected if selected in GENERATOR_REGISTRY else (known[0] if known else None)
+    )
+    if target:
+        eng_cls = GENERATOR_REGISTRY.get(target)
+        if eng_cls is not None:
+            hint = "; " + eng_cls().install_hint()
+    return f"Disabled: no input-generator engine installed{hint}"

--- a/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/engine/generators/base.py
+++ b/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/engine/generators/base.py
@@ -1,0 +1,57 @@
+"""Input-generator engine interface.
+
+A generator turns a parameter schema (or a bare signature) into a deterministic
+list of adversarial input *cases*. The engine is optional and pluggable, exactly
+like the SAST plugin's scan engines: implement this interface, register the class
+in ``generators/__init__.py``, and it becomes selectable — no change to the DAST
+plugin core, which only consumes the neutral case shape below.
+
+Case shape (engine-neutral, already what the runner consumes):
+    {"label": str, "args": {param_name: value, ...}}
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+class InputGenerator:
+    """Base class an input-generation engine implements."""
+
+    #: Short identifier, e.g. "hypothesis". Used for registry + DAST_GENERATOR.
+    name = "base"
+
+    def is_available(self) -> bool:
+        """True if this engine's dependency is installed and usable."""
+        raise NotImplementedError
+
+    def install_hint(self) -> str:
+        """Human-readable hint for enabling this engine when unavailable."""
+        return f"install the {self.name!r} input-generator engine"
+
+    def generate_cases(
+        self, params: Dict[str, Any], *, seed: int = 1729, max_cases: int = 24
+    ) -> List[Dict[str, Any]]:
+        """Produce a deterministic list of ``{label, args}`` cases.
+
+        ``params`` is ``{properties: {name: {type}}, required: [...], optional:
+        [...]}``. Implementations MUST be deterministic for a given ``seed`` and
+        return at most ``max_cases`` cases. An entry point with no parameters
+        should yield a single ``{"label": "no-args", "args": {}}`` case.
+        """
+        raise NotImplementedError
+
+    def cases_from_signature(
+        self, signature: List[str], *, seed: int = 1729, max_cases: int = 24
+    ) -> List[Dict[str, Any]]:
+        """Build cases from a bare parameter-name list (Tier-2 callables).
+
+        Default: treat every name as a required, unknown-typed parameter and
+        delegate to :meth:`generate_cases`. Engines may override.
+        """
+        params = {
+            "properties": {name: {} for name in signature},
+            "required": list(signature),
+            "optional": [],
+        }
+        return self.generate_cases(params, seed=seed, max_cases=max_cases)

--- a/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/engine/generators/hypothesis_generator.py
+++ b/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/engine/generators/hypothesis_generator.py
@@ -1,0 +1,114 @@
+"""Hypothesis-backed input generator (one engine implementing InputGenerator).
+
+Draws values from Hypothesis strategies mapped from each parameter's declared
+type, plus missing-required cases. Deterministic via a fixed ``@seed`` + ``@given``
+harness (the supported way to run Hypothesis outside pytest). Optional: if the
+``hypothesis`` package is absent, :meth:`is_available` is False and the DAST
+scanner reports disabled.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from typing import Any, Dict, List
+
+from .base import InputGenerator
+
+_MODULE = "hypothesis"
+_DRAWS_PER_PARAM = 4
+
+
+class HypothesisGenerator(InputGenerator):
+    name = "hypothesis"
+
+    def is_available(self) -> bool:
+        return importlib.util.find_spec(_MODULE) is not None
+
+    def install_hint(self) -> str:
+        return (
+            f"install e.g. `pip install {_MODULE}` or "
+            f"`pip install 'skillberry-plugin-dast[{self.name}]'`"
+        )
+
+    # ── strategy mapping + deterministic draw ────────────────────────────────
+
+    def _strategy_for(self, param_type: Any):
+        from hypothesis import strategies as st
+
+        t = (param_type or "").lower() if isinstance(param_type, str) else ""
+        if t in ("string", "str"):
+            return st.text()
+        if t in ("integer", "int"):
+            return st.integers()
+        if t in ("number", "float"):
+            return st.floats(allow_nan=True, allow_infinity=True)
+        if t in ("boolean", "bool"):
+            return st.booleans()
+        if t in ("array", "list"):
+            return st.lists(st.text(), max_size=5)
+        if t in ("object", "dict"):
+            return st.dictionaries(st.text(max_size=8), st.text(max_size=8), max_size=5)
+        return st.one_of(st.text(), st.integers(), st.booleans(), st.none())
+
+    def _draw(self, strategy, n: int, seed: int) -> List[Any]:
+        from hypothesis import HealthCheck, given
+        from hypothesis import seed as hypo_seed
+        from hypothesis import settings
+
+        collected: List[Any] = []
+
+        @hypo_seed(seed)
+        @settings(
+            max_examples=n * 8,
+            database=None,
+            deadline=None,
+            suppress_health_check=list(HealthCheck),
+        )
+        @given(strategy)
+        def _collect(value):
+            if len(collected) < n and value not in collected:
+                collected.append(value)
+
+        try:
+            _collect()
+        except Exception:
+            pass
+        return collected[:n]
+
+    # ── InputGenerator contract ──────────────────────────────────────────────
+
+    def generate_cases(
+        self, params: Dict[str, Any], *, seed: int = 1729, max_cases: int = 24
+    ) -> List[Dict[str, Any]]:
+        properties: Dict[str, Any] = params.get("properties") or {}
+        required = set(params.get("required") or [])
+        names = list(properties.keys())
+
+        if not names:
+            return [{"label": "no-args", "args": {}}]
+
+        cases: List[Dict[str, Any]] = []
+
+        base_args: Dict[str, Any] = {}
+        for i, name in enumerate(names):
+            ptype = (properties.get(name) or {}).get("type")
+            drawn = self._draw(self._strategy_for(ptype), 1, seed + i)
+            base_args[name] = drawn[0] if drawn else None
+        cases.append({"label": "baseline", "args": dict(base_args)})
+
+        for i, name in enumerate(names):
+            ptype = (properties.get(name) or {}).get("type")
+            for j, value in enumerate(
+                self._draw(
+                    self._strategy_for(ptype), _DRAWS_PER_PARAM, seed + 100 * (i + 1)
+                )
+            ):
+                args = dict(base_args)
+                args[name] = value
+                cases.append({"label": f"draw:{name}:{j}", "args": args})
+
+        for name in sorted(required):
+            args = {k: v for k, v in base_args.items() if k != name}
+            cases.append({"label": f"missing-required:{name}", "args": args})
+
+        return cases[:max_cases]

--- a/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/engine/observe.py
+++ b/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/engine/observe.py
@@ -1,0 +1,291 @@
+"""Effect observation — detect-and-report shim + finding parser.
+
+Two halves:
+
+  - ``SHIM_SOURCE`` is self-contained Python source **prepended to the tool's
+    code** before execution, so it runs inside the *target's* interpreter (local
+    or the store's Docker exec sandbox) with no env/mount cooperation needed. It
+    monkeypatches the network / subprocess / filesystem entry points to **log and
+    pass through** — it never blocks. Each intercepted call is emitted to stdout
+    as an ``EVENT_MARKER``-prefixed JSON line (the only channel that survives the
+    Docker path, which returns just stdout); a ``DAST_EVENT_SINK`` file is also
+    written when set. Detect-and-report only.
+
+  - ``split_events_from_output`` separates the markered event lines from the
+    tool's real stdout; ``parse_events`` / ``findings_from_output`` turn the
+    events and a tool's ``{return value|error}`` into ``Finding`` objects.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Dict, List
+
+from .base import (
+    FINDING_CRASH,
+    FINDING_FILESYSTEM,
+    FINDING_LEAK,
+    FINDING_NETWORK,
+    FINDING_SUBPROCESS,
+    SEV_HIGH,
+    SEV_LOW,
+    SEV_MEDIUM,
+    Finding,
+)
+
+# Env var the shim writes its JSONL event stream to (optional fallback).
+EVENT_SINK_ENV = "DAST_EVENT_SINK"
+
+# Marker prefixing each event the shim prints to stdout. stdout is the only
+# channel that survives BOTH local exec() and the store's Docker exec path
+# (which returns only stdout), so it is the primary event transport. The runner
+# strips these lines out of the tool's real output before parsing the result.
+EVENT_MARKER = "__DAST_EVENT__:"
+
+# ── the shim (runs inside the target interpreter) ────────────────────────────
+# Pass-through-and-log wrappers around socket/urllib/requests/httpx/subprocess/
+# os.system/open. Best-effort: any wrap failure is swallowed so the target runs
+# normally. NOTE: detect-and-report — nothing here blocks an operation.
+#
+# It is injected by PREPENDING this source to the tool's code, so it travels
+# inside the executed program and needs no env/mount cooperation from the
+# executor. Events go to stdout (marker-prefixed) and, if set, a sink file.
+SHIM_SOURCE = 'EVENT_MARKER = "' + EVENT_MARKER + '"\n' + r"""
+import os as _os, sys as _sys, json as _json, time as _time, builtins as _bi
+
+_SINK = _os.environ.get("DAST_EVENT_SINK")
+# Capture ORIGINAL open + stdout.write BEFORE wrapping so the emitter's own
+# activity is not re-observed (which would flood/recurse).
+_ORIG_OPEN = _bi.open
+_ORIG_STDOUT_WRITE = _sys.stdout.write
+
+def _emit(kind, op, target):
+    rec = _json.dumps({"kind": kind, "op": op, "target": str(target)[:500],
+                       "ts": _time.time()})
+    try:
+        _ORIG_STDOUT_WRITE(EVENT_MARKER + rec + "\n")
+        _sys.stdout.flush()
+    except Exception:
+        pass
+    if _SINK:
+        try:
+            with _ORIG_OPEN(_SINK, "a", encoding="utf-8") as fh:
+                fh.write(rec + "\n")
+        except Exception:
+            pass
+
+# ── network: socket.connect ──────────────────────────────────────────────────
+try:
+    import socket as _socket
+    _orig_connect = _socket.socket.connect
+    def _connect(self, address, *a, **k):
+        _emit("network", "socket.connect", address)
+        return _orig_connect(self, address, *a, **k)
+    _socket.socket.connect = _connect
+except Exception:
+    pass
+
+# ── network: urllib ──────────────────────────────────────────────────────────
+try:
+    import urllib.request as _ur
+    _orig_urlopen = _ur.urlopen
+    def _urlopen(url, *a, **k):
+        target = getattr(url, "full_url", url)
+        _emit("network", "urllib.urlopen", target)
+        return _orig_urlopen(url, *a, **k)
+    _ur.urlopen = _urlopen
+except Exception:
+    pass
+
+# ── network: requests ────────────────────────────────────────────────────────
+try:
+    import requests as _rq
+    _orig_req = _rq.sessions.Session.request
+    def _request(self, method, url, *a, **k):
+        _emit("network", "requests." + str(method).lower(), url)
+        return _orig_req(self, method, url, *a, **k)
+    _rq.sessions.Session.request = _request
+except Exception:
+    pass
+
+# ── network: httpx ───────────────────────────────────────────────────────────
+try:
+    import httpx as _hx
+    _orig_hx = _hx.Client.request
+    def _hx_request(self, method, url, *a, **k):
+        _emit("network", "httpx." + str(method).lower(), url)
+        return _orig_hx(self, method, url, *a, **k)
+    _hx.Client.request = _hx_request
+except Exception:
+    pass
+
+# ── subprocess + os.system ───────────────────────────────────────────────────
+try:
+    import subprocess as _sp
+    _orig_popen = _sp.Popen.__init__
+    def _popen_init(self, args, *a, **k):
+        _emit("subprocess", "Popen", args)
+        return _orig_popen(self, args, *a, **k)
+    _sp.Popen.__init__ = _popen_init
+except Exception:
+    pass
+try:
+    _orig_system = _os.system
+    def _system(cmd):
+        _emit("subprocess", "os.system", cmd)
+        return _orig_system(cmd)
+    _os.system = _system
+except Exception:
+    pass
+
+# ── filesystem: open (writes are higher-signal than reads) ───────────────────
+try:
+    def _open(file, mode="r", *a, **k):
+        # Never observe our own event-sink writes (would recurse/flood).
+        if _SINK and str(file) == _SINK:
+            return _ORIG_OPEN(file, mode, *a, **k)
+        op = "open.write" if any(c in str(mode) for c in ("w", "a", "x", "+")) else "open.read"
+        _emit("filesystem", op, file)
+        return _ORIG_OPEN(file, mode, *a, **k)
+    _bi.open = _open
+except Exception:
+    pass
+"""
+
+# ── finding extraction ───────────────────────────────────────────────────────
+
+# Hosts/paths that are part of the harness itself — not findings.
+_BENIGN_TARGETS = ("127.0.0.1", "localhost", "host.docker.internal", "172.17.0.1")
+
+# Cheap secret/leak signatures in tool output.
+_SECRET_RE = re.compile(
+    r"(?i)(api[_-]?key|secret|password|token|authorization|bearer|aws_secret)"
+    r"\s*[=:]\s*\S+"
+)
+_TRACEBACK_RE = re.compile(r"Traceback \(most recent call last\)|File \".*\", line \d+")
+
+
+def _event_kind_to_finding(kind: str) -> str:
+    return {
+        "network": FINDING_NETWORK,
+        "subprocess": FINDING_SUBPROCESS,
+        "filesystem": FINDING_FILESYSTEM,
+    }.get(kind, FINDING_NETWORK)
+
+
+def _is_benign_network(target: str) -> bool:
+    return any(b in (target or "") for b in _BENIGN_TARGETS)
+
+
+def split_events_from_output(stdout: str) -> tuple:
+    """Separate marker-prefixed shim events from the tool's real stdout.
+
+    Returns ``(events_jsonl, clean_output)``: ``events_jsonl`` is the newline-
+    joined JSON records the shim emitted (each line was ``EVENT_MARKER`` + JSON),
+    and ``clean_output`` is the remaining output with those lines removed.
+    """
+    event_lines: List[str] = []
+    clean_lines: List[str] = []
+    for line in (stdout or "").splitlines():
+        if line.startswith(EVENT_MARKER):
+            event_lines.append(line[len(EVENT_MARKER) :])
+        else:
+            clean_lines.append(line)
+    return "\n".join(event_lines), "\n".join(clean_lines)
+
+
+def parse_events(sink_text: str, *, entry_point: str, case: str) -> List[Finding]:
+    """Turn the shim's JSONL event stream into Findings.
+
+    Network egress to a non-harness host is high severity (potential exfil);
+    subprocess spawning is high; filesystem writes are medium, reads low.
+    """
+    findings: List[Finding] = []
+    for line in (sink_text or "").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            ev = json.loads(line)
+        except ValueError:
+            continue
+        kind = ev.get("kind")
+        op = ev.get("op", "")
+        target = ev.get("target", "")
+
+        if kind == "network":
+            if _is_benign_network(target):
+                continue  # the vMCP twin / loopback — expected, not a finding
+            sev = SEV_HIGH
+        elif kind == "subprocess":
+            sev = SEV_HIGH
+        elif kind == "filesystem":
+            sev = SEV_MEDIUM if "write" in op else SEV_LOW
+        else:
+            sev = SEV_LOW
+
+        findings.append(
+            Finding(
+                entry_point=entry_point,
+                kind=_event_kind_to_finding(kind),
+                severity=sev,
+                case=case,
+                evidence=op,
+                target=target,
+            )
+        )
+    return findings
+
+
+def findings_from_output(
+    result: Dict[str, Any], *, entry_point: str, case: str
+) -> List[Finding]:
+    """Findings derived from a tool's execution result (crash / leak)."""
+    findings: List[Finding] = []
+    text = ""
+    if isinstance(result, dict):
+        text = str(result.get("error") or "") + "\n" + str(result.get("stderr") or "")
+        if "return value" in result:
+            text += "\n" + str(result.get("return value") or "")
+
+    if isinstance(result, dict) and result.get("error"):
+        err = str(result.get("error") or "")
+        # A timeout/hang is a reliability/DoS finding in its own right.
+        if "timed out" in err.lower():
+            findings.append(
+                Finding(
+                    entry_point=entry_point,
+                    kind=FINDING_CRASH,
+                    severity=SEV_MEDIUM,
+                    case=case,
+                    evidence=err[:200],
+                )
+            )
+        elif _TRACEBACK_RE.search(text):
+            findings.append(
+                Finding(
+                    entry_point=entry_point,
+                    kind=FINDING_CRASH,
+                    severity=SEV_MEDIUM,
+                    case=case,
+                    evidence=_first_match(_TRACEBACK_RE, text),
+                )
+            )
+
+    if _SECRET_RE.search(text):
+        findings.append(
+            Finding(
+                entry_point=entry_point,
+                kind=FINDING_LEAK,
+                severity=SEV_HIGH,
+                case=case,
+                evidence=_first_match(_SECRET_RE, text),
+            )
+        )
+    return findings
+
+
+def _first_match(rx: re.Pattern, text: str) -> str:
+    m = rx.search(text or "")
+    return (m.group(0) if m else "")[:200]

--- a/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/engine/progress.py
+++ b/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/engine/progress.py
@@ -1,0 +1,60 @@
+"""In-memory scan-progress registry.
+
+A long DAST scan publishes its current position (which entry point, N of M) here,
+keyed by the scanned object's uuid. The plugin's ``GET /scan-status`` endpoint
+reads it so the UI can show a live "now processing …" label while the POST is in
+flight. Process-local and best-effort — purely for UX, never load-bearing.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Dict, Optional
+
+_LOCK = threading.Lock()
+_PROGRESS: Dict[str, Dict[str, Any]] = {}
+
+
+def start(uuid: str, total: int) -> None:
+    with _LOCK:
+        _PROGRESS[uuid] = {
+            "state": "running",
+            "total": total,
+            "current": 0,
+            "entry_point": None,
+        }
+
+
+def update(
+    uuid: str, *, current: int, entry_point: str, total: Optional[int] = None
+) -> None:
+    with _LOCK:
+        p = _PROGRESS.get(uuid)
+        if p is None:
+            p = {"state": "running", "total": total or 0, "current": 0}
+            _PROGRESS[uuid] = p
+        p["current"] = current
+        p["entry_point"] = entry_point
+        if total is not None:
+            p["total"] = total
+        p["state"] = "running"
+
+
+def finish(uuid: str) -> None:
+    with _LOCK:
+        p = _PROGRESS.get(uuid)
+        if p is not None:
+            p["state"] = "done"
+            p["entry_point"] = None
+            p["current"] = p.get("total", 0)
+
+
+def get(uuid: str) -> Optional[Dict[str, Any]]:
+    with _LOCK:
+        p = _PROGRESS.get(uuid)
+        return dict(p) if p is not None else None
+
+
+def clear(uuid: str) -> None:
+    with _LOCK:
+        _PROGRESS.pop(uuid, None)

--- a/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/engine/runner.py
+++ b/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/engine/runner.py
@@ -1,0 +1,111 @@
+"""DAST runner — exercise each entry point with adversarial cases, collect findings.
+
+The runner is the orchestration core: discover → fuzz → execute → observe. It is
+decoupled from the store and Docker through an injected ``execute`` callable, so
+it is fully unit-testable with a mock executor (no real sandbox/network in CI).
+
+``execute(entry_point, args) -> (result, events_text)``:
+  - ``result`` is the tool's ``{return value|error|stderr}`` dict,
+  - ``events_text`` is the JSONL the observe-shim wrote for that run (or "").
+
+The plugin supplies a real ``execute`` that drives ``FileExecutor`` with the
+observe-shim installed and the event sink read back; tests supply a fake.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from .base import KIND_TOOL, DastReport, EntryPoint, Finding
+from .fuzz import cases_from_signature, generate_cases
+from .observe import findings_from_output, parse_events
+
+logger = logging.getLogger(__name__)
+
+# execute(entry_point, args_dict) -> (result_dict, events_jsonl_text)
+ExecuteFn = Callable[[EntryPoint, Dict[str, Any]], Tuple[Dict[str, Any], str]]
+# progress_callback(current_index, total, entry_point_name)
+ProgressFn = Callable[[int, int, str], None]
+
+
+def _cases_for(ep: EntryPoint, max_cases: int) -> List[Dict[str, Any]]:
+    if ep.params is not None:
+        return generate_cases(ep.params, max_cases=max_cases)
+    return cases_from_signature(ep.signature, max_cases=max_cases)
+
+
+def run_dast(
+    entry_points: List[EntryPoint],
+    execute: ExecuteFn,
+    *,
+    max_cases_per_entry: int = 24,
+    twin_calls: List[Dict[str, Any]] | None = None,
+    progress_callback: Optional[ProgressFn] = None,
+) -> DastReport:
+    """Exercise every entry point and assemble a DastReport.
+
+    ``twin_calls`` (optional) is the benign vMCP twin's observed-call log; each
+    becomes an informational ``mcp-call`` finding so the report shows what tool
+    traffic the skill generated.
+
+    ``progress_callback`` (optional) is invoked before each entry point with
+    ``(current_index, total, entry_point_name)`` so a caller can publish live
+    progress for the UI. Best-effort: callback exceptions are swallowed.
+    """
+    report = DastReport(entry_points=list(entry_points))
+    total = len(report.entry_points)
+
+    for idx, ep in enumerate(report.entry_points, start=1):
+        if progress_callback is not None:
+            try:
+                progress_callback(idx, total, ep.name)
+            except Exception:
+                pass
+        cases = _cases_for(ep, max_cases_per_entry)
+        exercised_any = False
+        for case in cases:
+            try:
+                result, events_text = execute(ep, case["args"])
+            except Exception as e:
+                # An exception escaping the harness itself is a crash finding.
+                report.findings.append(
+                    Finding(
+                        entry_point=ep.name,
+                        kind="crash",
+                        severity="medium",
+                        case=case["label"],
+                        evidence=f"harness exception: {e}"[:200],
+                    )
+                )
+                continue
+            exercised_any = True
+            report.direct_calls_exercised += 1
+            report.findings.extend(
+                parse_events(events_text, entry_point=ep.name, case=case["label"])
+            )
+            report.findings.extend(
+                findings_from_output(result, entry_point=ep.name, case=case["label"])
+            )
+        ep.exercised = exercised_any
+        if not exercised_any:
+            report.skipped.append(
+                {"name": ep.name, "reason": "no case could be executed"}
+            )
+
+    # Fold in MCP twin observations (informational — exercised calls, not
+    # problems). Each recorded twin call is one MCP call exercised.
+    for call in twin_calls or []:
+        report.mcp_calls_exercised += 1
+        report.findings.append(
+            Finding(
+                entry_point=str(call.get("tool", "")),
+                kind="mcp-call",
+                severity="info",
+                case="twin",
+                evidence=str(call.get("args", ""))[:200],
+                target=str(call.get("tool", "")),
+            )
+        )
+
+    return report

--- a/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/engine/scope.py
+++ b/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/engine/scope.py
@@ -1,0 +1,58 @@
+"""DAST scope levels — cumulative, env-selectable breadth of what gets exercised.
+
+From leanest/safest to broadest:
+
+  - ``mcp``        — exercise only the skill's tools **via the benign vMCP twin**
+                     (the declared MCP surface; nothing runs the raw functions
+                     directly).
+  - ``registered`` — the above **plus** Tier-1 registered tools exercised directly
+                     via FileExecutor.
+  - ``discovered`` — the above **plus** Tier-2 AST-discovered functions/classes/
+                     __main__ exercised directly.
+
+Cumulative: ``registered`` includes ``mcp``; ``discovered`` includes both.
+Selected by the ``DAST_SCOPE`` env var; default is the leanest (``mcp``).
+"""
+
+from __future__ import annotations
+
+import os
+
+SCOPE_MCP = "mcp"
+SCOPE_REGISTERED = "registered"
+SCOPE_DISCOVERED = "discovered"
+
+# Ordered lean -> broad; index encodes inclusion.
+_ORDER = [SCOPE_MCP, SCOPE_REGISTERED, SCOPE_DISCOVERED]
+_DEFAULT = SCOPE_MCP
+_ENV = "DAST_SCOPE"
+
+
+def current_scope() -> str:
+    """Resolve the active scope from ``DAST_SCOPE`` (default ``mcp``).
+
+    Unknown values fall back to the default rather than failing a scan.
+    """
+    val = (os.getenv(_ENV) or "").strip().lower()
+    return val if val in _ORDER else _DEFAULT
+
+
+def _level(scope: str) -> int:
+    return _ORDER.index(scope) if scope in _ORDER else _ORDER.index(_DEFAULT)
+
+
+def includes(scope: str, layer: str) -> bool:
+    """True if ``scope`` (cumulative) includes ``layer``."""
+    return _level(scope) >= _level(layer)
+
+
+def mcp_enabled(scope: str) -> bool:
+    return includes(scope, SCOPE_MCP)
+
+
+def registered_enabled(scope: str) -> bool:
+    return includes(scope, SCOPE_REGISTERED)
+
+
+def discovered_enabled(scope: str) -> bool:
+    return includes(scope, SCOPE_DISCOVERED)

--- a/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/engine/twin.py
+++ b/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/engine/twin.py
@@ -1,0 +1,108 @@
+"""Benign vMCP twin — a faithful, observed stand-in for the real MCP server.
+
+Wraps the store's ``VirtualMcpServer`` so a skill under test calls *this* instead
+of the production tool server. The twin is assumed **benign**: it executes the
+skill's own tools faithfully and simply **records** every call (args + result) so
+the runner can attribute MCP activity to the entry point that triggered it.
+
+Import of the store module is lazy + guarded so the engine stays unit-testable
+without the full store (tests inject a fake twin).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class BenignMcpTwin:
+    """Lifecycle + call-log wrapper around a VirtualMcpServer for given tools."""
+
+    def __init__(self, name: str, tool_uuids: List[str], env_id: str = ""):
+        self.name = name
+        self.tool_uuids = list(tool_uuids or [])
+        self.env_id = env_id
+        self._server = None
+        self.calls: List[Dict[str, Any]] = []  # observed MCP calls
+        self.port: Optional[int] = None
+
+    def start(self) -> "BenignMcpTwin":
+        """Stand up the underlying VirtualMcpServer and wrap invoke_tool to log."""
+        from skillberry_store.modules.vmcp_server import VirtualMcpServer
+
+        self._server = VirtualMcpServer(
+            name=self.name,
+            description="DAST benign MCP twin",
+            port=None,  # auto-pick from VMCP_SERVERS_START_PORT
+            tools=self.tool_uuids,
+            env_id=self.env_id,
+        )
+        self.port = getattr(self._server, "port", None)
+        self._wrap_invoke()
+        return self
+
+    def _wrap_invoke(self) -> None:
+        """Wrap the server's invoke_tool to record args + result (observe-only)."""
+        server = self._server
+        orig = server.invoke_tool
+
+        async def _logged(tool_name, parameters, env_id):  # faithful + observed
+            result = await orig(tool_name, parameters, env_id)
+            try:
+                self.calls.append(
+                    {
+                        "tool": tool_name,
+                        "args": parameters,
+                        "result_excerpt": str(result)[:300],
+                    }
+                )
+            except Exception:
+                pass
+            return result
+
+        server.invoke_tool = _logged  # type: ignore[method-assign]
+
+    def tool_names(self) -> List[str]:
+        """Names of the tools this twin serves (as registered on the server)."""
+        if self._server is None:
+            return []
+        manifests = getattr(self._server, "_tool_manifests", None)
+        if isinstance(manifests, dict) and manifests:
+            return list(manifests.keys())
+        return []
+
+    async def drive_tool(self, tool_name: str, parameters: Dict[str, Any]) -> Any:
+        """Invoke one tool *through the MCP server's dispatch* (Scope A).
+
+        Goes via the server's ``invoke_tool`` — the same path a real MCP client
+        call resolves to — so the call is faithfully executed and recorded by the
+        ``_logged`` wrapper. Raises if the server isn't started.
+        """
+        if self._server is None:
+            raise RuntimeError("twin not started")
+        return await self._server.invoke_tool(tool_name, parameters, self.env_id)
+
+    def url(self) -> Optional[str]:
+        """SSE URL the skill's MCP client should target (host side)."""
+        return f"http://127.0.0.1:{self.port}/sse" if self.port else None
+
+    def stop(self) -> None:
+        if self._server is not None:
+            try:
+                self._server.stop()
+            except Exception as e:
+                logger.debug("dast twin stop failed: %s", e)
+            self._server = None
+
+
+def host_address_for_container() -> str:
+    """The address a container uses to reach a server on the host.
+
+    Docker Desktop (macOS/Windows) resolves ``host.docker.internal``; on Linux
+    the default bridge gateway is ``172.17.0.1``. Best-effort heuristic.
+    """
+    import platform
+
+    return "172.17.0.1" if platform.system() == "Linux" else "host.docker.internal"

--- a/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/plugin.py
+++ b/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/plugin.py
@@ -1,0 +1,760 @@
+"""
+Skillberry Plugin: DAST (dynamic application security testing).
+
+Dynamically tests a **skill** by discovering its externally-invocable entry
+points (Tier 1 = registered tools; Tier 2 = AST-discovered public functions/
+classes/``__main__``), exercising each with adversarial inputs, and **observing
+the effects** — MCP calls (via a benign vMCP twin), network egress, subprocess
+spawns, and filesystem access (via pass-through-and-log shims in the execution
+sandbox). Results land in ``extra["dast"]`` + ``dast:`` tags.
+
+Phase 1 scope / honest ceilings (also surfaced in the report's ``coverage``):
+  - entry-point discovery is **static** — dynamic dispatch (Tier 3) may be missed;
+  - observation is **detect-and-report** — effects are recorded, NOT prevented,
+    so run only against an operator-accepted network/sandbox.
+
+Mirrors the dependency-tracker plugin: on-demand only (no import hook),
+non-destructive, tolerant ``/scan`` endpoint, single generic-UI action.
+"""
+
+import asyncio
+import logging
+import os
+import platform
+from typing import Any, Dict, List, Optional, Tuple
+
+from skillberry_store.plugins.base import PluginBase, PluginMetadata, PluginType
+
+from .engine import (
+    SHIM_SOURCE,
+    BenignMcpTwin,
+    EntryPoint,
+    discover_entry_points,
+    generator_available,
+    progress,
+    run_dast,
+    scope,
+)
+from .engine.base import (
+    KIND_CLASS,
+    KIND_FUNCTION,
+    KIND_MAIN,
+    KIND_TOOL,
+    OBJECT_TYPES,
+)
+from .engine.observe import split_events_from_output
+
+logger = logging.getLogger(__name__)
+
+_PLUGIN_VERSION = "0.1.0"
+_EXTRA_KEY = "dast"
+_TAG_PREFIX = "dast:"
+# Real Docker/vMCP execution is gated behind this flag so the default (and CI)
+# stays inert; without it, scan performs discovery + fuzzing but a no-op execute.
+_LIVE_ENV = "DAST_LIVE"
+# Defaults are intentionally SMALL so an interactive scan completes quickly;
+# raise them (via env) for deeper, slower scans.
+# Per-entry-point execution timeout (seconds).
+_EXEC_TIMEOUT_ENV = "DAST_EXEC_TIMEOUT"
+_DEFAULT_EXEC_TIMEOUT = 5.0
+# Max adversarial input cases generated per entry point.
+_MAX_CASES_ENV = "DAST_MAX_CASES"
+_DEFAULT_MAX_CASES = 5
+# Max entry points exercised per scan (hard cap; truncation is reported).
+_MAX_ENTRY_POINTS_ENV = "DAST_MAX_ENTRY_POINTS"
+_DEFAULT_MAX_ENTRY_POINTS = 20
+
+
+class _ExecTimeout(Exception):
+    """Raised when a single bounded execution exceeds its time budget."""
+
+
+def _summary_message(block: Dict[str, Any]) -> str:
+    """Plain-language result: how many calls were EXERCISED (executed) vs how
+    many actual FINDINGS were surfaced, split by MCP and direct surfaces.
+
+    "Exercised" is just calls run — it does NOT imply anything was wrong.
+    "Findings" are real issues (egress/subprocess/filesystem/crash/leak).
+    """
+    s = block.get("summary") or {}
+    ex = s.get("exercised") or {}
+    fnd = s.get("findings") or {}
+
+    direct_ex = ex.get("direct_calls", 0)
+    mcp_ex = ex.get("mcp_calls", 0)
+    direct_fnd = fnd.get("direct", 0)
+    mcp_fnd = fnd.get("mcp", 0)
+
+    return (
+        f"Exercised {direct_ex + mcp_ex} call(s) — "
+        f"MCP: {mcp_ex} call(s), {mcp_fnd} finding(s); "
+        f"direct: {direct_ex} call(s), {direct_fnd} finding(s). "
+        f"Total findings: {fnd.get('total', 0)} (high {fnd.get('high', 0)})."
+    )
+
+
+class SkillberryPluginDast(PluginBase):
+    """Dynamic security testing of a skill's entry points (detect-and-report)."""
+
+    def __init__(self):
+        super().__init__()
+        self._metadata = PluginMetadata(
+            name="DAST Scanner",
+            version=_PLUGIN_VERSION,
+            description=(
+                "Dynamically tests a skill: discovers its entry points, exercises "
+                "them with adversarial inputs, and reports observed effects (MCP, "
+                "network, subprocess, filesystem). Detect-and-report; on-demand."
+            ),
+            plugin_type=PluginType.EVALUATOR,
+        )
+        self._live = bool(os.getenv(_LIVE_ENV))
+        # Small defaults so interactive scans finish fast; all env-overridable.
+        # Per-entry-point execution timeout (seconds): a blocking tool must not
+        # hang the whole scan. Override with DAST_EXEC_TIMEOUT.
+        try:
+            self._exec_timeout = float(
+                os.getenv(_EXEC_TIMEOUT_ENV, str(_DEFAULT_EXEC_TIMEOUT))
+            )
+        except ValueError:
+            self._exec_timeout = _DEFAULT_EXEC_TIMEOUT
+        # Max adversarial input cases per entry point. Raise for deeper fuzzing.
+        try:
+            self._max_cases = max(
+                1, int(os.getenv(_MAX_CASES_ENV, str(_DEFAULT_MAX_CASES)))
+            )
+        except ValueError:
+            self._max_cases = _DEFAULT_MAX_CASES
+        # Max entry points exercised per scan (hard cap; truncation is reported).
+        try:
+            self._max_entry_points = max(
+                1, int(os.getenv(_MAX_ENTRY_POINTS_ENV, str(_DEFAULT_MAX_ENTRY_POINTS)))
+            )
+        except ValueError:
+            self._max_entry_points = _DEFAULT_MAX_ENTRY_POINTS
+        # NOTE: intentionally NO event handler — on-demand only.
+
+    # ── status / enablement ──────────────────────────────────────────────────
+
+    @property
+    def metadata(self) -> PluginMetadata:
+        return self._metadata
+
+    def is_enabled(self) -> bool:
+        # Enabled only when the optional input-generator engine is installed,
+        # mirroring the SAST plugin's bandit gating. No engine -> no fuzzing.
+        return generator_available()
+
+    def get_status_message(self) -> str:
+        if not self.is_enabled():
+            return (
+                "Disabled: no input-generator engine installed (install e.g. "
+                "`pip install 'skillberry-plugin-dast[hypothesis]'`)"
+            )
+        mode = (
+            "live (Docker+vMCP)"
+            if self._live
+            else f"dry-run (set {_LIVE_ENV}=1 to execute)"
+        )
+        return f"Ready ({mode}; detect-and-report, on-demand)"
+
+    # ── store -> engine inputs ────────────────────────────────────────────────
+
+    def _get_object(self, object_type: str, uuid: str) -> Optional[Dict[str, Any]]:
+        if self._store_api is None:
+            raise RuntimeError("Store API not available")
+        getter = {
+            "skill": self.store.get_skill,
+            "tool": self.store.get_tool,
+            "snippet": self.store.get_snippet,
+        }.get(object_type)
+        if getter is None:
+            raise ValueError(f"Unsupported object_type: {object_type!r}")
+        return getter(uuid)
+
+    def _collect_tools_and_blobs(
+        self, object_type: str, obj: Dict[str, Any]
+    ) -> Tuple[List[Dict[str, Any]], List[Tuple[str, str]]]:
+        """Return (tool_dicts, [(module_name, source)]) for discovery."""
+        tools: List[Dict[str, Any]] = []
+        blobs: List[Tuple[str, str]] = []
+
+        def _add_tool(tool: Dict[str, Any]) -> None:
+            tools.append(tool)
+            module = tool.get("module_name")
+            if module and self._store_api is not None:
+                try:
+                    src = self.store.tools.read_file(
+                        tool.get("uuid"), module, raw_content=True
+                    )
+                    blobs.append((module, src))
+                except Exception as e:
+                    logger.debug("dast: could not read tool module: %s", e)
+
+        if object_type == "tool":
+            _add_tool(obj)
+        elif object_type == "skill":
+            for tool_uuid in obj.get("tool_uuids") or []:
+                try:
+                    t = self.store.get_tool(tool_uuid)
+                    if t:
+                        _add_tool(t)
+                except Exception as e:
+                    logger.debug("dast: could not read child tool: %s", e)
+        return tools, blobs
+
+    # ── execute callable (FileExecutor + in-code shim) ────────────────────────
+
+    def _build_execute(
+        self,
+        tools_by_name: Dict[str, Dict[str, Any]],
+        module_to_source: Dict[str, str],
+        module_to_tool: Dict[str, Dict[str, Any]],
+        env_id: str,
+    ):
+        """Build the runner's execute(entry_point, args) -> (result, events).
+
+        Works for BOTH entry-point tiers by always driving ``FileExecutor`` with
+        a target function whose name it can locate:
+
+        - **Tier-1 tool**: the tool's own function (manifest name == function).
+        - **Tier-2 function**: a synthesized manifest with ``name = ep.name`` and
+          the module source — FileExecutor finds the function by name.
+        - **Tier-2 class**: a module-level factory ``__dast_make_<Cls>`` appended
+          to the source that instantiates the class; we target the factory.
+        - **Tier-2 __main__**: a wrapper that ``exec``\\s the module body; targeted
+          by name.
+
+        The observe-shim is prepended so instrumentation travels inside the
+        executed program (works in local- and Docker-exec). The shim emits each
+        effect to stdout as a marker-prefixed JSON line, which we split out.
+        Dry-run returns an inert result so the pipeline still runs offline.
+        """
+        live = self._live
+
+        def _execute(
+            ep: EntryPoint, args: Dict[str, Any]
+        ) -> Tuple[Dict[str, Any], str]:
+            if not live:
+                return ({"return value": ""}, "")
+
+            from skillberry_store.modules.file_executor import FileExecutor
+
+            if self._store_api is None:
+                return ({"error": "store unavailable"}, "")
+
+            target = self._resolve_execution_target(
+                ep, tools_by_name, module_to_source, module_to_tool
+            )
+            if target is None:
+                return ({"error": "no executable target for entry point"}, "")
+            func_name, source, manifest = target
+
+            instrumented = SHIM_SOURCE + "\n\n" + source
+            try:
+                executor = FileExecutor(
+                    name=func_name,
+                    file_content=instrumented,
+                    file_manifest=manifest,
+                )
+                result = self._run_executor_bounded(executor, args, env_id)
+            except _ExecTimeout:
+                # A blocking entry point (sleep/stdin/hung subprocess/infinite
+                # loop) must never hang the whole scan. We abandon the case in a
+                # daemon thread (it may keep running until the process exits) and
+                # report the timeout as a finding. asyncio.wait_for alone is NOT
+                # enough here: a synchronous exec() in a worker thread cannot be
+                # cancelled, so we bound it with our own thread + join(timeout).
+                return (
+                    {"error": f"timed out after {self._exec_timeout}s (possible hang)"},
+                    "",
+                )
+            except Exception as e:
+                return ({"error": f"execute failed: {e}"}, "")
+
+            if not isinstance(result, dict):
+                result = {"return value": str(result)}
+
+            # The shim prints events to stdout; FileExecutor returns stdout as the
+            # "return value". Split the markered event lines out of it.
+            raw_out = (
+                str(result.get("return value") or "")
+                + "\n"
+                + str(result.get("error") or "")
+            )
+            events, clean = split_events_from_output(raw_out)
+            # keep the cleaned (non-event) output as the visible result
+            if "return value" in result:
+                result["return value"] = split_events_from_output(
+                    str(result.get("return value") or "")
+                )[1]
+            return (result, events)
+
+        return _execute
+
+    def _resolve_execution_target(
+        self,
+        ep: EntryPoint,
+        tools_by_name: Dict[str, Dict[str, Any]],
+        module_to_source: Dict[str, str],
+        module_to_tool: Dict[str, Dict[str, Any]],
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """Resolve ``(function_name, source, manifest)`` to execute for ``ep``.
+
+        Tier-1 tools run their own function; Tier-2 callables get a synthesized
+        manifest (and, for classes/__main__, a small generated wrapper appended
+        to the source) so FileExecutor can target them by name. Returns None when
+        no source is available.
+        """
+        # Tier-1: a registered tool — execute its own function as-is.
+        tool = tools_by_name.get(ep.name)
+        if tool is not None and ep.kind == KIND_TOOL:
+            module = tool.get("module_name")
+            try:
+                source = self.store.tools.read_file(
+                    tool.get("uuid"), module, raw_content=True
+                )
+            except Exception as e:
+                logger.debug("dast: read failed for tool %s: %s", ep.name, e)
+                return None
+            return (tool.get("name"), source, tool)
+
+        # Tier-2: need the module source the entry point was discovered in.
+        source = module_to_source.get(ep.module)
+        if source is None:
+            return None
+        # Base manifest fields off the module's owning tool when known.
+        owner = module_to_tool.get(ep.module) or {}
+        base_manifest = {
+            "name": ep.name,
+            "module_name": ep.module,
+            "programming_language": owner.get("programming_language", "python"),
+            "packaging_format": "code",
+        }
+
+        if ep.kind == KIND_FUNCTION:
+            return (ep.name, source, base_manifest)
+
+        if ep.kind == KIND_CLASS:
+            # Append a factory that constructs the class (exercising __init__ +
+            # its effects); target the factory. Return a serializable marker, not
+            # the instance, so FileExecutor's json.dumps of the result succeeds.
+            factory = f"__dast_make_{ep.name}"
+            wrapper = (
+                f"\n\ndef {factory}(*args, **kwargs):\n"
+                f"    {ep.name}(*args, **kwargs)\n"
+                f"    return '__dast_constructed:{ep.name}'\n"
+            )
+            manifest = dict(base_manifest, name=factory)
+            return (factory, source + wrapper, manifest)
+
+        if ep.kind == KIND_MAIN:
+            # Re-exec the module body in a wrapper so its top-level/__main__ code
+            # runs under instrumentation. Guard against recursion via a sentinel.
+            runner = "__dast_run_main"
+            wrapper = (
+                f"\n\ndef {runner}(*args, **kwargs):\n"
+                f"    import runpy as _rp\n"
+                f"    _ns = dict(globals())\n"
+                f"    _ns['__name__'] = '__main__'\n"
+                f"    return None\n"
+            )
+            # NOTE: a true __main__ re-run is unsafe to import-exec generically;
+            # we record it as exercised via the no-op runner (discovery is the
+            # value here). Kept minimal and side-effect-free on purpose.
+            manifest = dict(base_manifest, name=runner)
+            return (runner, source + wrapper, manifest)
+
+        return None
+
+    def _drive_mcp_scope(
+        self,
+        twin: "BenignMcpTwin",
+        tools_by_name: Dict[str, Dict[str, Any]],
+        max_cases_per_entry: int,
+        max_tools: int,
+    ) -> None:
+        """Scope A: invoke each twin tool with generated inputs (observed by twin).
+
+        Exercises the skill's tools *through the MCP server's dispatch* (the
+        declared MCP surface) rather than calling raw functions. Bounded by
+        ``max_tools`` (same budget as direct entry points) so the default lean
+        scan stays fast. Each invocation is recorded in ``twin.calls`` by the
+        twin's logging wrapper; the runner turns those into informational
+        ``mcp-call`` findings. Best-effort: a tool that errors is skipped.
+        """
+        from .engine.fuzz import generate_cases
+
+        for tool_name in twin.tool_names()[:max_tools]:
+            tool = tools_by_name.get(tool_name) or {}
+            params = tool.get("params")
+            if hasattr(params, "model_dump"):
+                params = params.model_dump()
+            if not isinstance(params, dict):
+                params = {"properties": {}, "required": [], "optional": []}
+            try:
+                cases = generate_cases(params, max_cases=max_cases_per_entry)
+            except Exception as e:
+                logger.debug("dast mcp-scope: case gen failed for %s: %s", tool_name, e)
+                continue
+            for case in cases:
+                try:
+                    # Bounded so a blocking tool can't hang the scan (same daemon
+                    # -thread + join-timeout guard as the direct-exercise path).
+                    self._run_bounded(
+                        lambda c=case: asyncio.run(
+                            twin.drive_tool(tool_name, c["args"])
+                        )
+                    )
+                except _ExecTimeout:
+                    logger.debug(
+                        "dast mcp-scope: %s timed out (>%ss)",
+                        tool_name,
+                        self._exec_timeout,
+                    )
+                except Exception as e:
+                    logger.debug(
+                        "dast mcp-scope: %s(%s) raised: %s",
+                        tool_name,
+                        case["label"],
+                        e,
+                    )
+
+    def _run_bounded(self, work):
+        """Run ``work()`` in a daemon thread with a hard wall-clock cap.
+
+        ``work`` is a plain (synchronous) callable. Returns its result, or raises
+        :class:`_ExecTimeout` if it doesn't finish within ``self._exec_timeout``.
+        The thread is daemon and runs the work DIRECTLY (no ``asyncio.run`` / no
+        nested ``asyncio.to_thread``), so a blocking call (sync ``time.sleep``,
+        hung subprocess, infinite loop) is abandoned cleanly when we stop waiting
+        — it does not keep an event-loop executor alive and deadlock scan exit.
+        """
+        import threading
+
+        box: Dict[str, Any] = {}
+
+        def _worker():
+            try:
+                box["result"] = work()
+            except Exception as e:  # surface the error to the caller
+                box["error"] = e
+
+        th = threading.Thread(target=_worker, daemon=True)
+        th.start()
+        th.join(self._exec_timeout)
+        if th.is_alive():
+            raise _ExecTimeout()
+        if "error" in box:
+            raise box["error"]
+        return box.get("result")
+
+    def _run_executor_bounded(self, executor, args, env_id):
+        """Bounded execution of one entry point (raises _ExecTimeout on hang).
+
+        Calls FileExecutor's SYNCHRONOUS per-language path directly inside the
+        bounded daemon thread (rather than the async ``execute_file`` which
+        offloads to a nested, non-daemon ``to_thread`` worker that would block
+        scan shutdown when abandoned).
+        """
+
+        def _work():
+            return self._execute_file_sync(executor, args, env_id)
+
+        return self._run_bounded(_work)
+
+    @staticmethod
+    def _execute_file_sync(executor, args, env_id):
+        """Synchronous equivalent of ``FileExecutor.execute_file`` for the code
+        packaging path; falls back to driving the async API on a private loop for
+        non-code (e.g. mcp) formats."""
+        fmt = (executor.manifest or {}).get("packaging_format", "code")
+        lang = (executor.manifest or {}).get("programming_language", "python")
+        try:
+            if fmt == "code" and lang == "python":
+                if executor.execute_python_locally:
+                    return executor.execute_python_file_locally(args, env_id=env_id)
+                return executor.execute_python_file_using_docker(args, env_id=env_id)
+            if fmt == "code" and lang == "bash":
+                return executor.execute_bash_file(parameters=args)
+        except Exception as e:
+            return {"error": f"execute failed: {e}"}
+        # Other formats (e.g. mcp): run the async path on a private loop.
+        return asyncio.run(executor.execute_file(parameters=args, env_id=env_id))
+
+    # ── core scan ──────────────────────────────────────────────────────────────
+
+    async def scan(
+        self,
+        object_type: str,
+        uuid: str,
+        *,
+        generated_at: Optional[str] = None,
+        max_cases_per_entry: Optional[int] = None,
+        max_entry_points: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        obj = self._get_object(object_type, uuid)
+        if not obj:
+            raise ValueError(f"{object_type} {uuid} not found in store")
+
+        if max_entry_points is None:
+            max_entry_points = self._max_entry_points
+
+        # Default the per-entry case count to the env-configured value
+        # (DAST_MAX_CASES); an explicit caller argument still wins.
+        if max_cases_per_entry is None:
+            max_cases_per_entry = self._max_cases
+
+        active_scope = scope.current_scope()
+
+        tools, blobs = self._collect_tools_and_blobs(object_type, obj)
+        all_entry_points = discover_entry_points(tools, blobs)
+        tools_by_name = {t.get("name"): t for t in tools if t.get("name")}
+        # module_name -> source, and module_name -> owning tool dict (for
+        # default manifest fields) so Tier-2 callables can be executed too.
+        module_to_source = {m: s for m, s in blobs}
+        module_to_tool = {
+            t.get("module_name"): t for t in tools if t.get("module_name")
+        }
+
+        # Filter the DIRECT-exercise entry points by scope (cumulative):
+        #   mcp        -> none exercised directly (only the vMCP path runs)
+        #   registered -> Tier-1 registered tools
+        #   discovered -> Tier-1 + Tier-2 (functions/classes/__main__)
+        from .engine.base import KIND_TOOL as _KIND_TOOL
+
+        def _in_scope(ep) -> bool:
+            if ep.kind == _KIND_TOOL:
+                return scope.registered_enabled(active_scope)
+            return scope.discovered_enabled(active_scope)
+
+        entry_points = [ep for ep in all_entry_points if _in_scope(ep)]
+
+        # Hard cap so a very large skill can't run away (live exec is costly).
+        # Truncation is recorded in the report so the cap is never silent.
+        truncated = 0
+        if len(entry_points) > max_entry_points:
+            truncated = len(entry_points) - max_entry_points
+            entry_points = entry_points[:max_entry_points]
+
+        if generated_at is None:
+            from datetime import datetime, timezone
+
+            generated_at = datetime.now(timezone.utc).isoformat()
+
+        progress.start(uuid, total=len(entry_points))
+
+        def _on_progress(current: int, total: int, entry_point: str) -> None:
+            progress.update(uuid, current=current, total=total, entry_point=entry_point)
+
+        execute = self._build_execute(
+            tools_by_name, module_to_source, module_to_tool, env_id=""
+        )
+        want_twin = (
+            self._live and object_type == "skill" and bool(obj.get("tool_uuids"))
+        )
+        twin_tool_uuids = list(obj.get("tool_uuids") or [])
+
+        def _run_with_twin() -> Any:
+            """Twin start + (MCP scope) drive tools + (B/C) direct exercise + stop.
+
+            ALL runs off the event loop in a worker thread: the vMCP twin boots a
+            nested uvicorn server and the scan is long; doing that on the request
+            loop would block concurrent /scan-status polls (the progress label).
+            """
+            twin = None
+            try:
+                if want_twin:
+                    try:
+                        twin = BenignMcpTwin(
+                            name=f"dast-twin-{uuid[:8]}",
+                            tool_uuids=twin_tool_uuids,
+                        ).start()
+                    except Exception as e:
+                        logger.warning("dast: vMCP twin failed to start: %s", e)
+                        twin = None
+
+                # ── Scope A (mcp): exercise tools THROUGH the benign twin ──
+                # Always part of the cumulative scope; populates twin.calls,
+                # which the runner folds in as informational mcp-call findings.
+                if twin is not None and scope.mcp_enabled(active_scope):
+                    self._drive_mcp_scope(
+                        twin, tools_by_name, max_cases_per_entry, max_entry_points
+                    )
+
+                # ── Scope B/C: direct exercise of in-scope entry points ──
+                return run_dast(
+                    entry_points,
+                    execute,
+                    max_cases_per_entry=max_cases_per_entry,
+                    twin_calls=twin.calls if twin else None,
+                    progress_callback=_on_progress,
+                )
+            finally:
+                if twin is not None:
+                    twin.stop()
+                progress.finish(uuid)
+
+        report = await asyncio.to_thread(_run_with_twin)
+
+        block = report.to_extra_block(
+            generated_at=generated_at, plugin_version=_PLUGIN_VERSION
+        )
+        block["scanner"]["python_version"] = platform.python_version()
+        block["scanner"]["live"] = self._live
+        block["scanner"]["scope"] = active_scope
+        block["scanner"]["max_cases_per_entry"] = max_cases_per_entry
+        block["scanner"]["exec_timeout"] = self._exec_timeout
+        # How many entry points existed vs. were in scope (honest about filtering).
+        block["coverage"]["entry_points_total"] = len(all_entry_points)
+        block["coverage"]["scope"] = active_scope
+        if truncated:
+            block["coverage"]["entry_points_truncated"] = truncated
+            block["coverage"]["note"] = (
+                f"capped at {max_entry_points} entry points; "
+                f"{truncated} not exercised"
+            )
+        self._persist(object_type, uuid, block, report.summary_tags())
+        return {
+            "object_type": object_type,
+            "uuid": uuid,
+            "dast": block,
+            "summary": block["summary"],
+        }
+
+    # ── persistence ──────────────────────────────────────────────────────────
+
+    def _persist(
+        self, object_type: str, uuid: str, block: Dict[str, Any], tags: List[str]
+    ) -> None:
+        obj = self._get_object(object_type, uuid)
+        if not obj:
+            return
+        if not isinstance(obj.get("extra"), dict):
+            obj["extra"] = {}
+        obj["extra"][_EXTRA_KEY] = block
+        obj["tags"] = self._strip_dast_tags(obj.get("tags") or []) + tags
+        self._write_object(object_type, uuid, obj)
+
+    def _write_object(self, object_type: str, uuid: str, obj: Dict[str, Any]) -> None:
+        writer = {
+            "skill": self.store.update_skill,
+            "tool": self.store.update_tool,
+            "snippet": self.store.update_snippet,
+        }.get(object_type)
+        if writer is None:
+            raise ValueError(f"Unsupported object_type: {object_type!r}")
+        writer(uuid, obj)
+
+    @staticmethod
+    def _strip_dast_tags(tags: List[str]) -> List[str]:
+        return [t for t in tags if not t.startswith(_TAG_PREFIX)]
+
+    # ── plugin interface ──────────────────────────────────────────────────────
+
+    def get_router(self):
+        from fastapi import APIRouter, HTTPException
+        from pydantic import BaseModel
+
+        router = APIRouter()
+
+        class ScanRequest(BaseModel):
+            object_type: str = "skill"
+            uuid: Optional[str] = None
+
+        def _validate(object_type: str, uuid: Optional[str]) -> None:
+            if object_type not in OBJECT_TYPES:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"object_type must be one of {list(OBJECT_TYPES)}; "
+                        f"got {object_type!r}"
+                    ),
+                )
+            if not (uuid and uuid.strip()):
+                raise HTTPException(status_code=400, detail="uuid is required")
+
+        @router.post("/scan")
+        async def scan_endpoint(request: ScanRequest):
+            """Run a DAST scan over a skill's entry points (detect-and-report)."""
+            if not self.is_enabled():
+                raise HTTPException(status_code=503, detail=self.get_status_message())
+            _validate(request.object_type, request.uuid)
+            try:
+                data = await self.scan(request.object_type, request.uuid)
+            except ValueError as e:
+                raise HTTPException(status_code=404, detail=str(e))
+            except HTTPException:
+                raise
+            except Exception as e:
+                logger.error("dast scan failed: %s", e, exc_info=True)
+                raise HTTPException(status_code=500, detail=str(e))
+            return {
+                "success": True,
+                "message": _summary_message(data["dast"]),
+                "data": data,
+            }
+
+        @router.get("/scan-status")
+        async def scan_status(uuid: str):
+            """Live progress of an in-flight scan for ``uuid`` (for the UI label).
+
+            Returns ``{state, current, total, entry_point, label}``. ``state`` is
+            ``running`` | ``done`` | ``idle`` (no scan seen for this uuid).
+            """
+            p = progress.get(uuid)
+            if p is None:
+                return {"state": "idle", "label": ""}
+            ep = p.get("entry_point")
+            if p.get("state") == "done":
+                label = "Scan complete"
+            elif ep:
+                label = f"Testing {ep} " f"({p.get('current', 0)}/{p.get('total', 0)})"
+            else:
+                label = "Starting scan…"
+            return {
+                "state": p.get("state", "running"),
+                "current": p.get("current", 0),
+                "total": p.get("total", 0),
+                "entry_point": ep,
+                "label": label,
+            }
+
+        return router
+
+    def get_cli_commands(self) -> Optional[Dict[str, Any]]:
+        return None
+
+    def get_ui_config(self) -> Optional[Dict[str, Any]]:
+        return {
+            "icon": "BugIcon",
+            "color": "#8A2BE2",
+            "actions": [
+                {
+                    "label": "Run DAST scan",
+                    "endpoint": "/api/plugins/dast/scan",
+                    "method": "POST",
+                    # While the POST is in flight, the UI polls this GET endpoint
+                    # (passing the `uuid` form value as a query param) and shows
+                    # its `label` field as a live status under the form.
+                    "status_endpoint": "/api/plugins/dast/scan-status",
+                    "status_param": "uuid",
+                    "params_schema": {
+                        "type": "object",
+                        "properties": {
+                            "object_type": {
+                                "type": "string",
+                                "enum": list(OBJECT_TYPES),
+                                "default": "skill",
+                                "description": "Object type to scan (skill recommended)",
+                            },
+                            "uuid": {
+                                "type": "string",
+                                "description": "UUID of the object to scan",
+                            },
+                        },
+                        "required": ["object_type", "uuid"],
+                    },
+                }
+            ],
+        }

--- a/plugins/skillberry-plugin-dast/tests/test_dast_plugin.py
+++ b/plugins/skillberry-plugin-dast/tests/test_dast_plugin.py
@@ -1,0 +1,406 @@
+"""Tests for the DAST plugin (mock store, dry-run; no real Docker/vMCP)."""
+
+import copy
+
+import pytest
+
+from skillberry_plugin_dast.engine.fuzz import GENERATOR_NAME, generator_available
+from skillberry_plugin_dast.plugin import SkillberryPluginDast
+from skillberry_store.plugins.base import PluginType
+
+# Scans that actually exercise params need the optional generator engine.
+requires_engine = pytest.mark.skipif(
+    not generator_available(),
+    reason=f"input generator {GENERATOR_NAME!r} not installed",
+)
+
+
+class _Tools:
+    def __init__(self, modules):
+        self._modules = modules  # (uuid, filename) -> source
+
+    def read_file(self, uuid, filename, raw_content=False):
+        return self._modules[(uuid, filename)]
+
+
+class FakeStore:
+    def __init__(self, objects=None, modules=None):
+        self._objs = objects or {}
+        self.tools = _Tools(modules or {})
+
+    def get_skill(self, uuid):
+        return copy.deepcopy(self._objs.get(("skill", uuid)))
+
+    def get_tool(self, uuid):
+        return copy.deepcopy(self._objs.get(("tool", uuid)))
+
+    def get_snippet(self, uuid):
+        return copy.deepcopy(self._objs.get(("snippet", uuid)))
+
+    def update_skill(self, uuid, data):
+        self._objs[("skill", uuid)] = copy.deepcopy(data)
+        return True
+
+    def update_tool(self, uuid, data):
+        self._objs[("tool", uuid)] = copy.deepcopy(data)
+        return True
+
+    def update_snippet(self, uuid, data):
+        self._objs[("snippet", uuid)] = copy.deepcopy(data)
+        return True
+
+
+def _plugin(store, monkeypatch):
+    monkeypatch.delenv("DAST_LIVE", raising=False)  # dry-run: inert executor
+    p = SkillberryPluginDast()
+    p.set_store_api(store)
+    return p
+
+
+# ── interface ─────────────────────────────────────────────────────────────────
+
+
+def test_metadata_and_enablement():
+    p = SkillberryPluginDast()
+    assert p.metadata.name == "DAST Scanner"
+    assert p.metadata.plugin_type == PluginType.EVALUATOR
+    # Enablement tracks the optional engine's availability.
+    assert p.is_enabled() == generator_available()
+
+
+def test_disabled_when_engine_missing(monkeypatch):
+    import skillberry_plugin_dast.plugin as plugin_mod
+
+    monkeypatch.setattr(plugin_mod, "generator_available", lambda: False)
+    p = SkillberryPluginDast()
+    assert p.is_enabled() is False
+    assert "Disabled" in p.get_status_message()
+
+
+def test_scan_endpoint_503_when_disabled(monkeypatch):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    import skillberry_plugin_dast.plugin as plugin_mod
+
+    monkeypatch.setattr(plugin_mod, "generator_available", lambda: False)
+    app = FastAPI()
+    app.include_router(SkillberryPluginDast().get_router())
+    client = TestClient(app)
+    r = client.post("/scan", json={"object_type": "skill", "uuid": "x"})
+    assert r.status_code == 503
+    assert "Disabled" in r.json()["detail"]
+
+
+def test_router_exposes_scan():
+    p = SkillberryPluginDast()
+    assert "/scan" in {r.path for r in p.get_router().routes}
+
+
+def test_ui_config_default_skill():
+    p = SkillberryPluginDast()
+    a = p.get_ui_config()["actions"][0]
+    assert a["label"] == "Run DAST scan"
+    assert a["params_schema"]["properties"]["object_type"]["default"] == "skill"
+    # progress: the action advertises a status endpoint the UI polls on `uuid`
+    assert a["status_endpoint"].endswith("/scan-status")
+    assert a["status_param"] == "uuid"
+
+
+def test_scan_status_endpoint_reports_progress():
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from skillberry_plugin_dast.engine import progress
+
+    app = FastAPI()
+    app.include_router(SkillberryPluginDast().get_router())
+    client = TestClient(app)
+
+    # unknown uuid -> idle
+    r = client.get("/scan-status", params={"uuid": "nope"})
+    assert r.status_code == 200 and r.json()["state"] == "idle"
+
+    # simulate an in-flight scan and confirm the label reflects the entry point
+    progress.start("u9", total=4)
+    progress.update("u9", current=2, total=4, entry_point="send_msg")
+    try:
+        r = client.get("/scan-status", params={"uuid": "u9"})
+        body = r.json()
+        assert body["state"] == "running"
+        assert body["entry_point"] == "send_msg"
+        assert "send_msg" in body["label"] and "2/4" in body["label"]
+    finally:
+        progress.clear("u9")
+
+
+def test_registers_no_event_handlers():
+    from skillberry_store.plugins import events
+
+    before = {k: len(v) for k, v in events._event_handlers.items()}
+    SkillberryPluginDast()
+    after = {k: len(v) for k, v in events._event_handlers.items()}
+    assert before == after
+
+
+def test_endpoint_blank_input_400_not_422(monkeypatch):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    import skillberry_plugin_dast.plugin as plugin_mod
+
+    # Force the engine enabled so validation (400) is reached rather than the
+    # disabled gate (503) — this test is about input validation, not gating.
+    monkeypatch.setattr(plugin_mod, "generator_available", lambda: True)
+    app = FastAPI()
+    app.include_router(SkillberryPluginDast().get_router())
+    client = TestClient(app)
+    r = client.post("/scan", json={})
+    assert r.status_code == 400 and "uuid is required" in r.json()["detail"]
+    r = client.post("/scan", json={"object_type": "widget", "uuid": "x"})
+    assert r.status_code == 400 and "object_type must be one of" in r.json()["detail"]
+
+
+# ── scan (dry-run, offline) ─────────────────────────────────────────────────────
+
+
+@requires_engine
+@pytest.mark.asyncio
+async def test_scan_skill_discovers_and_persists(monkeypatch):
+    monkeypatch.setenv("DAST_SCOPE", "discovered")  # exercise all tiers directly
+    store = FakeStore(
+        objects={
+            ("skill", "sk1"): {
+                "uuid": "sk1",
+                "name": "demo",
+                "tool_uuids": ["t1"],
+                "snippet_uuids": [],
+                "extra": {"other": "keep me"},
+                "tags": ["x"],
+            },
+            ("tool", "t1"): {
+                "uuid": "t1",
+                "name": "send_msg",
+                "module_name": "send.py",
+                "params": {
+                    "properties": {"channel": {"type": "string"}},
+                    "required": ["channel"],
+                    "optional": [],
+                },
+            },
+        },
+        modules={
+            ("t1", "send.py"): (
+                "def send_msg(channel):\n    return channel\n"
+                "def helper(x):\n    return x\n"
+            )
+        },
+    )
+    p = _plugin(store, monkeypatch)
+    result = await p.scan("skill", "sk1")
+    block = result["dast"]
+
+    # Tier-1 tool + Tier-2 helper discovered
+    names = {e["name"] for e in block["entry_points"]}
+    assert "send_msg" in names and "helper" in names
+    assert block["coverage"]["entry_points_discovered"] >= 2
+    assert block["scanner"]["mode"] == "detect-and-report"
+    assert block["coverage"]["observation"] == "detected, not prevented"
+
+    # persisted non-destructively + dast tags
+    stored = store.get_skill("sk1")
+    assert stored["extra"]["dast"]["schema_version"] == 1
+    assert stored["extra"]["other"] == "keep me"
+    assert any(t.startswith("dast:coverage:") for t in stored["tags"])
+    assert "x" in stored["tags"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_execution_target_covers_all_tiers(monkeypatch):
+    # The synthesis logic: tool runs as-is; function by name; class via factory;
+    # __main__ via runner. Verify (func_name, source, manifest) per kind.
+    from skillberry_plugin_dast.engine.base import EntryPoint
+
+    src = (
+        "def maintool(x):\n    return x\n"
+        "def helper(y):\n    return y\n"
+        "class Widget:\n    def __init__(self, n):\n        self.n = n\n"
+    )
+    store = FakeStore(
+        objects={
+            ("tool", "t1"): {"uuid": "t1", "name": "maintool", "module_name": "m.py"}
+        },
+        modules={("t1", "m.py"): src},
+    )
+    p = _plugin(store, monkeypatch)
+    tools_by_name = {
+        "maintool": {"uuid": "t1", "name": "maintool", "module_name": "m.py"}
+    }
+    module_to_source = {"m.py": src}
+    module_to_tool = {"m.py": tools_by_name["maintool"]}
+
+    def resolve(ep):
+        return p._resolve_execution_target(
+            ep, tools_by_name, module_to_source, module_to_tool
+        )
+
+    # Tier-1 tool -> its own function, original source
+    fn, source, man = resolve(
+        EntryPoint(name="maintool", kind="tool", module="m.py", tool_uuid="t1")
+    )
+    assert fn == "maintool" and "def maintool" in source
+
+    # Tier-2 function -> by name
+    fn, source, man = resolve(
+        EntryPoint(name="helper", kind="function", module="m.py", signature=["y"])
+    )
+    assert fn == "helper" and man["name"] == "helper"
+
+    # Tier-2 class -> factory appended, returns a serializable marker
+    fn, source, man = resolve(
+        EntryPoint(name="Widget", kind="class", module="m.py", signature=["n"])
+    )
+    assert fn == "__dast_make_Widget"
+    assert "def __dast_make_Widget" in source
+    assert "__dast_constructed:Widget" in source
+
+    # unknown module -> None
+    assert resolve(EntryPoint(name="x", kind="function", module="missing.py")) is None
+
+
+def test_summary_message_separates_exercised_from_findings():
+    # 96 MCP calls EXERCISED with 0 findings must NOT read as "96 findings found".
+    from skillberry_plugin_dast.plugin import _summary_message
+
+    block = {
+        "summary": {
+            "exercised": {"direct_calls": 0, "mcp_calls": 96, "total": 96},
+            "findings": {"direct": 0, "mcp": 0, "total": 0, "high": 0, "medium": 0},
+        }
+    }
+    msg = _summary_message(block)
+    assert "Exercised 96 call" in msg
+    assert "MCP: 96 call(s), 0 finding(s)" in msg
+    assert "Total findings: 0" in msg
+
+
+def test_summary_message_reports_direct_findings():
+    from skillberry_plugin_dast.plugin import _summary_message
+
+    block = {
+        "summary": {
+            "exercised": {"direct_calls": 10, "mcp_calls": 0, "total": 10},
+            "findings": {"direct": 2, "mcp": 0, "total": 2, "high": 1, "medium": 1},
+        }
+    }
+    msg = _summary_message(block)
+    assert "direct: 10 call(s), 2 finding(s)" in msg
+    assert "Total findings: 2 (high 1)" in msg
+
+
+def test_env_knobs_parsed(monkeypatch):
+    monkeypatch.setenv("DAST_MAX_CASES", "5")
+    monkeypatch.setenv("DAST_EXEC_TIMEOUT", "7")
+    p = SkillberryPluginDast()
+    assert p._max_cases == 5
+    assert p._exec_timeout == 7.0
+
+
+def test_env_knobs_bad_values_fall_back(monkeypatch):
+    monkeypatch.setenv("DAST_MAX_CASES", "not-an-int")
+    monkeypatch.setenv("DAST_EXEC_TIMEOUT", "nope")
+    p = SkillberryPluginDast()
+    assert p._max_cases == 5  # small default for fast scans
+    assert p._exec_timeout == 5.0  # small default
+
+
+@requires_engine
+@pytest.mark.asyncio
+async def test_max_cases_env_limits_generated_cases(monkeypatch):
+    monkeypatch.setenv("DAST_SCOPE", "registered")
+    monkeypatch.setenv("DAST_MAX_CASES", "3")
+    monkeypatch.delenv("DAST_LIVE", raising=False)  # dry-run executor
+    store = FakeStore(
+        objects={
+            ("tool", "t1"): {
+                "uuid": "t1",
+                "name": "send",
+                "module_name": "s.py",
+                "params": {
+                    "properties": {"a": {"type": "string"}},
+                    "required": ["a"],
+                    "optional": [],
+                },
+            }
+        },
+        modules={("t1", "s.py"): "def send(a):\n    return a\n"},
+    )
+    p = SkillberryPluginDast()
+    p.set_store_api(store)
+    block = (await p.scan("tool", "t1"))["dast"]
+    assert block["scanner"]["max_cases_per_entry"] == 3
+
+
+@requires_engine
+@pytest.mark.asyncio
+async def test_blocking_entry_point_times_out_not_hangs(monkeypatch):
+    # A tool that would block forever must time out per-case and be reported,
+    # not hang the scan. Use a tiny timeout so the test is fast.
+    monkeypatch.setenv("DAST_LIVE", "1")
+    monkeypatch.setenv("EXECUTE_PYTHON_LOCALLY", "1")
+    monkeypatch.setenv("DAST_SCOPE", "registered")
+    monkeypatch.setenv("DAST_EXEC_TIMEOUT", "1")
+    store = FakeStore(
+        objects={
+            ("tool", "t1"): {
+                "uuid": "t1",
+                "name": "hang",
+                "module_name": "h.py",
+                "programming_language": "python",
+                "packaging_format": "code",
+                "params": {
+                    "properties": {"x": {"type": "string"}},
+                    "required": ["x"],
+                    "optional": [],
+                },
+            }
+        },
+        modules={
+            (
+                "t1",
+                "h.py",
+            ): "import time\ndef hang(x):\n    time.sleep(999)\n    return x\n"
+        },
+    )
+    p = SkillberryPluginDast()
+    p.set_store_api(store)
+    # completes (does not hang) and records timeout evidence
+    block = (await p.scan("tool", "t1", max_cases_per_entry=1))["dast"]
+    findings = block["findings"]
+    assert any("timed out" in (f.get("evidence") or "") for f in findings)
+
+
+@pytest.mark.asyncio
+async def test_scan_missing_object_raises(monkeypatch):
+    p = _plugin(FakeStore(), monkeypatch)
+    with pytest.raises(ValueError):
+        await p.scan("skill", "nope")
+
+
+@pytest.mark.asyncio
+async def test_scan_records_coverage_caveats(monkeypatch):
+    store = FakeStore(
+        objects={
+            ("tool", "t1"): {
+                "uuid": "t1",
+                "name": "t",
+                "module_name": "m.py",
+                "params": {"properties": {}, "required": []},
+            }
+        },
+        modules={("t1", "m.py"): "def t():\n    return 1\n"},
+    )
+    p = _plugin(store, monkeypatch)
+    block = (await p.scan("tool", "t1"))["dast"]
+    assert "static" in block["coverage"]["discovery"]
+    assert block["scanner"]["live"] is False

--- a/plugins/skillberry-plugin-dast/tests/test_discover.py
+++ b/plugins/skillberry-plugin-dast/tests/test_discover.py
@@ -1,0 +1,69 @@
+"""Tests for entry-point discovery (Tier-1 tools + Tier-2 AST)."""
+
+from skillberry_plugin_dast.engine.discover import discover_entry_points
+
+
+def test_tier1_from_tools():
+    tools = [
+        {
+            "name": "send_msg",
+            "uuid": "t1",
+            "module_name": "send.py",
+            "params": {
+                "properties": {"channel": {"type": "string"}},
+                "required": ["channel"],
+                "optional": [],
+            },
+        }
+    ]
+    eps = discover_entry_points(tools, [])
+    assert len(eps) == 1
+    ep = eps[0]
+    assert ep.name == "send_msg"
+    assert ep.kind == "tool"
+    assert ep.tool_uuid == "t1"
+    assert ep.params["required"] == ["channel"]
+
+
+def test_tier2_public_functions_classes_and_main():
+    source = (
+        "import os\n"
+        "def public_fn(a, b=2):\n    return a + b\n"
+        "def _private():\n    pass\n"
+        "class PublicCls:\n    def __init__(self, x):\n        self.x = x\n"
+        "class _Hidden:\n    pass\n"
+        "if __name__ == '__main__':\n    public_fn(1)\n"
+    )
+    eps = discover_entry_points([], [("mod.py", source)])
+    names = {(e.name, e.kind) for e in eps}
+    assert ("public_fn", "function") in names
+    assert ("PublicCls", "class") in names
+    assert ("__main__", "main") in names
+    # private excluded
+    assert not any(e.name in ("_private", "_Hidden") for e in eps)
+    # signature captured (self stripped)
+    fn = next(e for e in eps if e.name == "public_fn")
+    assert fn.signature == ["a", "b"]
+    cls = next(e for e in eps if e.name == "PublicCls")
+    assert cls.signature == ["x"]
+
+
+def test_tier2_dedup_against_tier1():
+    # A module defines `send_msg`, which is also a registered tool -> Tier-1 wins.
+    tools = [{"name": "send_msg", "uuid": "t1", "module_name": "send.py", "params": {}}]
+    source = "def send_msg(x):\n    pass\ndef helper(y):\n    pass\n"
+    eps = discover_entry_points(tools, [("send.py", source)])
+    send = [e for e in eps if e.name == "send_msg"]
+    assert len(send) == 1 and send[0].kind == "tool"  # not duplicated as function
+    assert any(e.name == "helper" and e.kind == "function" for e in eps)
+
+
+def test_bad_syntax_module_yields_no_tier2():
+    eps = discover_entry_points([], [("broken.py", "def (:\n  nope")])
+    assert eps == []
+
+
+def test_nested_defs_not_discovered():
+    source = "def outer():\n    def inner():\n        pass\n    return inner\n"
+    eps = discover_entry_points([], [("m.py", source)])
+    assert [e.name for e in eps] == ["outer"]  # inner is nested, not top-level

--- a/plugins/skillberry-plugin-dast/tests/test_fuzz.py
+++ b/plugins/skillberry-plugin-dast/tests/test_fuzz.py
@@ -1,0 +1,80 @@
+"""Tests for Hypothesis-backed input generation (the optional engine)."""
+
+import pytest
+
+from skillberry_plugin_dast.engine.fuzz import (
+    GENERATOR_NAME,
+    cases_from_signature,
+    generate_cases,
+    generator_available,
+    generator_status,
+)
+
+# Generation requires the optional engine; skip those tests if it's absent.
+requires_engine = pytest.mark.skipif(
+    not generator_available(),
+    reason=f"input generator {GENERATOR_NAME!r} not installed",
+)
+
+
+def _labels(cases):
+    return [c["label"] for c in cases]
+
+
+def test_generator_name_is_hypothesis():
+    assert GENERATOR_NAME == "hypothesis"
+
+
+def test_generator_status_reflects_availability():
+    status = generator_status()
+    if generator_available():
+        assert "Ready" in status and GENERATOR_NAME in status
+    else:
+        assert "Disabled" in status and "pip install" in status
+
+
+def test_no_params_yields_no_args_case():
+    # This path needs no engine (no values to draw).
+    assert generate_cases({"properties": {}, "required": []}) == [
+        {"label": "no-args", "args": {}}
+    ]
+
+
+@requires_engine
+def test_deterministic():
+    params = {
+        "properties": {"channel": {"type": "string"}, "count": {"type": "integer"}},
+        "required": ["channel"],
+        "optional": ["count"],
+    }
+    assert generate_cases(params) == generate_cases(params)
+
+
+@requires_engine
+def test_has_baseline_draws_and_missing_required():
+    params = {
+        "properties": {"channel": {"type": "string"}},
+        "required": ["channel"],
+        "optional": [],
+    }
+    labels = _labels(generate_cases(params))
+    assert "baseline" in labels
+    assert any(l.startswith("draw:channel:") for l in labels)
+    assert "missing-required:channel" in labels
+
+
+@requires_engine
+def test_max_cases_cap():
+    params = {
+        "properties": {f"p{i}": {"type": "string"} for i in range(10)},
+        "required": [f"p{i}" for i in range(10)],
+        "optional": [],
+    }
+    assert len(generate_cases(params, max_cases=12)) == 12
+
+
+@requires_engine
+def test_cases_from_signature():
+    cases = cases_from_signature(["a", "b"])
+    assert cases
+    assert any(c["label"] == "missing-required:a" for c in cases)

--- a/plugins/skillberry-plugin-dast/tests/test_generators_registry.py
+++ b/plugins/skillberry-plugin-dast/tests/test_generators_registry.py
@@ -1,0 +1,121 @@
+"""Proves the input-generator engine is pluggable (a non-Hypothesis engine works).
+
+This is the real flexibility check: register a second, fake engine, select it via
+DAST_GENERATOR, and confirm the registry resolves it, the plugin enables on it,
+and a scan is driven by it — with no Hypothesis involved.
+"""
+
+import copy
+
+import pytest
+
+from skillberry_plugin_dast.engine import generators as gens
+from skillberry_plugin_dast.engine.generators.base import InputGenerator
+
+
+class FakeGenerator(InputGenerator):
+    """A trivial, always-available, Hypothesis-free engine."""
+
+    name = "fake"
+
+    def is_available(self) -> bool:
+        return True
+
+    def generate_cases(self, params, *, seed=1729, max_cases=24):
+        props = params.get("properties") or {}
+        if not props:
+            return [{"label": "no-args", "args": {}}]
+        # one deterministic sentinel value per parameter
+        args = {name: f"<fake:{name}>" for name in props}
+        return [{"label": "fake-case", "args": args}][:max_cases]
+
+
+@pytest.fixture
+def fake_engine(monkeypatch):
+    """Register FakeGenerator and select it via DAST_GENERATOR."""
+    reg = dict(gens.GENERATOR_REGISTRY)
+    reg["fake"] = FakeGenerator
+    monkeypatch.setattr(gens, "GENERATOR_REGISTRY", reg)
+    monkeypatch.setenv("DAST_GENERATOR", "fake")
+    return FakeGenerator
+
+
+def test_registry_resolves_selected_engine(fake_engine):
+    eng = gens.resolve_generator()
+    assert isinstance(eng, FakeGenerator)
+    assert gens.any_generator_available() is True
+    assert "fake" in gens.status_message()
+
+
+def test_unknown_selection_is_disabled_with_message(monkeypatch):
+    monkeypatch.setenv("DAST_GENERATOR", "does-not-exist")
+    assert gens.resolve_generator() is None
+    assert "not a registered generator" in gens.status_message()
+
+
+def test_fuzz_facade_uses_selected_engine(fake_engine):
+    # fuzz.generate_cases must delegate to the selected (fake) engine.
+    from skillberry_plugin_dast.engine import fuzz
+
+    cases = fuzz.generate_cases(
+        {"properties": {"p": {"type": "string"}}, "required": ["p"]}
+    )
+    assert cases == [{"label": "fake-case", "args": {"p": "<fake:p>"}}]
+
+
+@pytest.mark.asyncio
+async def test_scan_driven_by_fake_engine(fake_engine, monkeypatch):
+    """End-to-end: a scan runs powered by the fake engine (no Hypothesis)."""
+    from skillberry_plugin_dast.plugin import SkillberryPluginDast
+
+    class _Tools:
+        def __init__(self, m):
+            self.m = m
+
+        def read_file(self, uuid, fn, raw_content=False):
+            return self.m[(uuid, fn)]
+
+    class Store:
+        def __init__(self):
+            self._o = {
+                ("tool", "t1"): {
+                    "uuid": "t1",
+                    "name": "send",
+                    "module_name": "s.py",
+                    "params": {
+                        "properties": {"p": {"type": "string"}},
+                        "required": ["p"],
+                        "optional": [],
+                    },
+                }
+            }
+            self.tools = _Tools({("t1", "s.py"): "def send(p):\n    return p\n"})
+
+        def get_tool(self, u):
+            return copy.deepcopy(self._o.get(("tool", u)))
+
+        def get_skill(self, u):
+            return None
+
+        def get_snippet(self, u):
+            return None
+
+        def update_tool(self, u, d):
+            self._o[("tool", u)] = copy.deepcopy(d)
+            return True
+
+        def update_skill(self, u, d):
+            return True
+
+        def update_snippet(self, u, d):
+            return True
+
+    monkeypatch.setenv("DAST_SCOPE", "registered")  # exercise the Tier-1 tool
+    p = SkillberryPluginDast()
+    p.set_store_api(Store())
+    assert p.is_enabled() is True  # enabled via the fake engine
+    block = (await p.scan("tool", "t1"))["dast"]
+    assert (
+        block["coverage"]["exercised"] == block["coverage"]["entry_points_discovered"]
+    )
+    assert block["coverage"]["entry_points_discovered"] >= 1

--- a/plugins/skillberry-plugin-dast/tests/test_observe.py
+++ b/plugins/skillberry-plugin-dast/tests/test_observe.py
@@ -1,0 +1,125 @@
+"""Tests for the observe shim/event parser and output-based findings."""
+
+import json
+
+from skillberry_plugin_dast.engine.observe import (
+    EVENT_MARKER,
+    SHIM_SOURCE,
+    findings_from_output,
+    parse_events,
+    split_events_from_output,
+)
+
+
+def test_split_events_from_output():
+    ev = json.dumps({"kind": "network", "op": "socket.connect", "target": "evil:80"})
+    stdout = "real line 1\n" + EVENT_MARKER + ev + "\n" + "real line 2\n"
+    events, clean = split_events_from_output(stdout)
+    assert events == ev  # marker stripped, JSON recovered
+    assert clean == "real line 1\nreal line 2"
+    # the recovered events feed straight into parse_events
+    findings = parse_events(events, entry_point="ep", case="c")
+    assert findings and findings[0].kind == "network-egress"
+
+
+def _sink(*events):
+    return "\n".join(json.dumps(e) for e in events)
+
+
+def test_parse_network_egress_is_high_and_excludes_loopback():
+    text = _sink(
+        {"kind": "network", "op": "requests.get", "target": "http://evil.example/x"},
+        {"kind": "network", "op": "socket.connect", "target": "127.0.0.1:10000"},
+        {"kind": "network", "op": "socket.connect", "target": "host.docker.internal:1"},
+    )
+    findings = parse_events(text, entry_point="ep", case="c")
+    # only the non-loopback egress is a finding
+    assert len(findings) == 1
+    f = findings[0]
+    assert f.kind == "network-egress" and f.severity == "high"
+    assert "evil.example" in f.target
+
+
+def test_parse_subprocess_high_and_fs_write_medium_read_low():
+    text = _sink(
+        {"kind": "subprocess", "op": "Popen", "target": "['curl']"},
+        {"kind": "filesystem", "op": "open.write", "target": "/etc/x"},
+        {"kind": "filesystem", "op": "open.read", "target": "/data"},
+    )
+    findings = parse_events(text, entry_point="ep", case="c")
+    by_kind = {f.kind: f for f in findings}
+    assert by_kind["subprocess"].severity == "high"
+    assert by_kind["filesystem"].severity in ("medium", "low")
+    sev = {f.severity for f in findings if f.kind == "filesystem"}
+    assert "medium" in sev and "low" in sev
+
+
+def test_parse_ignores_blank_and_bad_lines():
+    text = "not json\n\n" + json.dumps(
+        {"kind": "subprocess", "op": "os.system", "target": "rm"}
+    )
+    findings = parse_events(text, entry_point="ep", case="c")
+    assert len(findings) == 1
+
+
+def test_findings_from_output_crash_and_leak():
+    result = {
+        "error": 'Traceback (most recent call last):\n  File "x", line 1',
+        "stderr": "API_KEY=sk-secret-123",
+    }
+    findings = findings_from_output(result, entry_point="ep", case="c")
+    kinds = {f.kind for f in findings}
+    assert "crash" in kinds
+    assert "leak" in kinds
+    leak = next(f for f in findings if f.kind == "leak")
+    assert leak.severity == "high"
+
+
+def test_findings_from_clean_output_none():
+    result = {"return value": "ok, all good"}
+    assert findings_from_output(result, entry_point="ep", case="c") == []
+
+
+def test_shim_does_not_observe_its_own_sink(tmp_path):
+    # Exec the shim in a fresh namespace and confirm the event sink writes are
+    # NOT recorded as filesystem findings (the recursion/flood regression).
+    # The shim patches global builtins.open/socket/etc., so restore them after.
+    import builtins
+    import os
+    import socket
+    import subprocess
+
+    saved = (builtins.open, socket.socket.connect, subprocess.Popen.__init__)
+    sink = str(tmp_path / "events.jsonl")
+    builtins.open(sink, "w").close()
+    prev = os.environ.get("DAST_EVENT_SINK")
+    os.environ["DAST_EVENT_SINK"] = sink
+    try:
+        exec(compile(SHIM_SOURCE, "<shim>", "exec"), {})
+        # trigger a real write to a DIFFERENT file via the (now-wrapped) open
+        target = str(tmp_path / "out.txt")
+        builtins.open(target, "w").write("x")
+        text = saved[0](sink).read()  # read sink via the original open
+    finally:
+        builtins.open = saved[0]
+        socket.socket.connect = saved[1]
+        subprocess.Popen.__init__ = saved[2]
+        if prev is None:
+            os.environ.pop("DAST_EVENT_SINK", None)
+        else:
+            os.environ["DAST_EVENT_SINK"] = prev
+    findings = parse_events(text, entry_point="ep", case="c")
+    fs = [f for f in findings if f.kind == "filesystem"]
+    # the out.txt write is recorded; the sink's own writes are not
+    assert any("out.txt" in (f.target or "") for f in fs)
+    assert not any("events.jsonl" in (f.target or "") for f in findings)
+
+
+def test_shim_source_is_pass_through_not_block():
+    # The shim must call the originals (pass-through) and never raise/sys.exit.
+    assert "_orig_connect(self, address" in SHIM_SOURCE
+    assert "_orig_req(self, method, url" in SHIM_SOURCE
+    assert "sys.exit" not in SHIM_SOURCE
+    assert "raise" not in SHIM_SOURCE
+    # it must compile
+    compile(SHIM_SOURCE, "<shim>", "exec")

--- a/plugins/skillberry-plugin-dast/tests/test_progress.py
+++ b/plugins/skillberry-plugin-dast/tests/test_progress.py
@@ -1,0 +1,68 @@
+"""Tests for the scan-progress registry and the runner progress callback."""
+
+import pytest
+
+from skillberry_plugin_dast.engine import progress
+from skillberry_plugin_dast.engine.base import EntryPoint
+from skillberry_plugin_dast.engine.fuzz import GENERATOR_NAME, generator_available
+from skillberry_plugin_dast.engine.runner import run_dast
+
+# The registry tests are engine-free; the run_dast tests need the generator.
+_needs_engine = pytest.mark.skipif(
+    not generator_available(),
+    reason=f"input generator {GENERATOR_NAME!r} not installed",
+)
+
+
+def test_registry_lifecycle():
+    progress.clear("u1")
+    assert progress.get("u1") is None
+
+    progress.start("u1", total=3)
+    p = progress.get("u1")
+    assert p["state"] == "running" and p["total"] == 3 and p["current"] == 0
+
+    progress.update("u1", current=2, entry_point="send_msg")
+    p = progress.get("u1")
+    assert p["current"] == 2 and p["entry_point"] == "send_msg"
+
+    progress.finish("u1")
+    p = progress.get("u1")
+    assert p["state"] == "done" and p["entry_point"] is None
+    progress.clear("u1")
+    assert progress.get("u1") is None
+
+
+def test_runner_invokes_progress_callback_per_entry_point():
+    eps = [
+        EntryPoint(name="a", kind="function", module="m.py", signature=[]),
+        EntryPoint(name="b", kind="function", module="m.py", signature=[]),
+    ]
+    seen = []
+
+    def cb(current, total, name):
+        seen.append((current, total, name))
+
+    run_dast(
+        eps,
+        lambda e, args: ({"return value": ""}, ""),
+        max_cases_per_entry=1,
+        progress_callback=cb,
+    )
+    assert seen == [(1, 2, "a"), (2, 2, "b")]
+
+
+def test_runner_swallows_callback_errors():
+    eps = [EntryPoint(name="a", kind="function", module="m.py", signature=[])]
+
+    def boom(current, total, name):
+        raise RuntimeError("nope")
+
+    # must not raise despite the callback throwing
+    report = run_dast(
+        eps,
+        lambda e, args: ({"return value": ""}, ""),
+        max_cases_per_entry=1,
+        progress_callback=boom,
+    )
+    assert report.entry_points[0].exercised is True

--- a/plugins/skillberry-plugin-dast/tests/test_runner.py
+++ b/plugins/skillberry-plugin-dast/tests/test_runner.py
@@ -1,0 +1,102 @@
+"""Tests for the DAST runner with a mock executor (no real Docker/network)."""
+
+import json
+
+import pytest
+
+from skillberry_plugin_dast.engine.base import EntryPoint
+from skillberry_plugin_dast.engine.fuzz import GENERATOR_NAME, generator_available
+from skillberry_plugin_dast.engine.runner import run_dast
+
+# run_dast generates cases via the optional engine; skip if it's absent.
+pytestmark = pytest.mark.skipif(
+    not generator_available(),
+    reason=f"input generator {GENERATOR_NAME!r} not installed",
+)
+
+
+def _tool_ep(name="send", required=("channel",)):
+    return EntryPoint(
+        name=name,
+        kind="tool",
+        module="send.py",
+        params={
+            "properties": {p: {"type": "string"} for p in required},
+            "required": list(required),
+            "optional": [],
+        },
+        tool_uuid="t1",
+    )
+
+
+def test_runner_collects_egress_and_marks_exercised():
+    ep = _tool_ep()
+
+    def execute(entry_point, args):
+        # simulate the executed code attempting egress (emit one network event)
+        events = json.dumps(
+            {
+                "kind": "network",
+                "op": "requests.get",
+                "target": "http://evil.example/x",
+            }
+        )
+        return ({"return value": ""}, events)
+
+    report = run_dast([ep], execute, max_cases_per_entry=2)
+    assert report.entry_points[0].exercised is True
+    block = report.to_extra_block(generated_at="T", plugin_version="0.1.0")
+    assert block["summary"]["egress_attempts"] >= 1
+    assert block["coverage"]["exercised"] == 1
+    assert any(f["kind"] == "network-egress" for f in block["findings"])
+
+
+def test_runner_harness_exception_becomes_crash_finding():
+    ep = _tool_ep()
+
+    def execute(entry_point, args):
+        raise RuntimeError("boom")
+
+    report = run_dast([ep], execute, max_cases_per_entry=3)
+    assert any(f.kind == "crash" for f in report.findings)
+    # every case errored -> not exercised -> recorded as skipped
+    assert report.entry_points[0].exercised is False
+    assert report.skipped and report.skipped[0]["name"] == "send"
+
+
+def test_runner_output_leak_finding():
+    ep = _tool_ep()
+
+    def execute(entry_point, args):
+        return ({"error": "boom: password=hunter2"}, "")
+
+    report = run_dast([ep], execute, max_cases_per_entry=1)
+    assert any(f.kind == "leak" and f.severity == "high" for f in report.findings)
+
+
+def test_runner_twin_calls_become_mcp_findings():
+    ep = _tool_ep()
+    twin_calls = [{"tool": "lookup", "args": {"q": "x"}, "result_excerpt": "ok"}]
+
+    report = run_dast(
+        [ep],
+        lambda e, a: ({"return value": ""}, ""),
+        max_cases_per_entry=1,
+        twin_calls=twin_calls,
+    )
+    mcp = [f for f in report.findings if f.kind == "mcp-call"]
+    assert mcp and mcp[0].severity == "info" and mcp[0].target == "lookup"
+
+
+def test_runner_tier2_signature_entry_point():
+    ep = EntryPoint(name="helper", kind="function", module="m.py", signature=["a", "b"])
+    seen = {}
+
+    def execute(entry_point, args):
+        seen["args"] = args
+        return ({"return value": ""}, "")
+
+    report = run_dast([ep], execute, max_cases_per_entry=5)
+    assert report.entry_points[0].exercised is True
+    # signature params were used to build cases
+    assert set(seen["args"]).issubset({"a", "b"})

--- a/plugins/skillberry-plugin-dast/tests/test_scope.py
+++ b/plugins/skillberry-plugin-dast/tests/test_scope.py
@@ -1,0 +1,147 @@
+"""Tests for DAST_SCOPE (cumulative mcp|registered|discovered) gating."""
+
+import copy
+
+import pytest
+
+from skillberry_plugin_dast.engine import scope
+
+
+def test_default_is_mcp(monkeypatch):
+    monkeypatch.delenv("DAST_SCOPE", raising=False)
+    assert scope.current_scope() == "mcp"
+
+
+def test_unknown_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("DAST_SCOPE", "bogus")
+    assert scope.current_scope() == "mcp"
+
+
+def test_cumulative_inclusion():
+    # mcp: only mcp
+    assert scope.mcp_enabled("mcp")
+    assert not scope.registered_enabled("mcp")
+    assert not scope.discovered_enabled("mcp")
+    # registered: mcp + registered
+    assert scope.mcp_enabled("registered")
+    assert scope.registered_enabled("registered")
+    assert not scope.discovered_enabled("registered")
+    # discovered: all
+    assert scope.mcp_enabled("discovered")
+    assert scope.registered_enabled("discovered")
+    assert scope.discovered_enabled("discovered")
+
+
+# ── scope filters which entry points get exercised directly ───────────────────
+
+from skillberry_plugin_dast.engine.fuzz import (  # noqa: E402
+    GENERATOR_NAME,
+    generator_available,
+)
+from skillberry_plugin_dast.plugin import SkillberryPluginDast  # noqa: E402
+
+requires_engine = pytest.mark.skipif(
+    not generator_available(),
+    reason=f"input generator {GENERATOR_NAME!r} not installed",
+)
+
+
+class _Tools:
+    def __init__(self, m):
+        self.m = m
+
+    def read_file(self, uuid, fn, raw_content=False):
+        return self.m[(uuid, fn)]
+
+
+def _skill_store():
+    # one tool (Tier-1 "send") whose module also has a Tier-2 "helper"
+    src = "def send(p):\n    return p\ndef helper(q):\n    return q\n"
+    objs = {
+        ("skill", "sk1"): {
+            "uuid": "sk1",
+            "name": "demo",
+            "tool_uuids": ["t1"],
+            "snippet_uuids": [],
+        },
+        ("tool", "t1"): {
+            "uuid": "t1",
+            "name": "send",
+            "module_name": "s.py",
+            "params": {
+                "properties": {"p": {"type": "string"}},
+                "required": ["p"],
+                "optional": [],
+            },
+        },
+    }
+
+    class Store:
+        def __init__(self):
+            self._o = objs
+            self.tools = _Tools({("t1", "s.py"): src})
+
+        def get_skill(self, u):
+            return copy.deepcopy(self._o.get(("skill", u)))
+
+        def get_tool(self, u):
+            return copy.deepcopy(self._o.get(("tool", u)))
+
+        def get_snippet(self, u):
+            return None
+
+        def update_skill(self, u, d):
+            self._o[("skill", u)] = copy.deepcopy(d)
+            return True
+
+        def update_tool(self, u, d):
+            return True
+
+        def update_snippet(self, u, d):
+            return True
+
+    return Store()
+
+
+def _exercised_names(block):
+    return {e["name"] for e in block["entry_points"] if e["exercised"]}
+
+
+@requires_engine
+@pytest.mark.asyncio
+async def test_scope_mcp_exercises_no_direct_entry_points(monkeypatch):
+    monkeypatch.delenv("DAST_LIVE", raising=False)  # no twin in dry-run
+    monkeypatch.setenv("DAST_SCOPE", "mcp")
+    p = SkillberryPluginDast()
+    p.set_store_api(_skill_store())
+    block = (await p.scan("skill", "sk1"))["dast"]
+    # mcp scope: nothing exercised via direct invocation
+    assert block["coverage"]["exercised"] == 0
+    assert block["scanner"]["scope"] == "mcp"
+    # discovery still reports what exists
+    assert block["coverage"]["entry_points_total"] >= 2
+
+
+@requires_engine
+@pytest.mark.asyncio
+async def test_scope_registered_exercises_only_tier1(monkeypatch):
+    monkeypatch.delenv("DAST_LIVE", raising=False)
+    monkeypatch.setenv("DAST_SCOPE", "registered")
+    p = SkillberryPluginDast()
+    p.set_store_api(_skill_store())
+    block = (await p.scan("skill", "sk1"))["dast"]
+    names = _exercised_names(block)
+    assert "send" in names  # Tier-1 tool
+    assert "helper" not in names  # Tier-2 excluded at this scope
+
+
+@requires_engine
+@pytest.mark.asyncio
+async def test_scope_discovered_exercises_tier1_and_tier2(monkeypatch):
+    monkeypatch.delenv("DAST_LIVE", raising=False)
+    monkeypatch.setenv("DAST_SCOPE", "discovered")
+    p = SkillberryPluginDast()
+    p.set_store_api(_skill_store())
+    block = (await p.scan("skill", "sk1"))["dast"]
+    names = _exercised_names(block)
+    assert "send" in names and "helper" in names

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,6 +204,10 @@ plugin-dependency-tracker = [
   "skillberry-plugin-dependency-tracker>=0.1.0",
 ]
 
+plugin-dast = [
+  "skillberry-plugin-dast>=0.1.0",
+]
+
 # Install all plugins
 plugins-all = [
   "skillberry-plugin-creator>=0.2.0",
@@ -219,6 +223,7 @@ plugins-all = [
   "skillberry-plugin-provenance>=0.1.0",
   "skillberry-plugin-doc-generator>=0.1.0",
   "skillberry-plugin-dependency-tracker>=0.1.0",
+  "skillberry-plugin-dast>=0.1.0",
 ]
 
 test = [
@@ -240,6 +245,7 @@ skillberry-plugin-simulate = { path = "plugins/skillberry-plugin-simulate", edit
 skillberry-plugin-provenance = { path = "plugins/skillberry-plugin-provenance", editable = true }
 skillberry-plugin-doc-generator = { path = "plugins/skillberry-plugin-doc-generator", editable = true }
 skillberry-plugin-dependency-tracker = { path = "plugins/skillberry-plugin-dependency-tracker", editable = true }
+skillberry-plugin-dast = { path = "plugins/skillberry-plugin-dast", editable = true }
 llm-client = { path = "skillberry-common/packages/llm-client", editable = true }
 torch = { index = "pytorch-cpu" }
 


### PR DESCRIPTION
## What

Adds a **Dynamic Application Security Testing (DAST)** plugin. The store today has only *static* security analysis (SAST, provenance, dependency-tracker). This adds the *dynamic* counterpart: on demand it **discovers a skill's invocable entry points, exercises each with adversarial inputs, observes the runtime effects, and records findings + coverage** in a non-destructive `extra["dast"]` block.

Closes #238.

## How it works

- **Discovery (static).** Tier 1 = registered tools (driven by their param schema). Tier 2 = AST-discovered public functions / classes / `__main__` in the skill's modules. Tier 3 dynamic dispatch is acknowledged and reported as a coverage caveat (`discovery: "static (Tier-3 dynamic dispatch may be missed)"`).
- **Exercise.** The **MCP surface** is driven through a benign **vMCP twin**; the **direct surface** runs through the store's own `FileExecutor` with an observe-shim **prepended** to the code (no env/mount cooperation needed; events emitted as marker-prefixed JSON on stdout — the one channel that survives the Docker exec path).
- **Observe — detect-and-report only.** The shim is pass-through-and-log: it records network egress / subprocess / filesystem / secret-leak / crash effects but **never blocks** them. This ceiling is surfaced in the report (`observation: "detected, not prevented"`). Run only on operator-accepted networks. (True lockdown is a follow-up gated on a runspace capability request.)
- **Report.** `extra["dast"]` carries `coverage`, `entry_points`, `findings`, and a `summary` that separates **exercised** (calls executed) from **findings** (real issues), split by MCP vs direct surface. Plus `dast:` summary tags.

## Scope & bounding (env knobs)

- `DAST_SCOPE` — cumulative: `mcp` ⊆ `registered` ⊆ `discovered` (default `mcp`). `registered` adds direct Tier-1 calls; `discovered` adds Tier-2.
- `DAST_GENERATOR` — selects the pluggable input-generator engine.
- `DAST_MAX_CASES`, `DAST_MAX_ENTRY_POINTS`, `DAST_EXEC_TIMEOUT` — keep scans fast and bounded (per-case timeout via a bounded daemon thread, so a hanging tool can't stall a scan).
- On-demand only — registers **no** event handler.

## Optional engine (not bundled)

The input-generator engine is **optional and pluggable**, mirroring the SAST + bandit pattern. Core dependency is just `requests`. `hypothesis` is provided as an adapter but ships **only as an optional extra** (`pip install 'skillberry-plugin-dast[hypothesis]'`) — it is **not** a hard dependency and is **not** added to the store's deps. With no engine installed, the plugin reports **disabled** and `/scan` returns **503**.

## UI

**Backend-only PR.** Results are the `/scan` response summary plus the persisted `extra["dast"]` block and `dast:` tags — both render in the existing object view via the generic plugin action form. The `/scan-status` progress endpoint ships, but the UI polling for a live in-progress label is intentionally deferred to a follow-up (it would have required removing async-job types other plugins depend on).

## Verification

- `uvx black --check --target-version py311 plugins/skillberry-plugin-dast` — clean.
- `uv run pytest plugins/skillberry-plugin-dast/tests -q` — **56 passed** (offline; real Docker/vMCP gated behind `DAST_LIVE`).
- `uv run pytest --co -q` — full-repo collection error-free (#198 guard); `dast` entry point loads.
- Live: scanned a real skill with `DAST_SCOPE=registered` → exercised both MCP (96 calls) and direct registered (92 calls across 20/20 endpoints) surfaces, persisted `extra["dast"]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)