### PR TITLE
feat(tools): MCP-friendly tool creation from code string + curate MCP surface

### DIFF
--- a/src/skillberry_store/fast_api/tools_api.py
+++ b/src/skillberry_store/fast_api/tools_api.py
@@ -6,6 +6,7 @@ import traceback
 from typing import Optional, Annotated, Dict, Any, List
 from fastapi import FastAPI, HTTPException, File, UploadFile, Query, Request
 from fastapi.responses import PlainTextResponse
+from pydantic import BaseModel
 
 from skillberry_store.modules.lifecycle import LifecycleState
 from skillberry_store.schemas.tool_schema import ToolSchema
@@ -15,6 +16,15 @@ from skillberry_store.services.exceptions import (
     ObjectInUseError,
 )
 from skillberry_store.services.tools_service import ToolsService
+
+
+class AddToolFromCodeRequest(BaseModel):
+    """Body for ``POST /tools/add_code`` — Python source as a string, not a file."""
+
+    code: str
+    selected_func: Optional[str] = None
+    update: bool = False
+    module_name: Optional[str] = None
 
 
 def register_tools_api(
@@ -354,6 +364,50 @@ def register_tools_api(
                 file_name=tool.filename,
                 selected_func=selected_func,
                 update_existing=update,
+            )
+        except ObjectAlreadyExistsError as e:
+            raise HTTPException(status_code=409, detail=str(e))
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Error adding tool: {str(e)}")
+
+    @app.post(
+        "/tools/add_code",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "add-tool-code", "x-mcp-tool": True},
+    )
+    async def add_tool_from_code(req: AddToolFromCodeRequest) -> Dict[str, Any]:
+        """Add a tool from Python source passed as a string (MCP-friendly).
+
+        Same behavior as ``POST /tools/add`` (auto-extracts the manifest from the
+        function docstring) but takes the source as a normal JSON ``code`` field
+        instead of a file upload — so it works over the MCP bridge, which cannot
+        transmit ``multipart``/octet-stream file bodies.
+
+        Args:
+            req: ``code`` (the Python source), optional ``selected_func`` (which
+                function to extract; defaults to the first), ``update`` (update an
+                existing tool of the same name), and ``module_name`` (stored file
+                name; defaults to ``tool.py``).
+
+        Returns:
+            dict: Success message with the tool name, uuid, and module_name.
+
+        Raises:
+            HTTPException: tool already exists (409), parse/validation error
+                (400), or any other error (500).
+        """
+        module_name = req.module_name or "tool.py"
+        if not module_name.endswith(".py"):
+            module_name += ".py"
+
+        try:
+            return service.add_from_python(
+                file_bytes=req.code.encode("utf-8"),
+                file_name=module_name,
+                selected_func=req.selected_func,
+                update_existing=req.update,
             )
         except ObjectAlreadyExistsError as e:
             raise HTTPException(status_code=409, detail=str(e))

--- a/src/skillberry_store/tests/test_tools_add_code.py
+++ b/src/skillberry_store/tests/test_tools_add_code.py
@@ -1,0 +1,81 @@
+"""Unit tests for the MCP-friendly /tools/add_code endpoint.
+
+Mirrors /tools/add (add_tool_from_python) but takes the Python source as a JSON
+string instead of a file upload, so it works over the MCP bridge (which cannot
+transmit multipart/octet-stream file bodies). The endpoint normalizes the
+module name and forwards the request to ``ToolsService.add_from_python``.
+"""
+
+from unittest.mock import MagicMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from skillberry_store.fast_api.tools_api import register_tools_api
+
+CODE = (
+    "def add_two_nums(a: float, b: float) -> float:\n"
+    '    """Add two numbers together.\n'
+    "\n"
+    "    Args:\n"
+    "        a: The first number.\n"
+    "        b: The second number.\n"
+    "\n"
+    "    Returns:\n"
+    "        The sum a + b.\n"
+    '    """\n'
+    "    return a + b\n"
+)
+
+
+def _client():
+    service = MagicMock()
+
+    def _add_from_python(
+        file_bytes, file_name=None, selected_func=None, update_existing=False
+    ):
+        return {
+            "message": "ok",
+            "name": "add_two_nums",
+            "uuid": "u1",
+            "module_name": file_name,
+        }
+
+    service.add_from_python.side_effect = _add_from_python
+
+    app = FastAPI()
+    register_tools_api(app, service=service)
+    return TestClient(app), service
+
+
+def test_add_tool_from_code_encodes_source_and_forwards():
+    client, service = _client()
+
+    resp = client.post("/tools/add_code", json={"code": CODE})
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["name"] == "add_two_nums"
+    # The string source is forwarded to the service as UTF-8 bytes.
+    kwargs = service.add_from_python.call_args.kwargs
+    assert kwargs["file_bytes"] == CODE.encode("utf-8")
+    assert kwargs["file_name"].endswith(".py")
+    assert kwargs["update_existing"] is False
+
+
+def test_add_tool_from_code_honors_module_name():
+    client, service = _client()
+
+    resp = client.post(
+        "/tools/add_code", json={"code": CODE, "module_name": "math_utils"}
+    )
+
+    assert resp.status_code == 200, resp.text
+    # A name without .py is normalized to a .py module file.
+    assert service.add_from_python.call_args.kwargs["file_name"] == "math_utils.py"
+
+
+def test_add_tool_from_code_requires_code():
+    client, _ = _client()
+
+    # Missing required `code` field → 422 from request-body validation.
+    assert client.post("/tools/add_code", json={}).status_code == 422


### PR DESCRIPTION
Closes #240

Tool creation over the control-plane MCP was impossible: `create_tool` and `add_tool_from_python` take the source as a required `UploadFile` (multipart), and an MCP tool call carries only JSON args — no file body — so the field arrives `null` and the call fails with HTTP 422. Agents could create snippets/skills (string fields) but never a real **tool** record.

### Changes
- **`POST /tools/add_code`** — takes the Python source as a JSON `code` string (plus optional `selected_func` / `update` / `module_name`) and reuses `add_tool_from_python`'s docstring extraction + registration. Works over MCP.
- **Curate the MCP surface** — pass `exclude_operations` to `FastApiMCP` to drop the endpoints that require a file upload and therefore can't be MCP tools: `create_tool`, `add_tool_from_python`, `restore_all_data`. The REST endpoints are unchanged; they're just no longer offered as (always-failing) MCP tools.

### Testing
In-process tests for `/tools/add_code`: extracts the manifest from the docstring and persists the string as the module file; honors `module_name`; requires `code` (422 otherwise). **3 passing.**