### PR TITLE
feat(ui): make Vite dev server allowedHosts configurable

### DIFF
--- a/src/skillberry_store/ui/.env.example
+++ b/src/skillberry_store/ui/.env.example
@@ -5,3 +5,13 @@ VITE_UI_PORT=8002
 
 # Backend API URL (default: http://localhost:8000)
 VITE_API_URL=http://localhost:8000
+
+# Hosts the Vite dev server accepts in the Host header (default: localhost only).
+# Required when the UI is reached through a reverse proxy / gateway under a
+# different hostname, otherwise Vite rejects the request with
+# "Blocked request. This host is not allowed."
+#   unset            -> localhost only (default, most secure)
+#   true / all / *   -> allow any host (use behind a trusted gateway)
+#   host1,host2      -> explicit allow-list
+# Example:
+# VITE_ALLOWED_HOSTS=skillberry-store.localtest.me

--- a/src/skillberry_store/ui/vite.config.js
+++ b/src/skillberry_store/ui/vite.config.js
@@ -1,6 +1,21 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
+// Parse the VITE_ALLOWED_HOSTS env var into Vite's server.allowedHosts value.
+// Unset  -> undefined (Vite default: only localhost is allowed).
+// "true"/"all"/"*" -> true (allow any host; useful behind a trusted gateway).
+// "a,b"  -> ["a", "b"] (explicit allow-list).
+function parseAllowedHosts(value) {
+    if (!value)
+        return undefined;
+    var trimmed = value.trim();
+    if (trimmed === 'true' || trimmed === 'all' || trimmed === '*')
+        return true;
+    return trimmed
+        .split(',')
+        .map(function (host) { return host.trim(); })
+        .filter(Boolean);
+}
 // https://vitejs.dev/config/
 export default defineConfig({
     plugins: [react()],
@@ -11,6 +26,7 @@ export default defineConfig({
     },
     server: {
         port: parseInt(process.env.VITE_UI_PORT || '8002'),
+        allowedHosts: parseAllowedHosts(process.env.VITE_ALLOWED_HOSTS),
         proxy: {
             '/api': {
                 target: process.env.VITE_API_URL || 'http://localhost:8000',

--- a/src/skillberry_store/ui/vite.config.ts
+++ b/src/skillberry_store/ui/vite.config.ts
@@ -2,6 +2,20 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 
+// Parse the VITE_ALLOWED_HOSTS env var into Vite's server.allowedHosts value.
+// Unset  -> undefined (Vite default: only localhost is allowed).
+// "true"/"all"/"*" -> true (allow any host; useful behind a trusted gateway).
+// "a,b"  -> ["a", "b"] (explicit allow-list).
+function parseAllowedHosts(value?: string): true | string[] | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  if (trimmed === 'true' || trimmed === 'all' || trimmed === '*') return true;
+  return trimmed
+    .split(',')
+    .map((host) => host.trim())
+    .filter(Boolean);
+}
+
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
@@ -12,6 +26,7 @@ export default defineConfig({
   },
   server: {
     port: parseInt(process.env.VITE_UI_PORT || '8002'),
+    allowedHosts: parseAllowedHosts(process.env.VITE_ALLOWED_HOSTS),
     proxy: {
       '/api': {
         target: process.env.VITE_API_URL || 'http://localhost:8000',


### PR DESCRIPTION
## Summary

The store UI is served by the Vite **dev server** (`UIManager` runs `npx vite --host 0.0.0.0`). Since Vite 5.4.12 the dev server rejects requests whose `Host` header is not in `server.allowedHosts`:

> Blocked request. This host is not allowed. To allow this host, add it to `server.allowedHosts` in vite.config.js.

This makes the UI unreachable through a reverse proxy / gateway under a non-localhost hostname — e.g. when skillberry-store is deployed in-cluster (Kubernetes) and exposed via an ingress gateway at `skillberry-store.<domain>`.

## Change

Add an optional `VITE_ALLOWED_HOSTS` env var, read by `vite.config`:

| Value | Behavior |
|-------|----------|
| _unset_ | Vite default — localhost only (**unchanged**) |
| `true` / `all` / `*` | allow any host (use behind a trusted gateway) |
| `host1,host2` | explicit allow-list |

Updated both `vite.config.ts` and the emitted `vite.config.js` (Vite resolves the `.js` first, so it must match), and documented the variable in `.env.example`. **Default behavior is unchanged** — the check still applies unless the operator opts in.

## Motivation

Enables the Kagenti platform to deploy skillberry-store in-cluster and expose its UI through the shared gateway by setting `VITE_ALLOWED_HOSTS=skillberry-store.<domain>` on the pod.

## Testing

- `node --check vite.config.js` passes.
- Default (unset) path returns `undefined`, preserving current behavior; `true`/`all`/`*` map to `true`; comma lists map to an array.

Assisted-By: Claude Code

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>