### PR TITLE
fix(simulate): retry harness startup on RemoteProtocolError

### DIFF
--- a/plugins/skillberry-plugin-simulate/src/skillberry_plugin_simulate/harness_client.py
+++ b/plugins/skillberry-plugin-simulate/src/skillberry_plugin_simulate/harness_client.py
@@ -43,7 +43,16 @@ class HarnessClient:
                     SIM_PATH, json={"openapi_spec": openapi_spec, "mcp_port": mcp_port}
                 )
                 break
-            except (httpx.ConnectError, httpx.ConnectTimeout, httpx.ReadError) as exc:
+            except (
+                httpx.ConnectError,
+                httpx.ConnectTimeout,
+                httpx.ReadError,
+                # Docker publishes the port before uvicorn binds inside the
+                # container; the proxy accepts the connection then closes it
+                # without a response ("Server disconnected..."). This is startup
+                # lag, not a hard failure, so retry it like the others.
+                httpx.RemoteProtocolError,
+            ) as exc:
                 if attempt == startup_retries:
                     raise HarnessError(
                         f"create_simulation: harness not reachable after "

--- a/plugins/skillberry-plugin-simulate/tests/test_harness_client.py
+++ b/plugins/skillberry-plugin-simulate/tests/test_harness_client.py
@@ -82,6 +82,26 @@ async def test_create_simulation_retries_on_connect_error():
 
 
 @pytest.mark.asyncio
+async def test_create_simulation_retries_on_remote_protocol_error():
+    """Docker publishes the port before uvicorn binds; the proxy accepts then
+    drops the connection, surfacing as RemoteProtocolError. This is startup lag
+    and must be retried, not raised."""
+    calls = {"n": 0}
+
+    def handler(request):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise httpx.RemoteProtocolError(
+                "Server disconnected without sending a response."
+            )
+        return httpx.Response(202, json={"status": "pending"})
+
+    hc = HarnessClient(_client(handler))
+    await hc.create_simulation({"openapi": "3.0.3"}, mcp_port=8701, startup_delay=0)
+    assert calls["n"] == 2
+
+
+@pytest.mark.asyncio
 async def test_create_simulation_raises_after_all_retries():
     def handler(request):
         raise httpx.ConnectError("still not ready")


### PR DESCRIPTION
Fixes #246.

## Problem

Simulate jobs intermittently fail with:

```
ERROR - simulate job <id> failed: Server disconnected without sending a response.
```

`create_simulation()` retries the initial spec POST to absorb harness startup lag, but only caught `(httpx.ConnectError, httpx.ConnectTimeout, httpx.ReadError)`. On Docker (notably WSL2), docker-proxy accepts the TCP connection the instant the container exists — before uvicorn inside binds to `:8086` — then closes it without a response. httpx raises `httpx.RemoteProtocolError`, a **sibling** of those three (all under `TransportError`), so it slipped past the retry loop and propagated raw to the job handler.

See #246 for the full evidence chain.

## Fix

Add `httpx.RemoteProtocolError` to the retried startup exceptions. A genuine harness crash now exhausts the retries into the clear `HarnessError "not reachable after N retries"` (and the container is torn down) instead of the cryptic raw message.

## Testing

- Added `test_create_simulation_retries_on_remote_protocol_error`, which reproduces the exact failure (raises `RemoteProtocolError` on the first POST, then succeeds) — fails before the fix, passes after.
- Full plugin suite: **62 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)