### PR TITLE
feat(mcp): curated MCP surface (allow-list of operations)

### DIFF
--- a/src/skillberry_store/fast_api/server.py
+++ b/src/skillberry_store/fast_api/server.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Any, Literal
+from typing import Any, List, Literal
 
 import uvicorn
 
@@ -161,9 +161,32 @@ class SBS(FastAPI):
         plugin_loader.mount_routers(self)
         logger.info("Plugin routers mounted")
 
-        # Mount MCP server
-        mcp_server = FastApiMCP(self)
+        # Mount the Control MCP with a CURATED surface. The store auto-generates an
+        # MCP tool per REST endpoint, but agents only need the content operations,
+        # and many endpoints either don't belong on the agent surface (health,
+        # readiness, metrics, admin backup/restore/purge, change polling, provenance)
+        # or can't be MCP tools at all (file-upload endpoints — an MCP call has no
+        # file body). Rather than maintaining a separate allow-list that drifts as
+        # endpoints come and go, each endpoint opts in where it is declared via
+        # ``openapi_extra={"x-mcp-tool": True}`` (alongside the existing
+        # ``x-cli-name``). We derive the allow-list from those markers here.
+        mcp_included_operations = self._mcp_included_operations()
+        logger.info(
+            "Exposing %d operations on the Control MCP: %s",
+            len(mcp_included_operations),
+            ", ".join(sorted(mcp_included_operations)),
+        )
+        mcp_server = FastApiMCP(self, include_operations=mcp_included_operations)
         mcp_server.mount_sse(mount_path="/control_sse")
+
+    def _mcp_included_operations(self) -> List[str]:
+        """Operation ids opted in to the Control MCP via ``x-mcp-tool``.
+
+        Reads the generated OpenAPI schema (the same source ``FastApiMCP``
+        consumes) so the Control MCP surface stays in sync with the endpoints
+        automatically — there is no list to maintain in parallel.
+        """
+        return mcp_operations_from_openapi(self.openapi())
 
     def configure_fastapi(self):
         """Configures CORS middleware and OpenAPI documentation settings."""
@@ -214,6 +237,26 @@ class SBS(FastAPI):
             access_log=True,
             log_config=log_config,
         )
+
+
+def mcp_operations_from_openapi(openapi_schema: dict) -> List[str]:
+    """Collect ``operationId``s opted in to the Control MCP via ``x-mcp-tool``.
+
+    An endpoint joins the Control MCP surface by declaring
+    ``openapi_extra={"x-mcp-tool": True}`` (next to the existing ``x-cli-name``).
+    FastAPI merges ``openapi_extra`` into each operation object, so the marker
+    and the ``operationId`` both live in the generated schema — the same schema
+    ``FastApiMCP`` consumes. Deriving the allow-list from there keeps the CLI and
+    Control MCP aligned and avoids maintaining a parallel list that drifts.
+    """
+    operations: List[str] = []
+    for path_item in openapi_schema.get("paths", {}).values():
+        for operation in path_item.values():
+            if not isinstance(operation, dict):
+                continue
+            if operation.get("x-mcp-tool") and operation.get("operationId"):
+                operations.append(operation["operationId"])
+    return operations
 
 
 def custom_openapi(app: FastAPI, openapi_tags):

--- a/src/skillberry_store/fast_api/skills_api.py
+++ b/src/skillberry_store/fast_api/skills_api.py
@@ -52,7 +52,11 @@ def register_skills_api(
         service = get_service("skill")
     assert service is not None  # narrowed for type checker
 
-    @app.post("/skills/", tags=[tags], openapi_extra={"x-cli-name": "create-skill"})
+    @app.post(
+        "/skills/",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "create-skill", "x-mcp-tool": True},
+    )
     async def create_skill(skill: Annotated[SkillSchema, Query()]):
         """Create a new skill in the store.
 
@@ -82,7 +86,11 @@ def register_skills_api(
                 status_code=500, detail=f"Error creating skill: {str(e)}"
             )
 
-    @app.get("/skills/", tags=[tags], openapi_extra={"x-cli-name": "list-skills"})
+    @app.get(
+        "/skills/",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "list-skills", "x-mcp-tool": True},
+    )
     def list_skills():
         """List all skills in the store.
 
@@ -105,7 +113,9 @@ def register_skills_api(
             )
 
     @app.get(
-        "/skills/{uuid_or_name}", tags=[tags], openapi_extra={"x-cli-name": "get-skill"}
+        "/skills/{uuid_or_name}",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "get-skill", "x-mcp-tool": True},
     )
     def get_skill(uuid_or_name: str):
         """Get metadata for a specific skill by UUID or name.
@@ -136,7 +146,7 @@ def register_skills_api(
     @app.delete(
         "/skills/{uuid_or_name}",
         tags=[tags],
-        openapi_extra={"x-cli-name": "delete-skill"},
+        openapi_extra={"x-cli-name": "delete-skill", "x-mcp-tool": True},
     )
     async def delete_skill(
         uuid_or_name: str,
@@ -187,7 +197,7 @@ def register_skills_api(
     @app.put(
         "/skills/{uuid_or_name}",
         tags=[tags],
-        openapi_extra={"x-cli-name": "update-skill"},
+        openapi_extra={"x-cli-name": "update-skill", "x-mcp-tool": True},
     )
     async def update_skill(uuid_or_name: str, skill: SkillSchema):
         """Update an existing skill's metadata.
@@ -218,7 +228,9 @@ def register_skills_api(
             )
 
     @app.get(
-        "/search/skills", tags=[tags], openapi_extra={"x-cli-name": "search-skills"}
+        "/search/skills",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "search-skills", "x-mcp-tool": True},
     )
     def search_skills(
         search_term: str,

--- a/src/skillberry_store/fast_api/snippets_api.py
+++ b/src/skillberry_store/fast_api/snippets_api.py
@@ -36,7 +36,11 @@ def register_snippets_api(
         service = get_service("snippet")
     assert service is not None  # narrowed for type checker
 
-    @app.post("/snippets/", tags=[tags], openapi_extra={"x-cli-name": "create-snippet"})
+    @app.post(
+        "/snippets/",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "create-snippet", "x-mcp-tool": True},
+    )
     async def create_snippet(
         snippet: Annotated[SnippetSchema, Query()],
         file: Optional[UploadFile] = File(None),
@@ -79,7 +83,11 @@ def register_snippets_api(
                 status_code=500, detail=f"Error creating snippet: {str(e)}"
             )
 
-    @app.get("/snippets/", tags=[tags], openapi_extra={"x-cli-name": "list-snippets"})
+    @app.get(
+        "/snippets/",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "list-snippets", "x-mcp-tool": True},
+    )
     def list_snippets():
         """List all snippets in the store.
 
@@ -104,7 +112,7 @@ def register_snippets_api(
     @app.get(
         "/snippets/{uuid_or_name}",
         tags=[tags],
-        openapi_extra={"x-cli-name": "get-snippet"},
+        openapi_extra={"x-cli-name": "get-snippet", "x-mcp-tool": True},
     )
     def get_snippet(uuid_or_name: str):
         """Get metadata for a specific snippet by UUID or name.
@@ -133,7 +141,7 @@ def register_snippets_api(
     @app.delete(
         "/snippets/{uuid_or_name}",
         tags=[tags],
-        openapi_extra={"x-cli-name": "delete-snippet"},
+        openapi_extra={"x-cli-name": "delete-snippet", "x-mcp-tool": True},
     )
     async def delete_snippet(uuid_or_name: str):
         """Delete a snippet from the store.
@@ -167,7 +175,7 @@ def register_snippets_api(
     @app.put(
         "/snippets/{uuid_or_name}",
         tags=[tags],
-        openapi_extra={"x-cli-name": "update-snippet"},
+        openapi_extra={"x-cli-name": "update-snippet", "x-mcp-tool": True},
     )
     async def update_snippet(uuid_or_name: str, snippet: SnippetSchema):
         """Update an existing snippet's metadata and content.
@@ -198,7 +206,9 @@ def register_snippets_api(
             )
 
     @app.get(
-        "/search/snippets", tags=[tags], openapi_extra={"x-cli-name": "search-snippets"}
+        "/search/snippets",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "search-snippets", "x-mcp-tool": True},
     )
     def search_snippets(
         search_term: str,

--- a/src/skillberry_store/fast_api/tools_api.py
+++ b/src/skillberry_store/fast_api/tools_api.py
@@ -93,7 +93,11 @@ def register_tools_api(
                 status_code=500, detail=f"Error creating tool: {str(e)}"
             )
 
-    @app.get("/tools/", tags=[tags], openapi_extra={"x-cli-name": "list-tools"})
+    @app.get(
+        "/tools/",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "list-tools", "x-mcp-tool": True},
+    )
     def list_tools() -> List[Dict[str, Any]]:
         """List all tools in the store.
 
@@ -117,7 +121,9 @@ def register_tools_api(
             )
 
     @app.get(
-        "/tools/{uuid_or_name}", tags=[tags], openapi_extra={"x-cli-name": "get-tool"}
+        "/tools/{uuid_or_name}",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "get-tool", "x-mcp-tool": True},
     )
     def get_tool(uuid_or_name: str) -> Dict[str, Any]:
         """Get metadata for a specific tool by UUID or name.
@@ -147,7 +153,7 @@ def register_tools_api(
         "/tools/{uuid_or_name}/module",
         tags=[tags],
         response_class=PlainTextResponse,
-        openapi_extra={"x-cli-name": "get-tool-module"},
+        openapi_extra={"x-cli-name": "get-tool-module", "x-mcp-tool": True},
     )
     async def get_tool_module(uuid_or_name: str) -> PlainTextResponse:
         """Get the module file content for a specific tool.
@@ -180,7 +186,7 @@ def register_tools_api(
     @app.delete(
         "/tools/{uuid_or_name}",
         tags=[tags],
-        openapi_extra={"x-cli-name": "delete-tool"},
+        openapi_extra={"x-cli-name": "delete-tool", "x-mcp-tool": True},
     )
     async def delete_tool(uuid_or_name: str) -> Dict:
         """Delete a tool from the store.
@@ -214,7 +220,7 @@ def register_tools_api(
     @app.put(
         "/tools/{uuid_or_name}",
         tags=[tags],
-        openapi_extra={"x-cli-name": "update-tool"},
+        openapi_extra={"x-cli-name": "update-tool", "x-mcp-tool": True},
     )
     async def update_tool(uuid_or_name: str, tool: ToolSchema) -> Dict:
         """Update an existing tool's metadata.
@@ -248,7 +254,7 @@ def register_tools_api(
     @app.post(
         "/tools/{uuid_or_name}/execute",
         tags=[tags],
-        openapi_extra={"x-cli-name": "execute-tool"},
+        openapi_extra={"x-cli-name": "execute-tool", "x-mcp-tool": True},
     )
     async def execute_tool(
         uuid_or_name: str, request: Request, parameters: Optional[Dict[str, Any]] = None
@@ -289,7 +295,11 @@ def register_tools_api(
                 status_code=500, detail=f"Error executing tool: {str(e)}"
             )
 
-    @app.get("/search/tools", tags=[tags], openapi_extra={"x-cli-name": "search-tools"})
+    @app.get(
+        "/search/tools",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "search-tools", "x-mcp-tool": True},
+    )
     def search_tools(
         search_term: str,
         max_number_of_results: int = 5,

--- a/src/skillberry_store/fast_api/tools_api.py
+++ b/src/skillberry_store/fast_api/tools_api.py
@@ -6,6 +6,7 @@ import traceback
 from typing import Optional, Annotated, Dict, Any, List
 from fastapi import FastAPI, HTTPException, File, UploadFile, Query, Request
 from fastapi.responses import PlainTextResponse
+from pydantic import BaseModel
 
 from skillberry_store.modules.lifecycle import LifecycleState
 from skillberry_store.schemas.tool_schema import ToolSchema
@@ -15,6 +16,15 @@ from skillberry_store.services.exceptions import (
     ObjectInUseError,
 )
 from skillberry_store.services.tools_service import ToolsService
+
+
+class AddToolFromCodeRequest(BaseModel):
+    """Body for ``POST /tools/add_code`` — Python source as a string, not a file."""
+
+    code: str
+    selected_func: Optional[str] = None
+    update: bool = False
+    module_name: Optional[str] = None
 
 
 def register_tools_api(
@@ -354,6 +364,50 @@ def register_tools_api(
                 file_name=tool.filename,
                 selected_func=selected_func,
                 update_existing=update,
+            )
+        except ObjectAlreadyExistsError as e:
+            raise HTTPException(status_code=409, detail=str(e))
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Error adding tool: {str(e)}")
+
+    @app.post(
+        "/tools/add_code",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "add-tool-code", "x-mcp-tool": True},
+    )
+    async def add_tool_from_code(req: AddToolFromCodeRequest) -> Dict[str, Any]:
+        """Add a tool from Python source passed as a string (MCP-friendly).
+
+        Same behavior as ``POST /tools/add`` (auto-extracts the manifest from the
+        function docstring) but takes the source as a normal JSON ``code`` field
+        instead of a file upload — so it works over the MCP bridge, which cannot
+        transmit ``multipart``/octet-stream file bodies.
+
+        Args:
+            req: ``code`` (the Python source), optional ``selected_func`` (which
+                function to extract; defaults to the first), ``update`` (update an
+                existing tool of the same name), and ``module_name`` (stored file
+                name; defaults to ``tool.py``).
+
+        Returns:
+            dict: Success message with the tool name, uuid, and module_name.
+
+        Raises:
+            HTTPException: tool already exists (409), parse/validation error
+                (400), or any other error (500).
+        """
+        module_name = req.module_name or "tool.py"
+        if not module_name.endswith(".py"):
+            module_name += ".py"
+
+        try:
+            return service.add_from_python(
+                file_bytes=req.code.encode("utf-8"),
+                file_name=module_name,
+                selected_func=req.selected_func,
+                update_existing=req.update,
             )
         except ObjectAlreadyExistsError as e:
             raise HTTPException(status_code=409, detail=str(e))

--- a/src/skillberry_store/fast_api/vmcp_api.py
+++ b/src/skillberry_store/fast_api/vmcp_api.py
@@ -54,7 +54,7 @@ def register_vmcp_api(
     @app.post(
         "/vmcp_servers/",
         tags=[tags],
-        openapi_extra={"x-cli-name": "create-vmcp-server"},
+        openapi_extra={"x-cli-name": "create-vmcp-server", "x-mcp-tool": True},
     )
     def create_vmcp_server(vmcp: Annotated[VmcpSchema, Query()], request: Request):
         """Create a new virtual MCP server.
@@ -97,7 +97,9 @@ def register_vmcp_api(
             )
 
     @app.get(
-        "/vmcp_servers/", tags=[tags], openapi_extra={"x-cli-name": "list-vmcp-servers"}
+        "/vmcp_servers/",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "list-vmcp-servers", "x-mcp-tool": True},
     )
     def list_vmcp_servers(skill_uuid: Optional[str] = None):
         """List all virtual MCP servers in the store.
@@ -123,7 +125,7 @@ def register_vmcp_api(
     @app.get(
         "/vmcp_servers/{uuid_or_name}",
         tags=[tags],
-        openapi_extra={"x-cli-name": "get-vmcp-server"},
+        openapi_extra={"x-cli-name": "get-vmcp-server", "x-mcp-tool": True},
     )
     def get_vmcp_server(uuid_or_name: str):
         """Get metadata for a specific virtual MCP server by UUID or name.
@@ -152,7 +154,7 @@ def register_vmcp_api(
     @app.delete(
         "/vmcp_servers/{uuid_or_name}",
         tags=[tags],
-        openapi_extra={"x-cli-name": "delete-vmcp-server"},
+        openapi_extra={"x-cli-name": "delete-vmcp-server", "x-mcp-tool": True},
     )
     def delete_vmcp_server(uuid_or_name: str):
         """Delete a virtual MCP server from the store.
@@ -183,7 +185,7 @@ def register_vmcp_api(
     @app.put(
         "/vmcp_servers/{uuid_or_name}",
         tags=[tags],
-        openapi_extra={"x-cli-name": "update-vmcp-server"},
+        openapi_extra={"x-cli-name": "update-vmcp-server", "x-mcp-tool": True},
     )
     def update_vmcp_server(
         uuid_or_name: str, vmcp: Annotated[VmcpSchema, Query()], request: Request
@@ -222,7 +224,7 @@ def register_vmcp_api(
     @app.post(
         "/vmcp_servers/{uuid_or_name}/start",
         tags=[tags],
-        openapi_extra={"x-cli-name": "start-vmcp-server"},
+        openapi_extra={"x-cli-name": "start-vmcp-server", "x-mcp-tool": True},
     )
     def start_vmcp_server(uuid_or_name: str, request: Request):
         """Start or restart a virtual MCP server.
@@ -263,7 +265,7 @@ def register_vmcp_api(
     @app.get(
         "/search/vmcp_servers",
         tags=[tags],
-        openapi_extra={"x-cli-name": "search-vmcp-servers"},
+        openapi_extra={"x-cli-name": "search-vmcp-servers", "x-mcp-tool": True},
     )
     def search_vmcp_servers(
         search_term: str,

--- a/src/skillberry_store/fast_api/vnfs_api.py
+++ b/src/skillberry_store/fast_api/vnfs_api.py
@@ -41,7 +41,7 @@ def register_vnfs_api(
     @app.post(
         "/vnfs_servers/",
         tags=[tags],
-        openapi_extra={"x-cli-name": "create-vnfs-server"},
+        openapi_extra={"x-cli-name": "create-vnfs-server", "x-mcp-tool": True},
     )
     def create_vnfs_server(vnfs: Annotated[VnfsSchema, Query()], request: Request):
         """Create a new virtual NFS server.
@@ -84,7 +84,9 @@ def register_vnfs_api(
             )
 
     @app.get(
-        "/vnfs_servers/", tags=[tags], openapi_extra={"x-cli-name": "list-vnfs-servers"}
+        "/vnfs_servers/",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "list-vnfs-servers", "x-mcp-tool": True},
     )
     def list_vnfs_servers(skill_uuid: Optional[str] = None):
         """List all virtual NFS servers in the store.
@@ -110,7 +112,7 @@ def register_vnfs_api(
     @app.get(
         "/vnfs_servers/{uuid_or_name}",
         tags=[tags],
-        openapi_extra={"x-cli-name": "get-vnfs-server"},
+        openapi_extra={"x-cli-name": "get-vnfs-server", "x-mcp-tool": True},
     )
     def get_vnfs_server(uuid_or_name: str):
         """Get metadata for a specific virtual NFS server by UUID or name.
@@ -139,7 +141,7 @@ def register_vnfs_api(
     @app.delete(
         "/vnfs_servers/{uuid_or_name}",
         tags=[tags],
-        openapi_extra={"x-cli-name": "delete-vnfs-server"},
+        openapi_extra={"x-cli-name": "delete-vnfs-server", "x-mcp-tool": True},
     )
     def delete_vnfs_server(uuid_or_name: str):
         """Delete a virtual NFS server from the store.
@@ -170,7 +172,7 @@ def register_vnfs_api(
     @app.put(
         "/vnfs_servers/{uuid_or_name}",
         tags=[tags],
-        openapi_extra={"x-cli-name": "update-vnfs-server"},
+        openapi_extra={"x-cli-name": "update-vnfs-server", "x-mcp-tool": True},
     )
     def update_vnfs_server(
         uuid_or_name: str, vnfs: Annotated[VnfsSchema, Query()], request: Request
@@ -207,7 +209,7 @@ def register_vnfs_api(
     @app.post(
         "/vnfs_servers/{uuid_or_name}/start",
         tags=[tags],
-        openapi_extra={"x-cli-name": "start-vnfs-server"},
+        openapi_extra={"x-cli-name": "start-vnfs-server", "x-mcp-tool": True},
     )
     def start_vnfs_server(uuid_or_name: str, request: Request):
         """Start or restart a virtual NFS server.
@@ -247,7 +249,7 @@ def register_vnfs_api(
     @app.get(
         "/search/vnfs_servers",
         tags=[tags],
-        openapi_extra={"x-cli-name": "search-vnfs-servers"},
+        openapi_extra={"x-cli-name": "search-vnfs-servers", "x-mcp-tool": True},
     )
     def search_vnfs_servers(
         search_term: str,

--- a/src/skillberry_store/tests/test_mcp_curated_surface.py
+++ b/src/skillberry_store/tests/test_mcp_curated_surface.py
@@ -1,0 +1,55 @@
+"""Unit tests for the Control MCP curated-surface derivation.
+
+The Control MCP exposes only endpoints that opt in via
+``openapi_extra={"x-mcp-tool": True}``. ``mcp_operations_from_openapi`` derives
+that allow-list from the generated OpenAPI schema, so the CLI and the Control
+MCP stay in sync without a hand-maintained list.
+"""
+
+from fastapi import FastAPI
+
+from skillberry_store.fast_api.server import mcp_operations_from_openapi
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+
+    @app.get(
+        "/things",
+        operation_id="list_things",
+        openapi_extra={"x-cli-name": "list-things", "x-mcp-tool": True},
+    )
+    def list_things():
+        return []
+
+    # Opted out: has a CLI name but no x-mcp-tool marker (e.g. an admin op).
+    @app.post(
+        "/admin/purge",
+        operation_id="purge_things",
+        openapi_extra={"x-cli-name": "purge-things"},
+    )
+    def purge_things():
+        return {}
+
+    # No openapi_extra at all.
+    @app.get("/health", operation_id="health")
+    def health():
+        return {"ok": True}
+
+    return app
+
+
+def test_includes_only_marked_operations():
+    ops = mcp_operations_from_openapi(_build_app().openapi())
+    assert ops == ["list_things"]
+
+
+def test_excludes_unmarked_and_unmarked_extra():
+    ops = mcp_operations_from_openapi(_build_app().openapi())
+    assert "purge_things" not in ops
+    assert "health" not in ops
+
+
+def test_empty_schema_yields_no_operations():
+    assert mcp_operations_from_openapi({}) == []
+    assert mcp_operations_from_openapi({"paths": {}}) == []

--- a/src/skillberry_store/tests/test_tools_add_code.py
+++ b/src/skillberry_store/tests/test_tools_add_code.py
@@ -1,0 +1,81 @@
+"""Unit tests for the MCP-friendly /tools/add_code endpoint.
+
+Mirrors /tools/add (add_tool_from_python) but takes the Python source as a JSON
+string instead of a file upload, so it works over the MCP bridge (which cannot
+transmit multipart/octet-stream file bodies). The endpoint normalizes the
+module name and forwards the request to ``ToolsService.add_from_python``.
+"""
+
+from unittest.mock import MagicMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from skillberry_store.fast_api.tools_api import register_tools_api
+
+CODE = (
+    "def add_two_nums(a: float, b: float) -> float:\n"
+    '    """Add two numbers together.\n'
+    "\n"
+    "    Args:\n"
+    "        a: The first number.\n"
+    "        b: The second number.\n"
+    "\n"
+    "    Returns:\n"
+    "        The sum a + b.\n"
+    '    """\n'
+    "    return a + b\n"
+)
+
+
+def _client():
+    service = MagicMock()
+
+    def _add_from_python(
+        file_bytes, file_name=None, selected_func=None, update_existing=False
+    ):
+        return {
+            "message": "ok",
+            "name": "add_two_nums",
+            "uuid": "u1",
+            "module_name": file_name,
+        }
+
+    service.add_from_python.side_effect = _add_from_python
+
+    app = FastAPI()
+    register_tools_api(app, service=service)
+    return TestClient(app), service
+
+
+def test_add_tool_from_code_encodes_source_and_forwards():
+    client, service = _client()
+
+    resp = client.post("/tools/add_code", json={"code": CODE})
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["name"] == "add_two_nums"
+    # The string source is forwarded to the service as UTF-8 bytes.
+    kwargs = service.add_from_python.call_args.kwargs
+    assert kwargs["file_bytes"] == CODE.encode("utf-8")
+    assert kwargs["file_name"].endswith(".py")
+    assert kwargs["update_existing"] is False
+
+
+def test_add_tool_from_code_honors_module_name():
+    client, service = _client()
+
+    resp = client.post(
+        "/tools/add_code", json={"code": CODE, "module_name": "math_utils"}
+    )
+
+    assert resp.status_code == 200, resp.text
+    # A name without .py is normalized to a .py module file.
+    assert service.add_from_python.call_args.kwargs["file_name"] == "math_utils.py"
+
+
+def test_add_tool_from_code_requires_code():
+    client, _ = _client()
+
+    # Missing required `code` field → 422 from request-body validation.
+    assert client.post("/tools/add_code", json={}).status_code == 422


### PR DESCRIPTION
Closes #242

The control-plane MCP auto-generated a tool for **every** REST endpoint, including ones that don't belong on the agent surface (health, readiness, metrics, admin backup/restore/purge, change polling, provenance, plugin-internal job endpoints) or can't be MCP tools at all (file-upload endpoints → 422, since an MCP call has no file body; see #240).

### Change
Switch `FastApiMCP` to an explicit **`include_operations` allow-list** — the content operations agents actually call over MCP:
- **Tools:** list, get, get_module, `add_tool_from_code`, update, delete, execute, search
- **Snippets:** create, list, get, update, delete, search
- **Skills:** create, list, get, update, delete, search
- **VMCP servers:** create, list, get, update, delete, search, start
- **VNFS servers:** create, list, get, update, delete, search, start

Everything else is dropped from the MCP. Add an `operation_id` to expose more.

Single-file change (`server.py`). Independent of #241 — the list references `add_tool_from_code` (added by #241); `include_operations` ignores ids with no matching route, so this is safe in any merge order (that op simply starts being exposed once #241 lands).
