### PR TITLE
Split API and Logic - All Object Services

### DIFF
--- a/src/skillberry_store/fast_api/server.py
+++ b/src/skillberry_store/fast_api/server.py
@@ -101,41 +101,30 @@ class SBS(FastAPI):
         self.state.vmcp_descriptions = vmcp_descriptions_api(self.settings.sbs_vdb)
         self.state.vnfs_descriptions = vnfs_descriptions_api(self.settings.sbs_vdb)
 
-        # Initialize service layer
-        from skillberry_store.modules.object_handler import get_object_handler
+        # Initialize service layer (singletons in services.registry)
         from skillberry_store.modules.vnfs_server_manager import VirtualNfsServerManager
         from skillberry_store.modules.vmcp_server_manager import VirtualMcpServerManager
-        from skillberry_store.services.tools_service import ToolsService
-        from skillberry_store.services.skills_service import SkillsService
-        from skillberry_store.services.snippets_service import SnippetsService
-        from skillberry_store.services.vnfs_service import VnfsService
-        from skillberry_store.services.vmcp_service import VmcpService
+        from skillberry_store.services.registry import (
+            initialize_services,
+            get_service,
+        )
 
         sts_url = f"http://{self.settings.sbs_host}:{self.settings.sbs_port}"
 
-        tools_service = ToolsService(
-            get_object_handler("tool"), self.state.tools_descriptions
+        initialize_services(
+            tools_descriptions=self.state.tools_descriptions,
+            snippets_descriptions=self.state.snippets_descriptions,
+            skills_descriptions=self.state.skills_descriptions,
+            vmcp_descriptions=self.state.vmcp_descriptions,
+            vnfs_descriptions=self.state.vnfs_descriptions,
+            vmcp_server_manager=VirtualMcpServerManager(sts_url=sts_url, app=self),
+            vnfs_server_manager=VirtualNfsServerManager(sts_url=sts_url, app=self),
         )
-        skills_service = SkillsService(
-            handler=get_object_handler("skill"),
-            tools_handler=get_object_handler("tool"),
-            snippets_handler=get_object_handler("snippet"),
-            descriptions=self.state.skills_descriptions,
-        )
-        snippets_service = SnippetsService(
-            get_object_handler("snippet"), self.state.snippets_descriptions
-        )
-        vnfs_service = VnfsService(
-            get_object_handler("vnfs"),
-            VirtualNfsServerManager(sts_url=sts_url, app=self),
-            self.state.vnfs_descriptions,
-        )
-        vmcp_service = VmcpService(
-            get_object_handler("vmcp"),
-            VirtualMcpServerManager(sts_url=sts_url, app=self),
-            get_object_handler("skill"),
-            self.state.vmcp_descriptions,
-        )
+        tools_service = get_service("tool")
+        skills_service = get_service("skill")
+        snippets_service = get_service("snippet")
+        vnfs_service = get_service("vnfs")
+        vmcp_service = get_service("vmcp")
 
         # Initialize plugin system
         from skillberry_store.plugins.loader import PluginLoader
@@ -159,34 +148,27 @@ class SBS(FastAPI):
 
         register_vmcp_api(
             self,
-            sts_url=sts_url,
             tags="vmcp_servers",
-            vmcp_descriptions=self.state.vmcp_descriptions,
             service=vmcp_service,
         )
         register_vnfs_api(
             self,
-            sts_url=sts_url,
             tags="vnfs_servers",
-            vnfs_descriptions=self.state.vnfs_descriptions,
             service=vnfs_service,
         )
         register_skills_api(
             self,
             tags="skills",
-            skills_descriptions=self.state.skills_descriptions,
             service=skills_service,
         )
         register_snippets_api(
             self,
             tags="snippets",
-            snippets_descriptions=self.state.snippets_descriptions,
             service=snippets_service,
         )
         register_tools_api(
             self,
             tags="tools",
-            tools_descriptions=self.state.tools_descriptions,
             service=tools_service,
         )
         register_admin_api(self, tags="admin")

--- a/src/skillberry_store/fast_api/skills_api.py
+++ b/src/skillberry_store/fast_api/skills_api.py
@@ -2,11 +2,8 @@
 
 from __future__ import annotations
 
-import json
 import logging
-import uuid
-from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Optional, Annotated, List, Dict, Any
+from typing import Optional, Annotated, List, Any
 from fastapi import FastAPI, HTTPException, Query, UploadFile, File, Form, Header
 from fastapi.responses import Response
 from prometheus_client import Counter
@@ -16,35 +13,10 @@ from skillberry_store.plugins.events import (
     emit_content_deleted,
 )
 
-from skillberry_store.tools.anthropic.importer import (
-    import_from_anthropic_skill,
-    parse_github_origin,
-)
-from skillberry_store.tools.endpoint_auth import (
-    resolve_auth_headers,
-    ReauthRequired,
-)
-from skillberry_store.modules.object_handler import get_object_handler
-from skillberry_store.modules.file_executor import detect_tool_dependencies
+from skillberry_store.tools.endpoint_auth import ReauthRequired
 from skillberry_store.modules.lifecycle import LifecycleState
 from skillberry_store.schemas.skill_schema import SkillSchema
-from skillberry_store.schemas.manifest_schema import ManifestState
-from skillberry_store.tools.anthropic.exporter import export_skill_to_anthropic_format
-from skillberry_store.tools.configure import (
-    get_files_directory_path,
-    get_skills_directory,
-    get_tools_directory,
-    get_snippets_directory,
-    is_auto_detect_dependencies_enabled,
-)
-from skillberry_store.fast_api.search_filters import apply_search_filters
-from skillberry_store.utils.utils import normalize_uuid, generate_or_validate_uuid
 from skillberry_store.services.skills_service import SkillsService
-from skillberry_store.services.tools_service import ToolsService
-from skillberry_store.services.snippets_service import SnippetsService
-
-if TYPE_CHECKING:
-    from skillberry_store.modules.description import Description
 
 logger = logging.getLogger(__name__)
 
@@ -93,7 +65,6 @@ def _auth_exception_to_http(exc: ReauthRequired) -> HTTPException:
 def register_skills_api(
     app: FastAPI,
     tags: str = "skills",
-    skills_descriptions: Optional[Description] = None,
     service: Optional[SkillsService] = None,
 ):
     """Register skills API endpoints with the FastAPI application.
@@ -101,74 +72,14 @@ def register_skills_api(
     Args:
         app: The FastAPI application instance.
         tags: FastAPI tags for grouping the endpoints in documentation.
-        skills_descriptions: Description instance for managing skill descriptions.
-        service: Optional SkillsService instance; created from default handlers if not provided.
+        service: Optional SkillsService instance. When ``None``, the singleton
+            from :func:`skillberry_store.services.registry.get_service` is used.
     """
     if service is None:
-        service = SkillsService(
-            handler=get_object_handler("skill"),
-            tools_handler=get_object_handler("tool"),
-            snippets_handler=get_object_handler("snippet"),
-            descriptions=skills_descriptions,
-        )
-    # expose handlers for Anthropic import/export endpoints below
-    skill_handler = service.handler
-    tools_handler = service.tools_handler
-    snippets_handler = service.snippets_handler
-    # descriptions=None: description file cleanup is skipped for cascade-deleted items (best-effort)
-    tools_service = ToolsService(handler=tools_handler)
-    snippets_service = SnippetsService(handler=snippets_handler)
+        from skillberry_store.services.registry import get_service
 
-    def populate_skill_objects(skill_dict):
-        """Populate full tool and snippet objects from UUIDs in a skill dictionary.
-
-        Resolves tool_uuids and snippet_uuids to their full manifest objects and
-        adds them as 'tools' and 'snippets' lists in the skill dictionary.
-
-        Args:
-            skill_dict: Skill dictionary containing tool_uuids and snippet_uuids.
-
-        Returns:
-            dict: The same skill_dict with 'tools' and 'snippets' lists populated.
-
-        Raises:
-            HTTPException: 505 if any referenced tool or snippet is missing or invalid.
-        """
-        # Populate tools - resolve and get resources (will raise 404 if any missing)
-        if "tool_uuids" in skill_dict and skill_dict["tool_uuids"]:
-            try:
-                # This will raise HTTPException if any UUID is invalid or not found
-                tools = tools_handler.read_dicts(skill_dict["tool_uuids"])
-                skill_dict["tools"] = tools
-            except HTTPException as e:
-                logger.error(
-                    f"Skill '{skill_dict['name']}' references missing or invalid tools"
-                )
-                raise HTTPException(
-                    status_code=505,
-                    detail=f"Skill '{skill_dict['name']}' references missing or invalid tools: {e.detail}",
-                )
-        else:
-            skill_dict["tools"] = []
-
-        # Populate snippets - resolve and get resources (will raise 404 if any missing)
-        if "snippet_uuids" in skill_dict and skill_dict["snippet_uuids"]:
-            try:
-                # This will raise HTTPException if any UUID is invalid or not found
-                snippets = snippets_handler.read_dicts(skill_dict["snippet_uuids"])
-                skill_dict["snippets"] = snippets
-            except HTTPException as e:
-                logger.error(
-                    f"Skill '{skill_dict['name']}' references missing or invalid snippets"
-                )
-                raise HTTPException(
-                    status_code=505,
-                    detail=f"Skill '{skill_dict['name']}' references missing or invalid snippets: {e.detail}",
-                )
-        else:
-            skill_dict["snippets"] = []
-
-        return skill_dict
+        service = get_service("skill")
+    assert service is not None  # narrowed for type checker
 
     @app.post("/skills/", tags=[tags], openapi_extra={"x-cli-name": "create-skill"})
     async def create_skill(skill: Annotated[SkillSchema, Query()]):
@@ -297,46 +208,16 @@ def register_skills_api(
         try:
             skill = service.get(uuid_or_name)
             skill_uuid = skill["uuid"]
-            deleted_tools: list = []
-            deleted_snippets: list = []
-
-            if delete_tools or delete_snippets:
-                all_skills = service.handler.list_all_dicts()
-                shared_tool_uuids: set = set()
-                shared_snippet_uuids: set = set()
-                for s in all_skills:
-                    if s.get("uuid") != skill_uuid:
-                        shared_tool_uuids.update(s.get("tool_uuids") or [])
-                        shared_snippet_uuids.update(s.get("snippet_uuids") or [])
-
-                if delete_tools:
-                    for tool_uuid in skill.get("tool_uuids") or []:
-                        if tool_uuid not in shared_tool_uuids:
-                            try:
-                                tools_service.delete(tool_uuid)
-                                deleted_tools.append(tool_uuid)
-                            except Exception as e:
-                                logger.warning(
-                                    f"Could not cascade-delete tool {tool_uuid}: {e}"
-                                )
-
-                if delete_snippets:
-                    for snippet_uuid in skill.get("snippet_uuids") or []:
-                        if snippet_uuid not in shared_snippet_uuids:
-                            try:
-                                snippets_service.delete(snippet_uuid)
-                                deleted_snippets.append(snippet_uuid)
-                            except Exception as e:
-                                logger.warning(
-                                    f"Could not cascade-delete snippet {snippet_uuid}: {e}"
-                                )
-
-            service.delete(uuid_or_name)
+            cascade = service.delete(
+                uuid_or_name,
+                delete_tools=delete_tools,
+                delete_snippets=delete_snippets,
+            )
             emit_content_deleted("skill", skill_uuid)
             return {
                 "message": f"Skill with UUID or name '{uuid_or_name}' deleted successfully.",
-                "deleted_tools": deleted_tools,
-                "deleted_snippets": deleted_snippets,
+                "deleted_tools": cascade.get("deleted_tools", []),
+                "deleted_snippets": cascade.get("deleted_snippets", []),
             }
         except KeyError as e:
             raise HTTPException(status_code=404, detail=str(e))
@@ -409,47 +290,16 @@ def register_skills_api(
         """
         logger.info(f"Request to search skill descriptions for term: {search_term}")
         search_skills_counter.inc()
-        if not skills_descriptions:
-            raise HTTPException(
-                status_code=503,
-                detail="Skill search is not available - descriptions not initialized",
-            )
         try:
-            matched_entities = skills_descriptions.search_description(
-                search_term=search_term, k=max_number_of_results
-            )
-            filtered_matched_entities = [
-                m
-                for m in matched_entities
-                if float(m["similarity_score"]) <= similarity_threshold
-            ]
-            skills_to_filter = []
-            for matched_entity in filtered_matched_entities:
-                skill_uuid = matched_entity.get("filename")
-                if not skill_uuid:
-                    continue
-                try:
-                    skill_dict = skill_handler.read_dict(skill_uuid)
-                    skill_dict["similarity_score"] = matched_entity.get(
-                        "similarity_score", 0.0
-                    )
-                    skills_to_filter.append(skill_dict)
-                except Exception as e:
-                    logger.warning(f"Could not load skill {skill_uuid}: {e}")
-            filtered_skills = apply_search_filters(
-                skills_to_filter,
+            return service.search(
+                search_term=search_term,
+                max_number_of_results=max_number_of_results,
+                similarity_threshold=similarity_threshold,
                 manifest_filter=manifest_filter,
                 lifecycle_state=lifecycle_state,
             )
-            filtered_skills.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
-            return [
-                {
-                    "filename": s.get("name", ""),
-                    "similarity_score": s.get("similarity_score", 0.0),
-                }
-                for s in filtered_skills
-                if s.get("name")
-            ]
+        except RuntimeError as e:
+            raise HTTPException(status_code=503, detail=str(e))
         except Exception as e:
             logger.error(f"Error searching skills: {e}")
             raise HTTPException(
@@ -484,154 +334,28 @@ def register_skills_api(
         Raises:
             HTTPException: If detection fails
         """
+        from skillberry_store.services.skills_service import GithubApiError
+
         logger.info(f"Request to detect Anthropic skills from {source_type}")
-
         try:
-            import os
-            import requests
-            import re
-
-            skill_paths = []
-
-            if source_type == "url":
-                if not github_url:
-                    raise HTTPException(
-                        status_code=400,
-                        detail="github_url is required for source_type='url'",
-                    )
-
-                # Resolve per-endpoint auth once for the requested URL. Raises
-                # ReauthRequired -> turned into a 401 below.
-                try:
-                    auth_headers = resolve_auth_headers(
-                        github_url,
-                        override_token=x_endpoint_token,
-                        anonymous=anonymous,
-                    )
-                except ReauthRequired as e:
-                    raise _auth_exception_to_http(e)
-
-                # Convert GitHub URL to API URL
-                api_url = github_url.replace("github.com", "api.github.com/repos")
-                api_url = re.sub(r"/tree/(main|master)/", r"/contents/", api_url)
-
-                logger.info(f"Fetching directory listing from: {api_url}")
-
-                # Fetch directory contents
-                response = requests.get(api_url, headers=auth_headers, timeout=30)
-                if not response.ok:
-                    raise HTTPException(
-                        status_code=response.status_code,
-                        detail=f"GitHub API error: {response.text or response.reason}",
-                    )
-
-                items = response.json()
-
-                # Check each subdirectory for SKILL.md
-                for item in items:
-                    if item["type"] == "dir":
-                        dir_name = item["name"]
-                        # Check if this directory contains SKILL.md
-                        dir_api_url = item["url"]
-                        try:
-                            dir_response = requests.get(
-                                dir_api_url, headers=auth_headers, timeout=30
-                            )
-                            if dir_response.ok:
-                                dir_items = dir_response.json()
-                                has_skill_md = any(
-                                    f["name"].upper() == "SKILL.MD"
-                                    and f["type"] == "file"
-                                    for f in dir_items
-                                )
-                                if has_skill_md:
-                                    skill_paths.append(dir_name)
-                                    logger.info(f"Found skill directory: {dir_name}")
-                        except Exception as e:
-                            logger.warning(f"Failed to check directory {dir_name}: {e}")
-
-            elif source_type == "folder":
-                if not folder_path:
-                    raise HTTPException(
-                        status_code=400,
-                        detail="folder_path is required for source_type='folder'",
-                    )
-
-                # Build safe_root from non-tainted components only.
-                # os.path.basename() is CodeQL's recognised py/path-injection
-                # sanitiser: each path segment from user input is stripped of
-                # directory separators before being joined with the fixed
-                # home-dir anchor.  This prevents path traversal and keeps all
-                # filesystem operations below free of user-controlled taint.
-                home_dir = os.path.realpath(os.path.expanduser("~"))
-                abs_input = os.path.realpath(folder_path)
-                if not (
-                    abs_input == home_dir or abs_input.startswith(home_dir + os.sep)
-                ):
-                    raise HTTPException(
-                        status_code=400,
-                        detail=(
-                            "folder_path must be within the current user's"
-                            " home directory"
-                        ),
-                    )
-                if abs_input == home_dir:
-                    safe_root = home_dir
-                else:
-                    rel = abs_input[len(home_dir) + len(os.sep) :]
-                    clean_parts = [os.path.basename(p) for p in rel.split(os.sep) if p]
-                    safe_root = os.path.join(home_dir, *clean_parts)
-
-                if not os.path.exists(safe_root):
-                    raise HTTPException(
-                        status_code=400,
-                        detail="Folder does not exist",
-                    )
-
-                if not os.path.isdir(safe_root):
-                    raise HTTPException(
-                        status_code=400,
-                        detail="Path is not a directory",
-                    )
-
-                # List subdirectories
-                try:
-                    for entry in os.listdir(safe_root):  # lgtm[py/path-injection]
-                        # Only accept plain directory names (no separators or
-                        # traversal) and confine the join to the sanitized root.
-                        if entry != os.path.basename(entry):
-                            continue
-                        entry_path = os.path.join(safe_root, entry)
-                        if os.path.realpath(entry_path).startswith(
-                            safe_root + os.sep
-                        ) and os.path.isdir(entry_path):
-                            # Check if this directory contains SKILL.md
-                            skill_md_path = os.path.join(entry_path, "SKILL.md")
-                            if os.path.isfile(skill_md_path):
-                                skill_paths.append(entry)
-                                logger.info(f"Found skill directory: {entry}")
-                except HTTPException:
-                    raise
-                except Exception as e:
-                    raise HTTPException(
-                        status_code=500,
-                        detail=f"Error reading directory: {str(e)}",
-                    )
-            else:
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"Invalid source_type: {source_type}. Must be 'url' or 'folder'",
-                )
-
-            logger.info(f"Detected {len(skill_paths)} skill directories")
+            skill_paths = service.detect_anthropic_skills(
+                source_type=source_type,
+                github_url=github_url,
+                folder_path=folder_path,
+                override_token=x_endpoint_token,
+                anonymous=anonymous,
+            )
             return {
                 "success": True,
                 "skill_paths": skill_paths,
                 "total": len(skill_paths),
             }
-
-        except HTTPException:
-            raise
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+        except ReauthRequired as e:
+            raise _auth_exception_to_http(e)
+        except GithubApiError as e:
+            raise HTTPException(status_code=e.status_code, detail=e.message)
         except Exception as e:
             logger.error(f"Error detecting Anthropic skills: {e}")
             raise HTTPException(
@@ -672,269 +396,68 @@ def register_skills_api(
             HTTPException: If import fails
         """
         logger.info(f"Request to import Anthropic skill from {source_type}")
-
-        try:
-            # Prepare source data based on type
-            source_data = None
-            if source_type == "url":
-                if not github_url:
-                    raise HTTPException(
-                        status_code=400,
-                        detail="github_url is required for source_type='url'",
-                    )
-                source_data = github_url
-            elif source_type == "zip":
-                if not zip_file:
-                    raise HTTPException(
-                        status_code=400,
-                        detail="zip_file is required for source_type='zip'",
-                    )
-                source_data = await zip_file.read()
-            elif source_type == "folder":
-                if not folder_path:
-                    raise HTTPException(
-                        status_code=400,
-                        detail="folder_path is required for source_type='folder'",
-                    )
-                source_data = folder_path
-            else:
+        # Validate inputs and convert UploadFile to bytes at the API boundary.
+        if source_type == "url":
+            if not github_url:
                 raise HTTPException(
                     status_code=400,
-                    detail=f"Invalid source_type: {source_type}. Must be 'url', 'zip', or 'folder'",
+                    detail="github_url is required for source_type='url'",
                 )
-
-            # Import the skill
-            try:
-                skill_name, skill_description, tools, snippets, ignored_files = (
-                    import_from_anthropic_skill(
-                        source_type=source_type,
-                        source_data=source_data,
-                        snippet_mode=snippet_mode,
-                        treat_all_as_documents=treat_all_as_documents,
-                        override_token=x_endpoint_token,
-                        anonymous=anonymous,
-                    )
+            source_data: Any = github_url
+        elif source_type == "zip":
+            if not zip_file:
+                raise HTTPException(
+                    status_code=400,
+                    detail="zip_file is required for source_type='zip'",
                 )
-            except ReauthRequired as e:
-                # Endpoint needs interactive auth: surface login details as 401.
-                raise _auth_exception_to_http(e)
-
-            # Create tools
-            created_tool_uuids = []
-            # First pass: collect all tool names for dependency detection
-            all_tool_names = {}
-
-            # Set tool UUIDs prior to creation to avoid failed lookups on tool name
-            for tool in tools:
-                tool.uuid = generate_or_validate_uuid(None)
-                created_tool_uuids.append(tool.uuid)
-                all_tool_names[tool.name] = tool.uuid
-
-            # Get list of available tools (existing + being imported)
-            existing_tools = tools_handler.get_existing_names()
-            available_tools = existing_tools | all_tool_names.keys()
-
-            # Import timestamp
-            current_time = datetime.now(timezone.utc).isoformat()
-
-            for tool in tools:
-                try:
-                    tool_dict = tool.to_dict()
-                    tool_uuid = tool.uuid
-                    tool_name = tool_dict["name"]
-
-                    # Prepare tool data
-                    ext = (
-                        ".py" if tool_dict["programmingLanguage"] == "python" else ".sh"
-                    )
-                    module_filename = f"{tool_name}{ext}"
-
-                    # Add additional tags to tool tags
-                    tool_tags = tool_dict["tags"].copy() if tool_dict["tags"] else []
-                    for tag in tags:
-                        if tag and tag not in tool_tags:
-                            tool_tags.append(tag)
-
-                    # Determine correct parent for this tool becoming HEAD
-                    tool_parent = tools_handler.get_cache_parent_for_head(
-                        tool_uuid, tool_name
-                    )
-                    logger.info(
-                        f"Setting parent for tool '{tool_name}' to {tool_parent}"
-                    )
-
-                    tool_data = {
-                        "uuid": tool_uuid,
-                        "name": tool_name,
-                        "version": tool_dict["version"],
-                        "description": tool_dict["description"],
-                        "tags": tool_tags,
-                        "programming_language": tool_dict["programmingLanguage"],
-                        "module_name": module_filename,
-                        "packaging_format": "code",
-                        "state": "approved",
-                        "created_at": current_time,
-                        "modified_at": current_time,
-                        "parent": tool_parent,
-                    }
-
-                    if "params" in tool_dict and tool_dict["params"]:
-                        tool_data["params"] = tool_dict["params"]
-                    if "returns" in tool_dict and tool_dict["returns"]:
-                        tool_data["returns"] = tool_dict["returns"]
-
-                    # Auto-detect dependencies for Python tools if enabled
-                    if (
-                        tool_dict["programmingLanguage"] == "python"
-                        and is_auto_detect_dependencies_enabled()
-                    ):
-                        try:
-                            # Detect dependencies from code
-                            detected_dep_names = detect_tool_dependencies(
-                                tool_dict["moduleContent"], tool_name, available_tools
-                            )
-                            if detected_dep_names:
-                                detected_deps = [
-                                    (
-                                        all_tool_names.get(m)
-                                        if m in all_tool_names
-                                        else tools_handler.name_to_uuid(m)
-                                    )
-                                    for m in detected_dep_names
-                                ]
-                                tool_data["dependencies"] = detected_deps
-                                logger.info(
-                                    f"Auto-detected dependencies for '{tool_name}': {detected_deps}"
-                                )
-                        except Exception as e:
-                            logger.warning(
-                                f"Failed to auto-detect dependencies for {tool_name}: {e}"
-                            )
-
-                    # Save tool dict to UUID subfolder
-                    tools_handler.write_dict(tool_uuid, tool_data)
-
-                    # Update cache after create
-                    tools_handler.update_cache(tool_uuid, new_name=tool_name)
-
-                    # Save tool module to UUID subfolder
-                    tools_handler.write_file(
-                        tool_uuid, module_filename, tool_dict["moduleContent"]
-                    )
-
-                    logger.info(f"Created tool: {tool_name}")
-                except Exception as e:
-                    logger.error(f"Failed to create tool {tool.name}: {e}")
-
-            # Create snippets
-            created_snippet_uuids = []
-            for snippet in snippets:
-                try:
-                    snippet_dict = snippet.to_dict()
-                    snippet_uuid = generate_or_validate_uuid(None)
-                    snippet_name = snippet_dict["name"]
-
-                    # Add additional tags to snippet tags
-                    snippet_tags = (
-                        snippet_dict["tags"].copy() if snippet_dict["tags"] else []
-                    )
-                    for tag in tags:
-                        if tag and tag not in snippet_tags:
-                            snippet_tags.append(tag)
-
-                    # Determine correct parent for this snippet becoming HEAD
-                    snippet_parent = snippets_handler.get_cache_parent_for_head(
-                        snippet_uuid, snippet_name
-                    )
-                    logger.info(
-                        f"Setting parent for snippet '{snippet_name}' to {snippet_parent}"
-                    )
-
-                    # Prepare snippet data
-                    snippet_data = {
-                        "uuid": snippet_uuid,
-                        "name": snippet_name,
-                        "version": snippet_dict["version"],
-                        "description": snippet_dict["description"],
-                        "content": snippet_dict["content"],
-                        "tags": snippet_tags,
-                        "content_type": "text/plain",
-                        "state": "approved",
-                        "created_at": current_time,
-                        "modified_at": current_time,
-                        "parent": snippet_parent,
-                    }
-
-                    # Save snippet dict to UUID subfolder
-                    snippets_handler.write_dict(snippet_uuid, snippet_data)
-
-                    # Update cache after create
-                    snippets_handler.update_cache(snippet_uuid, new_name=snippet_name)
-
-                    created_snippet_uuids.append(snippet_uuid)
-                    logger.info(f"Created snippet: {snippet_name}")
-                except Exception as e:
-                    logger.error(f"Failed to create snippet {snippet.name}: {e}")
-
-            skill_tags = ["anthropic", "imported"]
-            for tag in tags:
-                if tag and tag not in skill_tags:
-                    skill_tags.append(tag)
-
-            # Record the skill's origin so it can be looked up / re-checked later
-            # by the provenance plugin (drift detection needs this baseline).
-            # Only URL imports have a remote origin; zip/folder imports do not.
-            skill_extra: Dict[str, Any] = {}
-            if source_type == "url" and github_url:
-                origin = parse_github_origin(github_url)
-                skill_extra["origin"] = {
-                    "type": "github" if origin else "url",
-                    "url": github_url,
-                    **(origin or {}),
-                }
-
-            # Prepare skill schema with UUID (either existing or None for new)
-            skill_schema = SkillSchema(
-                uuid=None,
-                name=skill_name,
-                version="1.0.0",
-                description=skill_description,
-                tags=skill_tags,
-                tool_uuids=created_tool_uuids,
-                snippet_uuids=created_snippet_uuids,
-                state=ManifestState.APPROVED,
-                parent=None,  # Will be set by create_skill if name exists
-                extra=skill_extra,
+            source_data = await zip_file.read()
+        elif source_type == "folder":
+            if not folder_path:
+                raise HTTPException(
+                    status_code=400,
+                    detail="folder_path is required for source_type='folder'",
+                )
+            source_data = folder_path
+        else:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid source_type: {source_type}. Must be 'url', 'zip', or 'folder'",
             )
 
-            # Create new skill
-            logger.info(f"Creating new skill '{skill_name}'...")
-            result = await create_skill(skill_schema)
-            skill_uuid = result.get("uuid")
-            action = "created"
-
-            logger.info(
-                f"Successfully imported Anthropic skill: {skill_name} ({action})"
+        try:
+            result = service.import_anthropic(
+                source_type=source_type,
+                source_data=source_data,
+                snippet_mode=snippet_mode,
+                treat_all_as_documents=treat_all_as_documents,
+                tags=tags,
+                override_token=x_endpoint_token,
+                anonymous=anonymous,
+                github_url=github_url,
             )
-
-            return {
-                "success": True,
-                "message": f"Successfully imported Anthropic skill '{skill_name}' ({action})",
-                "skill_name": skill_name,
-                "skill_uuid": skill_uuid,
-                "action": action,
-                "tools_created": len(created_tool_uuids),
-                "snippets_created": len(created_snippet_uuids),
-                "ignored_files": ignored_files,
-            }
-
-        except HTTPException:
-            raise
+        except ReauthRequired as e:
+            raise _auth_exception_to_http(e)
         except Exception as e:
             logger.error(f"Error importing Anthropic skill: {e}")
             raise HTTPException(
                 status_code=500, detail=f"Error importing Anthropic skill: {str(e)}"
             )
+
+        skill_uuid = result.get("skill_uuid")
+        if skill_uuid:
+            emit_content_added("skill", skill_uuid)
+        skill_name = result.get("skill_name")
+        logger.info(f"Successfully imported Anthropic skill: {skill_name}")
+        return {
+            "success": True,
+            "message": f"Successfully imported Anthropic skill '{skill_name}' (created)",
+            "skill_name": skill_name,
+            "skill_uuid": skill_uuid,
+            "action": "created",
+            "tools_created": result.get("tools_created", 0),
+            "snippets_created": result.get("snippets_created", 0),
+            "ignored_files": result.get("ignored_files", []),
+        }
 
     @app.get(
         "/skills/{uuid_or_name}/export-anthropic",
@@ -954,62 +477,10 @@ def register_skills_api(
             HTTPException: If skill not found or export fails
         """
         logger.info(f"Request to export skill to Anthropic format: {uuid_or_name}")
-
         try:
-            # Resolve UUID or name to UUID and read manifest
-            skill_uuid = skill_handler.resolve_to_uuid_or_error(uuid_or_name)
-            skill_dict = skill_handler.read_dict(skill_uuid)
-
-            # Get tools using read_manifests
-            tools = []
-            tool_modules = {}
-            if "tool_uuids" in skill_dict and skill_dict["tool_uuids"]:
-                tools = tools_handler.read_dicts(skill_dict["tool_uuids"])
-                # Get tool modules
-                for tool_dict in tools:
-                    tool_uuid = tool_dict.get("uuid")
-                    tool_name = tool_dict["name"]
-                    module_name = tool_dict.get("module_name")
-                    if tool_uuid and module_name:
-                        try:
-                            module_content = tools_handler.read_file(
-                                tool_uuid, module_name, raw_content=True
-                            )
-                            if isinstance(module_content, str):
-                                tool_modules[tool_name] = module_content
-                        except Exception as e:
-                            logger.warning(
-                                f"Could not read module for tool {tool_name}: {e}"
-                            )
-
-            # Get snippets using read_manifests
-            snippets = []
-            if "snippet_uuids" in skill_dict and skill_dict["snippet_uuids"]:
-                snippets = snippets_handler.read_dicts(skill_dict["snippet_uuids"])
-
-            # Export to Anthropic format
-            zip_content = export_skill_to_anthropic_format(
-                skill=skill_dict,
-                tools=tools,
-                snippets=snippets,
-                tool_modules=tool_modules,
-            )
-
-            logger.info(
-                f"Successfully exported skill '{uuid_or_name}' to Anthropic format"
-            )
-
-            # Return as downloadable ZIP file
-            return Response(
-                content=zip_content,
-                media_type="application/zip",
-                headers={
-                    "Content-Disposition": f'attachment; filename="{uuid_or_name}.zip"'
-                },
-            )
-
-        except HTTPException:
-            raise
+            zip_content = service.export_anthropic(uuid_or_name)
+        except KeyError as e:
+            raise HTTPException(status_code=404, detail=str(e))
         except Exception as e:
             logger.error(
                 f"Error exporting skill '{uuid_or_name}' to Anthropic format: {e}"
@@ -1017,3 +488,13 @@ def register_skills_api(
             raise HTTPException(
                 status_code=500, detail=f"Error exporting skill: {str(e)}"
             )
+        logger.info(
+            f"Successfully exported skill '{uuid_or_name}' to Anthropic format"
+        )
+        return Response(
+            content=zip_content,
+            media_type="application/zip",
+            headers={
+                "Content-Disposition": f'attachment; filename="{uuid_or_name}.zip"'
+            },
+        )

--- a/src/skillberry_store/fast_api/skills_api.py
+++ b/src/skillberry_store/fast_api/skills_api.py
@@ -2,44 +2,14 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Optional, Annotated, List, Any
 from fastapi import FastAPI, HTTPException, Query, UploadFile, File, Form, Header
 from fastapi.responses import Response
-from prometheus_client import Counter
-from skillberry_store.plugins.events import (
-    emit_content_added,
-    emit_content_updated,
-    emit_content_deleted,
-)
 
 from skillberry_store.tools.endpoint_auth import ReauthRequired
 from skillberry_store.modules.lifecycle import LifecycleState
 from skillberry_store.schemas.skill_schema import SkillSchema
 from skillberry_store.services.skills_service import SkillsService
-
-logger = logging.getLogger(__name__)
-
-# observability - metrics
-prom_prefix = "sts_fastapi_skills_"
-create_skill_counter = Counter(
-    f"{prom_prefix}create_skill_counter", "Count number of skill create operations"
-)
-list_skills_counter = Counter(
-    f"{prom_prefix}list_skills_counter", "Count number of skill list operations"
-)
-get_skill_counter = Counter(
-    f"{prom_prefix}get_skill_counter", "Count number of skill get operations"
-)
-delete_skill_counter = Counter(
-    f"{prom_prefix}delete_skill_counter", "Count number of skill delete operations"
-)
-update_skill_counter = Counter(
-    f"{prom_prefix}update_skill_counter", "Count number of skill update operations"
-)
-search_skills_counter = Counter(
-    f"{prom_prefix}search_skills_counter", "Count number of skill search operations"
-)
 
 
 def _auth_exception_to_http(exc: ReauthRequired) -> HTTPException:
@@ -97,11 +67,8 @@ def register_skills_api(
         Raises:
             HTTPException: 409 if skill already exists, 500 for other errors.
         """
-        logger.info(f"Request to create skill: {skill.name}")
-        create_skill_counter.inc()
         try:
             result = service.create(skill.to_dict())
-            emit_content_added("skill", result["uuid"])
             return {
                 "message": f"Skill '{result['name']}' created successfully.",
                 "name": result["name"],
@@ -110,7 +77,6 @@ def register_skills_api(
         except ValueError as e:
             raise HTTPException(status_code=409, detail=str(e))
         except Exception as e:
-            logger.error(f"Error creating skill '{skill.name}': {e}")
             raise HTTPException(
                 status_code=500, detail=f"Error creating skill: {str(e)}"
             )
@@ -130,12 +96,9 @@ def register_skills_api(
         Raises:
             HTTPException: 500 if listing fails.
         """
-        logger.info("Request to list skills")
-        list_skills_counter.inc()
         try:
             return service.list_all()
         except Exception as e:
-            logger.error(f"Error listing skills: {e}")
             raise HTTPException(
                 status_code=500, detail=f"Error listing skills: {str(e)}"
             )
@@ -158,8 +121,6 @@ def register_skills_api(
         Raises:
             HTTPException: 404 if skill not found, 505 if referenced resources are invalid, 500 for other errors.
         """
-        logger.info(f"Request to get skill: {uuid_or_name}")
-        get_skill_counter.inc()
         try:
             return service.get(uuid_or_name)
         except KeyError as e:
@@ -167,7 +128,6 @@ def register_skills_api(
         except RuntimeError as e:
             raise HTTPException(status_code=505, detail=str(e))
         except Exception as e:
-            logger.error(f"Error retrieving skill '{uuid_or_name}': {e}")
             raise HTTPException(
                 status_code=500, detail=f"Error retrieving skill: {str(e)}"
             )
@@ -203,15 +163,12 @@ def register_skills_api(
         Raises:
             HTTPException: 404 if skill not found, 500 for other errors.
         """
-        logger.info(f"Request to delete skill: {uuid_or_name}")
-        delete_skill_counter.inc()
         try:
             cascade = service.delete(
                 uuid_or_name,
                 delete_tools=delete_tools,
                 delete_snippets=delete_snippets,
             )
-            emit_content_deleted("skill", cascade["uuid"])
             return {
                 "message": f"Skill with UUID or name '{uuid_or_name}' deleted successfully.",
                 "deleted_tools": cascade.get("deleted_tools", []),
@@ -220,7 +177,6 @@ def register_skills_api(
         except KeyError as e:
             raise HTTPException(status_code=404, detail=str(e))
         except Exception as e:
-            logger.error(f"Error deleting skill '{uuid_or_name}': {e}")
             raise HTTPException(
                 status_code=500, detail=f"Error deleting skill: {str(e)}"
             )
@@ -246,18 +202,14 @@ def register_skills_api(
         Raises:
             HTTPException: 404 if skill not found, 500 for other errors.
         """
-        logger.info(f"Request to update skill: {uuid_or_name}")
-        update_skill_counter.inc()
         try:
-            result = service.update(uuid_or_name, skill.to_dict())
-            emit_content_updated("skill", result["uuid"])
+            service.update(uuid_or_name, skill.to_dict())
             return {
                 "message": f"Skill with UUID or name '{uuid_or_name}' updated successfully."
             }
         except KeyError as e:
             raise HTTPException(status_code=404, detail=str(e))
         except Exception as e:
-            logger.error(f"Error updating skill '{uuid_or_name}': {e}")
             raise HTTPException(
                 status_code=500, detail=f"Error updating skill: {str(e)}"
             )
@@ -286,8 +238,6 @@ def register_skills_api(
         Returns:
             list: A list of matched skill names and similarity scores.
         """
-        logger.info(f"Request to search skill descriptions for term: {search_term}")
-        search_skills_counter.inc()
         try:
             return service.search(
                 search_term=search_term,
@@ -299,7 +249,6 @@ def register_skills_api(
         except RuntimeError as e:
             raise HTTPException(status_code=503, detail=str(e))
         except Exception as e:
-            logger.error(f"Error searching skills: {e}")
             raise HTTPException(
                 status_code=500, detail=f"Error searching skills: {str(e)}"
             )
@@ -334,7 +283,6 @@ def register_skills_api(
         """
         from skillberry_store.services.skills_service import GithubApiError
 
-        logger.info(f"Request to detect Anthropic skills from {source_type}")
         try:
             skill_paths = service.detect_anthropic_skills(
                 source_type=source_type,
@@ -355,7 +303,6 @@ def register_skills_api(
         except GithubApiError as e:
             raise HTTPException(status_code=e.status_code, detail=e.message)
         except Exception as e:
-            logger.error(f"Error detecting Anthropic skills: {e}")
             raise HTTPException(
                 status_code=500,
                 detail=f"Error detecting skills: {str(e)}",
@@ -393,7 +340,6 @@ def register_skills_api(
         Raises:
             HTTPException: If import fails
         """
-        logger.info(f"Request to import Anthropic skill from {source_type}")
         # Convert the per-source-type input into a single ``source_data`` value
         # at the API boundary; the service validates ``source_type`` and the
         # presence of ``source_data``.
@@ -423,21 +369,16 @@ def register_skills_api(
         except ReauthRequired as e:
             raise _auth_exception_to_http(e)
         except Exception as e:
-            logger.error(f"Error importing Anthropic skill: {e}")
             raise HTTPException(
                 status_code=500, detail=f"Error importing Anthropic skill: {str(e)}"
             )
 
-        skill_uuid = result.get("skill_uuid")
-        if skill_uuid:
-            emit_content_added("skill", skill_uuid)
         skill_name = result.get("skill_name")
-        logger.info(f"Successfully imported Anthropic skill: {skill_name}")
         return {
             "success": True,
             "message": f"Successfully imported Anthropic skill '{skill_name}' (created)",
             "skill_name": skill_name,
-            "skill_uuid": skill_uuid,
+            "skill_uuid": result.get("skill_uuid"),
             "action": "created",
             "tools_created": result.get("tools_created", 0),
             "snippets_created": result.get("snippets_created", 0),
@@ -461,21 +402,14 @@ def register_skills_api(
         Raises:
             HTTPException: If skill not found or export fails
         """
-        logger.info(f"Request to export skill to Anthropic format: {uuid_or_name}")
         try:
             zip_content = service.export_anthropic(uuid_or_name)
         except KeyError as e:
             raise HTTPException(status_code=404, detail=str(e))
         except Exception as e:
-            logger.error(
-                f"Error exporting skill '{uuid_or_name}' to Anthropic format: {e}"
-            )
             raise HTTPException(
                 status_code=500, detail=f"Error exporting skill: {str(e)}"
             )
-        logger.info(
-            f"Successfully exported skill '{uuid_or_name}' to Anthropic format"
-        )
         return Response(
             content=zip_content,
             media_type="application/zip",

--- a/src/skillberry_store/fast_api/skills_api.py
+++ b/src/skillberry_store/fast_api/skills_api.py
@@ -206,14 +206,12 @@ def register_skills_api(
         logger.info(f"Request to delete skill: {uuid_or_name}")
         delete_skill_counter.inc()
         try:
-            skill = service.get(uuid_or_name)
-            skill_uuid = skill["uuid"]
             cascade = service.delete(
                 uuid_or_name,
                 delete_tools=delete_tools,
                 delete_snippets=delete_snippets,
             )
-            emit_content_deleted("skill", skill_uuid)
+            emit_content_deleted("skill", cascade["uuid"])
             return {
                 "message": f"Skill with UUID or name '{uuid_or_name}' deleted successfully.",
                 "deleted_tools": cascade.get("deleted_tools", []),
@@ -396,33 +394,18 @@ def register_skills_api(
             HTTPException: If import fails
         """
         logger.info(f"Request to import Anthropic skill from {source_type}")
-        # Validate inputs and convert UploadFile to bytes at the API boundary.
-        if source_type == "url":
-            if not github_url:
-                raise HTTPException(
-                    status_code=400,
-                    detail="github_url is required for source_type='url'",
-                )
-            source_data: Any = github_url
-        elif source_type == "zip":
-            if not zip_file:
-                raise HTTPException(
-                    status_code=400,
-                    detail="zip_file is required for source_type='zip'",
-                )
-            source_data = await zip_file.read()
+        # Convert the per-source-type input into a single ``source_data`` value
+        # at the API boundary; the service validates ``source_type`` and the
+        # presence of ``source_data``.
+        source_data: Any
+        if source_type == "zip":
+            source_data = await zip_file.read() if zip_file else None
+        elif source_type == "url":
+            source_data = github_url
         elif source_type == "folder":
-            if not folder_path:
-                raise HTTPException(
-                    status_code=400,
-                    detail="folder_path is required for source_type='folder'",
-                )
             source_data = folder_path
         else:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Invalid source_type: {source_type}. Must be 'url', 'zip', or 'folder'",
-            )
+            source_data = None
 
         try:
             result = service.import_anthropic(
@@ -435,6 +418,8 @@ def register_skills_api(
                 anonymous=anonymous,
                 github_url=github_url,
             )
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
         except ReauthRequired as e:
             raise _auth_exception_to_http(e)
         except Exception as e:

--- a/src/skillberry_store/fast_api/snippets_api.py
+++ b/src/skillberry_store/fast_api/snippets_api.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Optional, Annotated
+from typing import Optional, Annotated
 from fastapi import FastAPI, HTTPException, Query, File, UploadFile
 from prometheus_client import Counter
 from skillberry_store.plugins.events import (
@@ -13,11 +13,7 @@ from skillberry_store.plugins.events import (
 )
 from skillberry_store.modules.lifecycle import LifecycleState
 from skillberry_store.schemas.snippet_schema import SnippetSchema
-from skillberry_store.fast_api.search_filters import apply_search_filters
 from skillberry_store.services.snippets_service import SnippetsService
-
-if TYPE_CHECKING:
-    from skillberry_store.modules.description import Description
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +41,6 @@ search_snippets_counter = Counter(
 def register_snippets_api(
     app: FastAPI,
     tags: str = "snippets",
-    snippets_descriptions: Optional[Description] = None,
     service: Optional[SnippetsService] = None,
 ):
     """Register all snippets-related API endpoints with the FastAPI application.
@@ -56,16 +51,17 @@ def register_snippets_api(
     Args:
         app: The FastAPI application instance to register routes with.
         tags: OpenAPI tag for grouping these endpoints (default: "snippets").
-        snippets_descriptions: Optional Description instance for semantic search functionality.
-        service: Optional SnippetsService instance. If None, a new instance will be created.
+        service: Optional SnippetsService instance. When ``None``, the singleton
+            from :func:`skillberry_store.services.registry.get_service` is used.
 
     Returns:
         None. Endpoints are registered directly on the app instance.
     """
     if service is None:
-        from skillberry_store.modules.object_handler import get_object_handler
+        from skillberry_store.services.registry import get_service
 
-        service = SnippetsService(get_object_handler("snippet"), snippets_descriptions)
+        service = get_service("snippet")
+    assert service is not None  # narrowed for type checker
 
     @app.post("/snippets/", tags=[tags], openapi_extra={"x-cli-name": "create-snippet"})
     async def create_snippet(
@@ -276,44 +272,16 @@ def register_snippets_api(
         """
         logger.info(f"Request to search snippets for term: {search_term}")
         search_snippets_counter.inc()
-        if not snippets_descriptions:
-            raise HTTPException(
-                status_code=503, detail="Snippet search is not available"
-            )
         try:
-            matched = snippets_descriptions.search_description(
-                search_term=search_term, k=max_number_of_results
-            )
-            filtered = [
-                m
-                for m in matched
-                if float(m["similarity_score"]) <= similarity_threshold
-            ]
-            snippets_to_filter = []
-            for m in filtered:
-                name = m.get("filename") or m.get("name")
-                if not name:
-                    continue
-                try:
-                    d = service.get(name)
-                    d["similarity_score"] = m.get("similarity_score", 0.0)
-                    snippets_to_filter.append(d)
-                except Exception:
-                    pass
-            result_snippets = apply_search_filters(
-                snippets_to_filter,
+            return service.search(
+                search_term=search_term,
+                max_number_of_results=max_number_of_results,
+                similarity_threshold=similarity_threshold,
                 manifest_filter=manifest_filter,
                 lifecycle_state=lifecycle_state,
             )
-            result_snippets.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
-            return [
-                {
-                    "filename": s.get("name", ""),
-                    "similarity_score": s.get("similarity_score", 0.0),
-                }
-                for s in result_snippets
-                if s.get("name")
-            ]
+        except RuntimeError as e:
+            raise HTTPException(status_code=503, detail=str(e))
         except Exception as e:
             logger.error(f"Error searching snippets: {e}")
             raise HTTPException(

--- a/src/skillberry_store/fast_api/snippets_api.py
+++ b/src/skillberry_store/fast_api/snippets_api.py
@@ -2,40 +2,12 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Optional, Annotated
 from fastapi import FastAPI, HTTPException, Query, File, UploadFile
-from prometheus_client import Counter
-from skillberry_store.plugins.events import (
-    emit_content_added,
-    emit_content_updated,
-    emit_content_deleted,
-)
+
 from skillberry_store.modules.lifecycle import LifecycleState
 from skillberry_store.schemas.snippet_schema import SnippetSchema
 from skillberry_store.services.snippets_service import SnippetsService
-
-logger = logging.getLogger(__name__)
-
-prom_prefix = "sts_fastapi_snippets_"
-create_snippet_counter = Counter(
-    f"{prom_prefix}create_snippet_counter", "Count number of snippet create operations"
-)
-list_snippets_counter = Counter(
-    f"{prom_prefix}list_snippets_counter", "Count number of snippet list operations"
-)
-get_snippet_counter = Counter(
-    f"{prom_prefix}get_snippet_counter", "Count number of snippet get operations"
-)
-delete_snippet_counter = Counter(
-    f"{prom_prefix}delete_snippet_counter", "Count number of snippet delete operations"
-)
-update_snippet_counter = Counter(
-    f"{prom_prefix}update_snippet_counter", "Count number of snippet update operations"
-)
-search_snippets_counter = Counter(
-    f"{prom_prefix}search_snippets_counter", "Count number of snippet search operations"
-)
 
 
 def register_snippets_api(
@@ -84,8 +56,6 @@ def register_snippets_api(
         Raises:
             HTTPException: 400 if file reading fails, 409 if snippet already exists, 500 for other errors.
         """
-        logger.info(f"Request to create snippet: {snippet.name}")
-        create_snippet_counter.inc()
         if file:
             try:
                 content_bytes = await file.read()
@@ -96,7 +66,6 @@ def register_snippets_api(
                 )
         try:
             result = service.create(snippet.to_dict())
-            emit_content_added("snippet", result["uuid"])
             return {
                 "message": f"Snippet '{result['name']}' created successfully.",
                 "name": result["name"],
@@ -105,7 +74,6 @@ def register_snippets_api(
         except ValueError as e:
             raise HTTPException(status_code=409, detail=str(e))
         except Exception as e:
-            logger.error(f"Error creating snippet '{snippet.name}': {e}")
             raise HTTPException(
                 status_code=500, detail=f"Error creating snippet: {str(e)}"
             )
@@ -125,12 +93,9 @@ def register_snippets_api(
         Raises:
             HTTPException: 500 if listing fails.
         """
-        logger.info("Request to list snippets")
-        list_snippets_counter.inc()
         try:
             return service.list_all()
         except Exception as e:
-            logger.error(f"Error listing snippets: {e}")
             raise HTTPException(
                 status_code=500, detail=f"Error listing snippets: {str(e)}"
             )
@@ -155,14 +120,11 @@ def register_snippets_api(
         Raises:
             HTTPException: 404 if snippet not found, 500 for other errors.
         """
-        logger.info(f"Request to get snippet: {uuid_or_name}")
-        get_snippet_counter.inc()
         try:
             return service.get(uuid_or_name)
         except KeyError as e:
             raise HTTPException(status_code=404, detail=str(e))
         except Exception as e:
-            logger.error(f"Error retrieving snippet '{uuid_or_name}': {e}")
             raise HTTPException(
                 status_code=500, detail=f"Error retrieving snippet: {str(e)}"
             )
@@ -187,18 +149,14 @@ def register_snippets_api(
         Raises:
             HTTPException: 404 if snippet not found, 500 for other errors.
         """
-        logger.info(f"Request to delete snippet: {uuid_or_name}")
-        delete_snippet_counter.inc()
         try:
-            result = service.delete(uuid_or_name)
-            emit_content_deleted("snippet", result["uuid"])
+            service.delete(uuid_or_name)
             return {
                 "message": f"Snippet with UUID or name '{uuid_or_name}' deleted successfully."
             }
         except KeyError as e:
             raise HTTPException(status_code=404, detail=str(e))
         except Exception as e:
-            logger.exception(f"Error deleting snippet '{uuid_or_name}': {e}")
             raise HTTPException(
                 status_code=500, detail=f"Error deleting snippet: {str(e)}"
             )
@@ -224,18 +182,14 @@ def register_snippets_api(
         Raises:
             HTTPException: 404 if snippet not found, 500 for other errors.
         """
-        logger.info(f"Request to update snippet: {uuid_or_name}")
-        update_snippet_counter.inc()
         try:
-            result = service.update(uuid_or_name, snippet.to_dict())
-            emit_content_updated("snippet", result["uuid"])
+            service.update(uuid_or_name, snippet.to_dict())
             return {
                 "message": f"Snippet with UUID or name '{uuid_or_name}' updated successfully."
             }
         except KeyError as e:
             raise HTTPException(status_code=404, detail=str(e))
         except Exception as e:
-            logger.error(f"Error updating snippet '{uuid_or_name}': {e}")
             raise HTTPException(
                 status_code=500, detail=f"Error updating snippet: {str(e)}"
             )
@@ -268,8 +222,6 @@ def register_snippets_api(
         Raises:
             HTTPException: 503 if search is not available, 500 for other errors.
         """
-        logger.info(f"Request to search snippets for term: {search_term}")
-        search_snippets_counter.inc()
         try:
             return service.search(
                 search_term=search_term,
@@ -281,7 +233,6 @@ def register_snippets_api(
         except RuntimeError as e:
             raise HTTPException(status_code=503, detail=str(e))
         except Exception as e:
-            logger.error(f"Error searching snippets: {e}")
             raise HTTPException(
                 status_code=500, detail=f"Error searching snippets: {str(e)}"
             )

--- a/src/skillberry_store/fast_api/snippets_api.py
+++ b/src/skillberry_store/fast_api/snippets_api.py
@@ -190,10 +190,8 @@ def register_snippets_api(
         logger.info(f"Request to delete snippet: {uuid_or_name}")
         delete_snippet_counter.inc()
         try:
-            snippet = service.get(uuid_or_name)
-            snippet_uuid = snippet["uuid"]
-            service.delete(uuid_or_name)
-            emit_content_deleted("snippet", snippet_uuid)
+            result = service.delete(uuid_or_name)
+            emit_content_deleted("snippet", result["uuid"])
             return {
                 "message": f"Snippet with UUID or name '{uuid_or_name}' deleted successfully."
             }

--- a/src/skillberry_store/fast_api/tools_api.py
+++ b/src/skillberry_store/fast_api/tools_api.py
@@ -18,6 +18,7 @@ from skillberry_store.plugins.events import (
 from skillberry_store.modules.lifecycle import LifecycleState
 from skillberry_store.schemas.tool_schema import ToolSchema
 from skillberry_store.utils.utils import SKILLBERRY_CONTEXT, unflatten_keys
+from skillberry_store.services.exceptions import ObjectAlreadyExistsError
 from skillberry_store.services.tools_service import ToolsService
 
 logger = logging.getLogger(__name__)
@@ -205,7 +206,7 @@ def register_tools_api(
         """Get the module file content for a specific tool.
 
         Retrieves the Python source code or MCP content for a tool. For MCP-packaged
-        tools, returns the MCP manifest content. For code-packaged tools, returns
+        tools, returns the MCP manifest stub. For code-packaged tools, returns
         the Python module source.
 
         Args:
@@ -220,18 +221,12 @@ def register_tools_api(
         logger.info(f"Request to get module file for tool: {uuid_or_name}")
         get_tool_module_counter.inc()
         try:
-            tool_dict = service.get(uuid_or_name)
-            if tool_dict.get("packaging_format") == "mcp":
-                return PlainTextResponse(
-                    content=mcp_content_from_manifest(tool_dict),
-                    media_type="text/plain",
-                )
-            content = service.get_module(uuid_or_name)
-            return PlainTextResponse(content=content, media_type="text/plain")
+            return PlainTextResponse(
+                content=service.get_module(uuid_or_name),
+                media_type="text/plain",
+            )
         except KeyError as e:
             raise HTTPException(status_code=404, detail=str(e))
-        except HTTPException:
-            raise
         except Exception as e:
             logger.error(f"Error retrieving module for '{uuid_or_name}': {e}")
             raise HTTPException(
@@ -261,10 +256,8 @@ def register_tools_api(
         logger.info(f"Request to delete tool: {uuid_or_name}")
         delete_tool_counter.inc()
         try:
-            tool = service.get(uuid_or_name)
-            tool_uuid = tool["uuid"]
-            service.delete(uuid_or_name)
-            emit_content_deleted("tool", tool_uuid)
+            result = service.delete(uuid_or_name)
+            emit_content_deleted("tool", result["uuid"])
             return {
                 "message": f"Tool with UUID or name '{uuid_or_name}' deleted successfully."
             }
@@ -457,12 +450,10 @@ def register_tools_api(
                 selected_func=selected_func,
                 update_existing=update,
             )
+        except ObjectAlreadyExistsError as e:
+            raise HTTPException(status_code=409, detail=str(e))
         except ValueError as e:
-            # ValueError from extract_docstring/missing description -> 400.
-            # ValueError from ToolsService.create on UUID conflict -> 409.
-            msg = str(e)
-            status = 409 if "already exists" in msg else 400
-            raise HTTPException(status_code=status, detail=msg)
+            raise HTTPException(status_code=400, detail=str(e))
         except Exception as e:
             logger.error(f"Error adding tool: {e}")
             raise HTTPException(status_code=500, detail=f"Error adding tool: {str(e)}")

--- a/src/skillberry_store/fast_api/tools_api.py
+++ b/src/skillberry_store/fast_api/tools_api.py
@@ -2,105 +2,25 @@
 
 from __future__ import annotations
 
-import json
 import logging
-from io import BytesIO
-import os
+import time
+import traceback
+from typing import Optional, Annotated, Dict, Any, List
+from fastapi import FastAPI, HTTPException, File, UploadFile, Query, Request
+from fastapi.responses import PlainTextResponse
+from prometheus_client import Counter, Histogram
+
 from skillberry_store.plugins.events import (
     emit_content_added,
     emit_content_updated,
     emit_content_deleted,
 )
-from starlette.responses import PlainTextResponse
-import traceback
-import uuid
-from datetime import datetime, timezone
-from typing import Optional, Type, TypeVar, Annotated, Dict, Any, List, Set, Tuple
-from inspect import Parameter, Signature
-from fastapi import FastAPI, HTTPException, File, UploadFile, Form, Query, Request
-from fastapi.responses import PlainTextResponse
-from pydantic import BaseModel
-from prometheus_client import Counter, Histogram
-import time
-
-from skillberry_store.modules.object_handler import ObjectHandler, get_object_handler
-from skillberry_store.modules.file_executor import (
-    FileExecutor,
-    detect_tool_dependencies,
-)
-from skillberry_store.modules.description import Description
 from skillberry_store.modules.lifecycle import LifecycleState
-from skillberry_store.schemas.tool_schema import (
-    ToolSchema,
-    ToolParamsSchema,
-    ToolReturnsSchema,
-)
-from skillberry_store.schemas.manifest_schema import ManifestState
-from skillberry_store.tools.configure import (
-    is_auto_detect_dependencies_enabled,
-    get_tools_directory,
-    get_files_directory_path,
-)
-from skillberry_store.utils.utils import (
-    SKILLBERRY_CONTEXT,
-    unflatten_keys,
-    normalize_uuid,
-    generate_or_validate_uuid,
-)
-from skillberry_store.utils.python_utils import extract_docstring
-from skillberry_store.fast_api.server_utils import (
-    mcp_json_converter,
-    mcp_content_from_manifest,
-)
-from skillberry_store.fast_api.search_filters import apply_search_filters
+from skillberry_store.schemas.tool_schema import ToolSchema
+from skillberry_store.utils.utils import SKILLBERRY_CONTEXT, unflatten_keys
 from skillberry_store.services.tools_service import ToolsService
 
 logger = logging.getLogger(__name__)
-
-
-def find_tool_dependencies(
-    dependencies: List[str], tool_handler: ObjectHandler, tool_uuid: str
-) -> Set[str]:
-    """
-    Recursively locate UUIDs of all dependencies of a given tool.
-
-    Args:
-        dependencies: List of current dependency tool UUIDs
-        tool_handler: ObjectHandler for tools
-        tool_uuid: UUID of the tool whose dependencies are found (for logging)
-
-    Returns:
-        - Set of UUIDs of all dependencies (transitive closure) of the given tool.
-    """
-    dependencies_uuids: Set[str] = set()
-
-    if not dependencies:
-        return dependencies_uuids
-
-    logger.info(f"Scanning {len(dependencies)} dependencies for tool '{tool_uuid}'")
-
-    for dep_uuid in dependencies:
-        # Skip if already visited (avoid circular dependencies)
-        if dep_uuid in dependencies_uuids:
-            logger.debug(f"Skipping already found dependency: {dep_uuid}")
-            continue
-
-        dependencies_uuids.add(dep_uuid)
-
-        dep_dict = tool_handler.read_dict(dep_uuid)
-
-        # Recursively load nested dependencies first
-        nested_dependencies = dep_dict.get("dependencies", [])
-        if nested_dependencies:
-            logger.info(f"Finding dependencies for '{dep_uuid}'")
-            nested_deps = find_tool_dependencies(
-                dependencies=nested_dependencies,
-                tool_handler=tool_handler,
-                tool_uuid=dep_uuid,
-            )
-            dependencies_uuids.update(nested_deps)
-
-    return dependencies_uuids
 
 
 # observability - metrics
@@ -151,7 +71,6 @@ add_tool_from_python_counter = Counter(
 def register_tools_api(
     app: FastAPI,
     tags: str = "tools",
-    tools_descriptions: Optional[Description] = None,
     service: Optional[ToolsService] = None,
 ):
     """Register all tools-related API endpoints with the FastAPI application.
@@ -162,15 +81,17 @@ def register_tools_api(
     Args:
         app: The FastAPI application instance to register routes with.
         tags: OpenAPI tag for grouping these endpoints (default: "tools").
-        tools_descriptions: Optional Description instance for semantic search functionality.
-        service: Optional ToolsService instance. If None, a new instance will be created.
+        service: Optional ToolsService instance. When ``None``, the singleton
+            from :func:`skillberry_store.services.registry.get_service` is used.
 
     Returns:
         None. Endpoints are registered directly on the app instance.
     """
     if service is None:
-        service = ToolsService(get_object_handler("tool"), tools_descriptions)
-    tool_handler = service.handler  # kept for add_tool_from_python and search endpoints
+        from skillberry_store.services.registry import get_service
+
+        service = get_service("tool")
+    assert service is not None  # narrowed for type checker
 
     @app.post("/tools/", tags=[tags], openapi_extra={"x-cli-name": "create-tool"})
     async def create_tool(
@@ -422,64 +343,37 @@ def register_tools_api(
         )
         try:
             tool_dict = service.get(uuid_or_name)
-            tool_uuid = tool_dict["uuid"]
-            tool_name = tool_dict.get("name", uuid_or_name)
-            execute_tool_counter.labels(name=tool_uuid).inc()
-            start_time = time.time()
-            headers_dict = dict(request.headers.items())
-            skillberry_context = unflatten_keys(headers_dict).get(
-                SKILLBERRY_CONTEXT.lower()
-            )
-            env_id = (
-                skillberry_context.get("env_id")
-                if skillberry_context is not None
-                else None
-            )
-            if tool_dict.get("packaging_format") == "mcp":
-                module_content = mcp_content_from_manifest(tool_dict)
-            else:
-                module_content = service.get_module(uuid_or_name)
-            dep_uuids = service.find_dependencies(
-                tool_dict.get("dependencies", []), tool_uuid
-            )
-            dep_dicts = service.handler.read_dicts(list(dep_uuids))
-            dep_files = [
-                service.handler.read_file(m["uuid"], m["module_name"], raw_content=True)
-                for m in dep_dicts
-            ]
-            file_executor = FileExecutor(
-                name=tool_name,
-                file_content=module_content,
-                file_manifest=tool_dict,
-                dependent_file_contents=dep_files,
-                dependent_tools_as_dict=dep_dicts,
-            )
-            result = await file_executor.execute_file(
-                parameters=parameters or {}, env_id=env_id
-            )
-            if not (isinstance(result, dict) and "error" in result):
-                duration = time.time() - start_time
-                execute_successfully_tool_counter.labels(name=tool_uuid).inc()
-                execute_successfully_tool_latency.labels(name=tool_uuid).observe(
-                    duration
-                )
-                logger.info(
-                    f"Tool '{tool_name}' (UUID: {tool_uuid}) executed successfully"
-                )
-            else:
-                error_message = result.get("error", "Unknown Error")
-                status_code = 404 if "not found" in error_message.lower() else 500
-                raise HTTPException(status_code=status_code, detail=error_message)
-            return result
         except KeyError as e:
             raise HTTPException(status_code=404, detail=str(e))
-        except HTTPException:
-            raise
+        tool_uuid = tool_dict["uuid"]
+        execute_tool_counter.labels(name=tool_uuid).inc()
+        headers_dict = dict(request.headers.items())
+        skillberry_context = unflatten_keys(headers_dict).get(
+            SKILLBERRY_CONTEXT.lower()
+        )
+        env_id = (
+            skillberry_context.get("env_id")
+            if skillberry_context is not None
+            else None
+        )
+        start_time = time.time()
+        try:
+            result = await service.execute(
+                uuid_or_name, parameters=parameters, env_id=env_id
+            )
+        except KeyError as e:
+            raise HTTPException(status_code=404, detail=str(e))
+        except RuntimeError as e:
+            raise HTTPException(status_code=500, detail=str(e))
         except Exception as e:
             logger.error(f"Error executing tool '{uuid_or_name}': {e}")
             raise HTTPException(
                 status_code=500, detail=f"Error executing tool: {str(e)}"
             )
+        duration = time.time() - start_time
+        execute_successfully_tool_counter.labels(name=tool_uuid).inc()
+        execute_successfully_tool_latency.labels(name=tool_uuid).observe(duration)
+        return result
 
     @app.get("/search/tools", tags=[tags], openapi_extra={"x-cli-name": "search-tools"})
     def search_tools(
@@ -505,47 +399,16 @@ def register_tools_api(
         """
         logger.info(f"Request to search tool descriptions for term: {search_term}")
         search_tools_counter.inc()
-        if not tools_descriptions:
-            raise HTTPException(
-                status_code=503,
-                detail="Tool search is not available - descriptions not initialized",
-            )
         try:
-            matched_entities = tools_descriptions.search_description(
-                search_term=search_term, k=max_number_of_results
-            )
-            filtered_matched_entities = [
-                m
-                for m in matched_entities
-                if float(m["similarity_score"]) <= similarity_threshold
-            ]
-            tools_to_filter = []
-            for matched_entity in filtered_matched_entities:
-                tool_name = matched_entity.get("filename") or matched_entity.get("name")
-                if not tool_name:
-                    continue
-                try:
-                    tool_dict = service.get(tool_name)
-                    tool_dict["similarity_score"] = matched_entity.get(
-                        "similarity_score", 0.0
-                    )
-                    tools_to_filter.append(tool_dict)
-                except Exception as e:
-                    logger.warning(f"Could not load tool {tool_name}: {e}")
-            filtered_tools = apply_search_filters(
-                tools_to_filter,
+            return service.search(
+                search_term=search_term,
+                max_number_of_results=max_number_of_results,
+                similarity_threshold=similarity_threshold,
                 manifest_filter=manifest_filter,
                 lifecycle_state=lifecycle_state,
             )
-            filtered_tools.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
-            return [
-                {
-                    "filename": t.get("name", ""),
-                    "similarity_score": t.get("similarity_score", 0.0),
-                }
-                for t in filtered_tools
-                if t.get("name")
-            ]
+        except RuntimeError as e:
+            raise HTTPException(status_code=503, detail=str(e))
         except Exception as e:
             logger.error(f"Error searching tools: {e}")
             raise HTTPException(
@@ -580,167 +443,32 @@ def register_tools_api(
         logger.info(f"Request to add tool from Python file: {tool.filename}")
         add_tool_from_python_counter.inc()
 
-        # Validate that the uploaded file is a Python file
         if not tool.filename or not tool.filename.endswith(".py"):
             raise HTTPException(
                 status_code=400,
                 detail="Only Python (.py) files are supported. Please upload a valid Python file.",
             )
+        tool_bytes = await tool.read()
 
         try:
-            tool_bytes = await tool.read()
-
-            try:
-                func_name, docstring_obj = extract_docstring(tool_bytes, selected_func)  # type: ignore
-                logger.info(f"Extracted function '{func_name}' from uploaded file")
-            except Exception as e:
-                logger.error(f"Failed to extract docstring: {e}")
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"Failed to parse Python code or extract docstring: {str(e)}. "
-                    "Ensure the function has a properly formatted docstring with parameters.",
-                )
-
-            description = docstring_obj.short_description  # type: ignore
-            if not description:
-                raise HTTPException(
-                    status_code=400,
-                    detail="Function docstring must include a description.",
-                )
-
-            params_properties = {}
-            required_params = []
-
-            for param in docstring_obj.params:  # type: ignore
-                params_properties[param.arg_name] = {
-                    "type": param.type_name if param.type_name else "string",
-                    "description": param.description if param.description else "",
-                }
-                required_params.append(param.arg_name)
-
-            returns_schema = None
-            if docstring_obj.returns:  # type: ignore
-                returns_schema = ToolReturnsSchema(
-                    type=docstring_obj.returns.type_name if docstring_obj.returns.type_name else None,  # type: ignore
-                    description=docstring_obj.returns.description if docstring_obj.returns.description else None,  # type: ignore
-                )
-
-            # Check if tool with this name already exists
-            existing_tool = tool_handler.lookup_by_name(func_name)
-
-            # Auto-detect dependencies if enabled
-            dependencies = None
-            if is_auto_detect_dependencies_enabled():
-                try:
-                    available_tools = tool_handler.get_existing_names()
-                    detected_deps = detect_tool_dependencies(
-                        (
-                            tool_bytes.decode("utf-8")
-                            if isinstance(tool_bytes, bytes)
-                            else tool_bytes
-                        ),
-                        func_name,
-                        available_tools,
-                    )
-                    if detected_deps:
-                        dependencies = detected_deps
-                        logger.info(
-                            f"Auto-detected dependencies for '{func_name}': {detected_deps}"
-                        )
-                except Exception as e:
-                    logger.warning(f"Failed to auto-detect dependencies: {e}")
-
-            if update and existing_tool:
-
-                logger.info(f"Updating existing tool: {func_name}")
-
-                # Use existing UUID for update
-                tool_uuid = existing_tool.get("uuid")
-                tool_uuid = generate_or_validate_uuid(tool_uuid)
-
-                # Update the module file in UUID sub-folder (update_tool doesn't handle files)
-                module_filename = tool.filename if tool.filename else f"{func_name}.py"
-                tool_handler.write_file(tool_uuid, module_filename, tool_bytes)
-                logger.info(
-                    f"Updated module file in UUID sub-folder: {module_filename}"
-                )
-
-                # Create the tool schema for update (parent will be set by update_tool)
-                tool_schema = ToolSchema(
-                    name=func_name,
-                    uuid=tool_uuid,
-                    description=description,
-                    programming_language="python",
-                    packaging_format="code",
-                    module_name=module_filename,
-                    version="0.0.1",
-                    state=ManifestState.APPROVED,
-                    parent=None,  # Will be set correctly by update_tool
-                    params=ToolParamsSchema(
-                        type="object",
-                        properties=params_properties,
-                        required=required_params,
-                        optional=[],
-                    ),
-                    returns=returns_schema,
-                    dependencies=dependencies,
-                )
-
-                # Delegate to update_tool to handle manifest merge and description update
-                update_result = await update_tool(tool_uuid, tool_schema)
-                logger.info(f"Tool '{func_name}' updated successfully")
-
-                return {
-                    "message": f"Tool '{func_name}' created successfully.",
-                    "name": func_name,
-                    "uuid": tool_uuid,
-                    "module_name": module_filename,
-                    "parameters": params_properties,
-                    "description": description,
-                }
-            else:
-                # Generate new UUID for new tool
-                tool_uuid = generate_or_validate_uuid(None)
-                logger.info(f"Generated UUID for tool '{func_name}': {tool_uuid}")
-
-                # Create the tool schema for new tool (parent will be set by create_tool)
-                tool_schema = ToolSchema(
-                    name=func_name,
-                    uuid=tool_uuid,
-                    module_name=tool.filename if tool.filename else f"{func_name}.py",
-                    description=description,
-                    programming_language="python",
-                    packaging_format="code",
-                    version="0.0.1",
-                    state=ManifestState.APPROVED,
-                    parent=None,  # Will be set correctly by create_tool
-                    params=ToolParamsSchema(
-                        type="object",
-                        properties=params_properties,
-                        required=required_params,
-                        optional=[],
-                    ),
-                    returns=returns_schema,
-                    dependencies=dependencies,
-                )
-
-                # Delegate to create_tool to handle everything (file, manifest, description)
-                create_response = await create_tool(
-                    tool=tool_schema,
-                    module=UploadFile(filename=tool.filename, file=BytesIO(tool_bytes)),
-                )
-
-                logger.info(
-                    f"Tool '{func_name}' added successfully with UUID {tool_uuid}"
-                )
-                return {
-                    **create_response,
-                    "parameters": params_properties,
-                    "description": description,
-                }
-
-        except HTTPException:
-            raise
+            result = service.add_from_python(
+                file_bytes=tool_bytes,
+                file_name=tool.filename,
+                selected_func=selected_func,
+                update_existing=update,
+            )
+        except ValueError as e:
+            # ValueError from extract_docstring/missing description -> 400.
+            # ValueError from ToolsService.create on UUID conflict -> 409.
+            msg = str(e)
+            status = 409 if "already exists" in msg else 400
+            raise HTTPException(status_code=status, detail=msg)
         except Exception as e:
             logger.error(f"Error adding tool: {e}")
             raise HTTPException(status_code=500, detail=f"Error adding tool: {str(e)}")
+
+        if result.get("action") == "updated":
+            emit_content_updated("tool", result["uuid"])
+        else:
+            emit_content_added("tool", result["uuid"])
+        return result

--- a/src/skillberry_store/fast_api/tools_api.py
+++ b/src/skillberry_store/fast_api/tools_api.py
@@ -259,9 +259,7 @@ def register_tools_api(
             SKILLBERRY_CONTEXT.lower()
         )
         env_id = (
-            skillberry_context.get("env_id")
-            if skillberry_context is not None
-            else None
+            skillberry_context.get("env_id") if skillberry_context is not None else None
         )
         try:
             return await service.execute(

--- a/src/skillberry_store/fast_api/tools_api.py
+++ b/src/skillberry_store/fast_api/tools_api.py
@@ -2,71 +2,16 @@
 
 from __future__ import annotations
 
-import logging
-import time
 import traceback
 from typing import Optional, Annotated, Dict, Any, List
 from fastapi import FastAPI, HTTPException, File, UploadFile, Query, Request
 from fastapi.responses import PlainTextResponse
-from prometheus_client import Counter, Histogram
 
-from skillberry_store.plugins.events import (
-    emit_content_added,
-    emit_content_updated,
-    emit_content_deleted,
-)
 from skillberry_store.modules.lifecycle import LifecycleState
 from skillberry_store.schemas.tool_schema import ToolSchema
 from skillberry_store.utils.utils import SKILLBERRY_CONTEXT, unflatten_keys
 from skillberry_store.services.exceptions import ObjectAlreadyExistsError
 from skillberry_store.services.tools_service import ToolsService
-
-logger = logging.getLogger(__name__)
-
-
-# observability - metrics
-prom_prefix = "sts_fastapi_tools_"
-create_tool_counter = Counter(
-    f"{prom_prefix}create_tool_counter", "Count number of tool create operations"
-)
-list_tools_counter = Counter(
-    f"{prom_prefix}list_tools_counter", "Count number of tool list operations"
-)
-get_tool_counter = Counter(
-    f"{prom_prefix}get_tool_counter", "Count number of tool get operations"
-)
-get_tool_module_counter = Counter(
-    f"{prom_prefix}get_tool_module_counter",
-    "Count number of tool module get operations",
-)
-delete_tool_counter = Counter(
-    f"{prom_prefix}delete_tool_counter", "Count number of tool delete operations"
-)
-update_tool_counter = Counter(
-    f"{prom_prefix}update_tool_counter", "Count number of tool update operations"
-)
-execute_tool_counter = Counter(
-    f"{prom_prefix}execute_tool_counter",
-    "Count number of tool execute operations",
-    ["name"],
-)
-execute_successfully_tool_counter = Counter(
-    f"{prom_prefix}execute_successfully_tool_counter",
-    "Count number of tool executed successfully operations",
-    ["name"],
-)
-execute_successfully_tool_latency = Histogram(
-    f"{prom_prefix}execute_successfully_tool_latency",
-    "Histogram of execute tool successfully latencies",
-    ["name"],
-)
-search_tools_counter = Counter(
-    f"{prom_prefix}search_tools_counter", "Count number of tool search operations"
-)
-add_tool_from_python_counter = Counter(
-    f"{prom_prefix}add_tool_from_python_counter",
-    "Count number of tool add from Python operations",
-)
 
 
 def register_tools_api(
@@ -114,8 +59,6 @@ def register_tools_api(
         Raises:
             HTTPException: 409 if tool already exists, 500 for other errors.
         """
-        logger.info(f"Request to create tool: {tool.name}")
-        create_tool_counter.inc()
         try:
             file_content = await module.read()
             module_filename = module.filename if module.filename else f"{tool.name}.py"
@@ -124,7 +67,6 @@ def register_tools_api(
                 module_content=file_content,
                 module_filename=module_filename,
             )
-            emit_content_added("tool", result["uuid"])
             return {
                 "message": f"Tool '{result['name']}' created successfully.",
                 "name": result["name"],
@@ -134,7 +76,6 @@ def register_tools_api(
         except ValueError as e:
             raise HTTPException(status_code=409, detail=str(e))
         except Exception as e:
-            logger.error(f"Error creating tool '{tool.name}': {e}")
             raise HTTPException(
                 status_code=500, detail=f"Error creating tool: {str(e)}"
             )
@@ -154,16 +95,12 @@ def register_tools_api(
         Raises:
             HTTPException: 500 if listing fails.
         """
-        logger.info("Request to list tools")
-        list_tools_counter.inc()
         try:
             return service.list_all()
         except Exception as e:
-            error_traceback = traceback.format_exc()
-            logger.error(f"Error listing tools: {e}\n{error_traceback}")
             raise HTTPException(
                 status_code=500,
-                detail=f"Error listing tools: {str(e)}\n{error_traceback}",
+                detail=f"Error listing tools: {str(e)}\n{traceback.format_exc()}",
             )
 
     @app.get(
@@ -184,14 +121,11 @@ def register_tools_api(
         Raises:
             HTTPException: 404 if tool not found, 500 for other errors.
         """
-        logger.info(f"Request to get tool: {uuid_or_name}")
-        get_tool_counter.inc()
         try:
             return service.get(uuid_or_name)
         except KeyError as e:
             raise HTTPException(status_code=404, detail=str(e))
         except Exception as e:
-            logger.error(f"Error retrieving tool '{uuid_or_name}': {e}")
             raise HTTPException(
                 status_code=500, detail=f"Error retrieving tool: {str(e)}"
             )
@@ -218,8 +152,6 @@ def register_tools_api(
         Raises:
             HTTPException: 404 if tool not found, 500 for other errors.
         """
-        logger.info(f"Request to get module file for tool: {uuid_or_name}")
-        get_tool_module_counter.inc()
         try:
             return PlainTextResponse(
                 content=service.get_module(uuid_or_name),
@@ -228,7 +160,6 @@ def register_tools_api(
         except KeyError as e:
             raise HTTPException(status_code=404, detail=str(e))
         except Exception as e:
-            logger.error(f"Error retrieving module for '{uuid_or_name}': {e}")
             raise HTTPException(
                 status_code=500, detail=f"Error retrieving module file: {str(e)}"
             )
@@ -253,18 +184,14 @@ def register_tools_api(
         Raises:
             HTTPException: 404 if tool not found, 500 for other errors.
         """
-        logger.info(f"Request to delete tool: {uuid_or_name}")
-        delete_tool_counter.inc()
         try:
-            result = service.delete(uuid_or_name)
-            emit_content_deleted("tool", result["uuid"])
+            service.delete(uuid_or_name)
             return {
                 "message": f"Tool with UUID or name '{uuid_or_name}' deleted successfully."
             }
         except KeyError as e:
             raise HTTPException(status_code=404, detail=str(e))
         except Exception as e:
-            logger.error(f"Error deleting tool '{uuid_or_name}': {e}")
             raise HTTPException(
                 status_code=500, detail=f"Error deleting tool: {str(e)}"
             )
@@ -291,18 +218,14 @@ def register_tools_api(
         Raises:
             HTTPException: 404 if tool not found, 500 for other errors.
         """
-        logger.info(f"Request to update tool: {uuid_or_name}")
-        update_tool_counter.inc()
         try:
-            result = service.update(uuid_or_name, tool.to_dict())
-            emit_content_updated("tool", result["uuid"])
+            service.update(uuid_or_name, tool.to_dict())
             return {
                 "message": f"Tool with UUID or name '{uuid_or_name}' updated successfully."
             }
         except KeyError as e:
             raise HTTPException(status_code=404, detail=str(e))
         except Exception as e:
-            logger.error(f"Error updating tool '{uuid_or_name}': {e}")
             raise HTTPException(
                 status_code=500, detail=f"Error updating tool: {str(e)}"
             )
@@ -331,15 +254,6 @@ def register_tools_api(
         Raises:
             HTTPException: If tool not found (404) or execution fails (500).
         """
-        logger.info(
-            f"[execute_tool] Received execute tool: {uuid_or_name} with parameters: {parameters}"
-        )
-        try:
-            tool_dict = service.get(uuid_or_name)
-        except KeyError as e:
-            raise HTTPException(status_code=404, detail=str(e))
-        tool_uuid = tool_dict["uuid"]
-        execute_tool_counter.labels(name=tool_uuid).inc()
         headers_dict = dict(request.headers.items())
         skillberry_context = unflatten_keys(headers_dict).get(
             SKILLBERRY_CONTEXT.lower()
@@ -349,9 +263,8 @@ def register_tools_api(
             if skillberry_context is not None
             else None
         )
-        start_time = time.time()
         try:
-            result = await service.execute(
+            return await service.execute(
                 uuid_or_name, parameters=parameters, env_id=env_id
             )
         except KeyError as e:
@@ -359,14 +272,9 @@ def register_tools_api(
         except RuntimeError as e:
             raise HTTPException(status_code=500, detail=str(e))
         except Exception as e:
-            logger.error(f"Error executing tool '{uuid_or_name}': {e}")
             raise HTTPException(
                 status_code=500, detail=f"Error executing tool: {str(e)}"
             )
-        duration = time.time() - start_time
-        execute_successfully_tool_counter.labels(name=tool_uuid).inc()
-        execute_successfully_tool_latency.labels(name=tool_uuid).observe(duration)
-        return result
 
     @app.get("/search/tools", tags=[tags], openapi_extra={"x-cli-name": "search-tools"})
     def search_tools(
@@ -390,8 +298,6 @@ def register_tools_api(
         Returns:
             list: A list of matched tool names and similarity scores.
         """
-        logger.info(f"Request to search tool descriptions for term: {search_term}")
-        search_tools_counter.inc()
         try:
             return service.search(
                 search_term=search_term,
@@ -403,7 +309,6 @@ def register_tools_api(
         except RuntimeError as e:
             raise HTTPException(status_code=503, detail=str(e))
         except Exception as e:
-            logger.error(f"Error searching tools: {e}")
             raise HTTPException(
                 status_code=500, detail=f"Error searching tools: {str(e)}"
             )
@@ -433,9 +338,6 @@ def register_tools_api(
             HTTPException: If file is not Python (400), tool already exists (409),
                           or any other error occurs (500).
         """
-        logger.info(f"Request to add tool from Python file: {tool.filename}")
-        add_tool_from_python_counter.inc()
-
         if not tool.filename or not tool.filename.endswith(".py"):
             raise HTTPException(
                 status_code=400,
@@ -444,7 +346,7 @@ def register_tools_api(
         tool_bytes = await tool.read()
 
         try:
-            result = service.add_from_python(
+            return service.add_from_python(
                 file_bytes=tool_bytes,
                 file_name=tool.filename,
                 selected_func=selected_func,
@@ -455,11 +357,4 @@ def register_tools_api(
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
         except Exception as e:
-            logger.error(f"Error adding tool: {e}")
             raise HTTPException(status_code=500, detail=f"Error adding tool: {str(e)}")
-
-        if result.get("action") == "updated":
-            emit_content_updated("tool", result["uuid"])
-        else:
-            emit_content_added("tool", result["uuid"])
-        return result

--- a/src/skillberry_store/fast_api/vmcp_api.py
+++ b/src/skillberry_store/fast_api/vmcp_api.py
@@ -110,6 +110,11 @@ def register_vmcp_api(
         Raises:
             HTTPException: 409 if server already exists or port conflict, 500 for other errors.
         """
+        from skillberry_store.services.exceptions import (
+            ObjectAlreadyExistsError,
+            PortConflictError,
+        )
+
         logger.info(f"Request to create vmcp server: {vmcp.name}")
         create_vmcp_counter.inc()
         try:
@@ -120,19 +125,12 @@ def register_vmcp_api(
                 "uuid": result["uuid"],
                 "port": result["port"],
             }
+        except ObjectAlreadyExistsError as e:
+            raise HTTPException(status_code=409, detail=str(e))
+        except PortConflictError as e:
+            raise HTTPException(status_code=409, detail=f"Port conflict: {e}")
         except ValueError as e:
-            error_msg = str(e)
-            if "already exists" in error_msg:
-                raise HTTPException(status_code=409, detail=error_msg)
-            if "port" in error_msg.lower() and (
-                "not available" in error_msg.lower()
-                or "already in use" in error_msg.lower()
-                or "in use" in error_msg.lower()
-            ):
-                raise HTTPException(
-                    status_code=409, detail=f"Port conflict: {error_msg}"
-                )
-            raise HTTPException(status_code=500, detail=error_msg)
+            raise HTTPException(status_code=500, detail=str(e))
         except Exception as e:
             logger.error(f"Error creating vmcp server '{vmcp.name}': {e}")
             raise HTTPException(
@@ -159,17 +157,7 @@ def register_vmcp_api(
         logger.info("Request to list vmcp servers")
         list_vmcp_counter.inc()
         try:
-            result = service.list_all()
-            if skill_uuid:
-                servers = result["virtual_mcp_servers"]
-                result = {
-                    "virtual_mcp_servers": {
-                        k: v
-                        for k, v in servers.items()
-                        if v.get("skill_uuid") == skill_uuid
-                    }
-                }
-            return result
+            return service.list_all(skill_uuid=skill_uuid)
         except Exception as e:
             logger.error(f"Error listing vmcp servers: {e}")
             raise HTTPException(

--- a/src/skillberry_store/fast_api/vmcp_api.py
+++ b/src/skillberry_store/fast_api/vmcp_api.py
@@ -2,53 +2,14 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Annotated, Optional
 
 from fastapi import FastAPI, HTTPException, Query, Request
-from prometheus_client import Counter, Histogram
 
 from skillberry_store.modules.lifecycle import LifecycleState
 from skillberry_store.schemas.vmcp_schema import VmcpSchema
 from skillberry_store.utils.utils import SKILLBERRY_CONTEXT, unflatten_keys
 from skillberry_store.services.vmcp_service import VmcpService
-
-logger = logging.getLogger(__name__)
-
-prom_prefix = "sts_fastapi_vmcp_"
-create_vmcp_counter = Counter(
-    f"{prom_prefix}create_vmcp_counter", "Count number of vmcp create operations"
-)
-list_vmcp_counter = Counter(
-    f"{prom_prefix}list_vmcp_counter", "Count number of vmcp list operations"
-)
-get_vmcp_counter = Counter(
-    f"{prom_prefix}get_vmcp_counter", "Count number of vmcp get operations"
-)
-delete_vmcp_counter = Counter(
-    f"{prom_prefix}delete_vmcp_counter", "Count number of vmcp delete operations"
-)
-update_vmcp_counter = Counter(
-    f"{prom_prefix}update_vmcp_counter", "Count number of vmcp update operations"
-)
-search_vmcp_counter = Counter(
-    f"{prom_prefix}search_vmcp_counter", "Count number of vmcp search operations"
-)
-invoke_vmcp_tool_counter = Counter(
-    f"{prom_prefix}invoke_vmcp_tool_counter",
-    "Count number of vmcp tool invoke operations",
-    ["server_name", "tool_name"],
-)
-invoke_successfully_vmcp_tool_counter = Counter(
-    f"{prom_prefix}invoke_successfully_vmcp_tool_counter",
-    "Count number of vmcp tool invoked successfully operations",
-    ["server_name", "tool_name"],
-)
-invoke_successfully_vmcp_tool_latency = Histogram(
-    f"{prom_prefix}invoke_successfully_vmcp_tool_latency",
-    "Histogram of invoke vmcp tool successfully latencies",
-    ["server_name", "tool_name"],
-)
 
 
 def register_vmcp_api(
@@ -115,8 +76,6 @@ def register_vmcp_api(
             PortConflictError,
         )
 
-        logger.info(f"Request to create vmcp server: {vmcp.name}")
-        create_vmcp_counter.inc()
         try:
             result = service.create(vmcp.to_dict(), env_id=_extract_env_id(request))
             return {
@@ -132,7 +91,6 @@ def register_vmcp_api(
         except ValueError as e:
             raise HTTPException(status_code=500, detail=str(e))
         except Exception as e:
-            logger.error(f"Error creating vmcp server '{vmcp.name}': {e}")
             raise HTTPException(
                 status_code=500, detail=f"Error creating vmcp server: {str(e)}"
             )
@@ -154,12 +112,9 @@ def register_vmcp_api(
         Raises:
             HTTPException: 500 if listing fails.
         """
-        logger.info("Request to list vmcp servers")
-        list_vmcp_counter.inc()
         try:
             return service.list_all(skill_uuid=skill_uuid)
         except Exception as e:
-            logger.error(f"Error listing vmcp servers: {e}")
             raise HTTPException(
                 status_code=500, detail=f"Error listing vmcp servers: {str(e)}"
             )
@@ -184,14 +139,11 @@ def register_vmcp_api(
         Raises:
             HTTPException: 404 if server not found, 500 for other errors.
         """
-        logger.info(f"Request to get vmcp server: {uuid_or_name}")
-        get_vmcp_counter.inc()
         try:
             return service.get(uuid_or_name)
         except KeyError as e:
             raise HTTPException(status_code=404, detail=str(e))
         except Exception as e:
-            logger.error(f"Error retrieving vmcp server '{uuid_or_name}': {e}")
             raise HTTPException(
                 status_code=500, detail=f"Error retrieving vmcp server: {str(e)}"
             )
@@ -215,15 +167,12 @@ def register_vmcp_api(
         Raises:
             HTTPException: 404 if server not found, 500 for other errors.
         """
-        logger.info(f"Request to delete vmcp server: {uuid_or_name}")
-        delete_vmcp_counter.inc()
         try:
             service.delete(uuid_or_name)
             return {"message": f"VMCP server '{uuid_or_name}' deleted successfully."}
         except KeyError as e:
             raise HTTPException(status_code=404, detail=str(e))
         except Exception as e:
-            logger.error(f"Error deleting vmcp server '{uuid_or_name}': {e}")
             raise HTTPException(
                 status_code=500, detail=f"Error deleting vmcp server: {str(e)}"
             )
@@ -252,8 +201,6 @@ def register_vmcp_api(
         Raises:
             HTTPException: 404 if server not found, 500 for other errors.
         """
-        logger.info(f"Request to update vmcp server: {uuid_or_name}")
-        update_vmcp_counter.inc()
         try:
             result = service.update(
                 uuid_or_name, vmcp.to_dict(), env_id=_extract_env_id(request)
@@ -265,7 +212,6 @@ def register_vmcp_api(
         except KeyError as e:
             raise HTTPException(status_code=404, detail=str(e))
         except Exception as e:
-            logger.error(f"Error updating vmcp server '{uuid_or_name}': {e}")
             raise HTTPException(
                 status_code=500, detail=f"Error updating vmcp server: {str(e)}"
             )
@@ -292,7 +238,6 @@ def register_vmcp_api(
         Raises:
             HTTPException: 404 if server or skill not found, 500 for other errors.
         """
-        logger.info(f"Request to start vmcp server: {uuid_or_name}")
         try:
             server, already_running = service.start(
                 uuid_or_name, env_id=_extract_env_id(request)
@@ -308,7 +253,6 @@ def register_vmcp_api(
         except ValueError as e:
             raise HTTPException(status_code=404, detail=str(e))
         except Exception as e:
-            logger.error(f"Error starting vmcp server '{uuid_or_name}': {e}")
             raise HTTPException(
                 status_code=500, detail=f"Error starting vmcp server: {str(e)}"
             )
@@ -343,8 +287,6 @@ def register_vmcp_api(
         Raises:
             HTTPException: 503 if search is not available, 500 for other errors.
         """
-        logger.info(f"Request to search vmcp servers for: {search_term}")
-        search_vmcp_counter.inc()
         try:
             return service.search(
                 search_term=search_term,
@@ -356,7 +298,6 @@ def register_vmcp_api(
         except RuntimeError as e:
             raise HTTPException(status_code=503, detail=str(e))
         except Exception as e:
-            logger.error(f"Error searching vmcp servers: {e}")
             raise HTTPException(
                 status_code=500, detail=f"Error searching vmcp servers: {str(e)}"
             )

--- a/src/skillberry_store/fast_api/vmcp_api.py
+++ b/src/skillberry_store/fast_api/vmcp_api.py
@@ -3,19 +3,15 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Annotated, Optional
+from typing import Annotated, Optional
 
 from fastapi import FastAPI, HTTPException, Query, Request
 from prometheus_client import Counter, Histogram
 
 from skillberry_store.modules.lifecycle import LifecycleState
 from skillberry_store.schemas.vmcp_schema import VmcpSchema
-from skillberry_store.fast_api.search_filters import apply_search_filters
 from skillberry_store.utils.utils import SKILLBERRY_CONTEXT, unflatten_keys
 from skillberry_store.services.vmcp_service import VmcpService
-
-if TYPE_CHECKING:
-    from skillberry_store.modules.description import Description
 
 logger = logging.getLogger(__name__)
 
@@ -57,9 +53,7 @@ invoke_successfully_vmcp_tool_latency = Histogram(
 
 def register_vmcp_api(
     app: FastAPI,
-    sts_url: str,
     tags: str = "vmcp_servers",
-    vmcp_descriptions: Optional[Description] = None,
     service: Optional[VmcpService] = None,
 ):
     """Register all Virtual MCP Server API endpoints with the FastAPI application.
@@ -69,24 +63,18 @@ def register_vmcp_api(
 
     Args:
         app: The FastAPI application instance to register routes with.
-        sts_url: The Skillberry Store URL for server communication.
         tags: OpenAPI tag for grouping these endpoints (default: "vmcp_servers").
-        vmcp_descriptions: Optional Description instance for semantic search functionality.
-        service: Optional VmcpService instance. If None, a new instance will be created.
+        service: Optional VmcpService instance. When ``None``, the singleton
+            from :func:`skillberry_store.services.registry.get_service` is used.
 
     Returns:
         None. Endpoints are registered directly on the app instance.
     """
     if service is None:
-        from skillberry_store.modules.object_handler import get_object_handler
-        from skillberry_store.modules.vmcp_server_manager import VirtualMcpServerManager
+        from skillberry_store.services.registry import get_service
 
-        service = VmcpService(
-            get_object_handler("vmcp"),
-            VirtualMcpServerManager(sts_url=sts_url, app=app),
-            get_object_handler("skill"),
-            vmcp_descriptions,
-        )
+        service = get_service("vmcp")
+    assert service is not None  # narrowed for type checker
     app.state.vmcp_server_manager = service.server_manager
 
     def _extract_env_id(request: Request) -> str:
@@ -318,43 +306,19 @@ def register_vmcp_api(
         """
         logger.info(f"Request to start vmcp server: {uuid_or_name}")
         try:
-            vmcp_uuid = service._resolve_uuid(uuid_or_name)
-            vmcp_data = service.handler.read_dict(vmcp_uuid)
-            server_name = vmcp_data.get("name", "")
-            server_uuid = vmcp_data.get("uuid", "")
-            try:
-                existing = service.server_manager.get_server(server_name, server_uuid)
-                if existing:
-                    return {
-                        "message": f"VMCP server '{server_name}' is already running.",
-                        "port": existing.port,
-                    }
-            except Exception:
-                pass
-            env_id = _extract_env_id(request)
-            tool_uuids, snippet_uuids = service._resolve_skill_uuids(
-                vmcp_data.get("skill_uuid")
+            server, already_running = service.start(
+                uuid_or_name, env_id=_extract_env_id(request)
             )
-            server = service.server_manager.add_server(
-                name=server_name,
-                uuid=server_uuid,
-                description=vmcp_data.get("description", ""),
-                port=vmcp_data.get("port"),
-                tools=tool_uuids,
-                snippets=snippet_uuids,
-                env_id=env_id,
+            message = (
+                f"VMCP server '{server.name}' is already running."
+                if already_running
+                else f"VMCP server '{server.name}' started successfully."
             )
-            logger.info(f"VMCP server '{server_name}' started on port {server.port}")
-            return {
-                "message": f"VMCP server '{server_name}' started successfully.",
-                "port": server.port,
-            }
+            return {"message": message, "port": server.port}
         except KeyError as e:
             raise HTTPException(status_code=404, detail=str(e))
         except ValueError as e:
             raise HTTPException(status_code=404, detail=str(e))
-        except HTTPException:
-            raise
         except Exception as e:
             logger.error(f"Error starting vmcp server '{uuid_or_name}': {e}")
             raise HTTPException(
@@ -393,44 +357,16 @@ def register_vmcp_api(
         """
         logger.info(f"Request to search vmcp servers for: {search_term}")
         search_vmcp_counter.inc()
-        if not vmcp_descriptions:
-            raise HTTPException(
-                status_code=503, detail="VMCP server search is not available"
-            )
         try:
-            matched_entities = vmcp_descriptions.search_description(
-                search_term=search_term, k=max_number_of_results
-            )
-            filtered = [
-                m
-                for m in matched_entities
-                if float(m.get("similarity_score", 0)) <= similarity_threshold
-            ]
-            to_filter = []
-            for m in filtered:
-                vmcp_uuid = m.get("filename") or m.get("name")
-                if not vmcp_uuid:
-                    continue
-                try:
-                    d = service.handler.read_dict(vmcp_uuid)
-                    d["similarity_score"] = m.get("similarity_score", 0.0)
-                    to_filter.append(d)
-                except Exception as exc:
-                    logger.warning(f"Could not load vmcp '{vmcp_uuid}': {exc}")
-            result_items = apply_search_filters(
-                to_filter,
+            return service.search(
+                search_term=search_term,
+                max_number_of_results=max_number_of_results,
+                similarity_threshold=similarity_threshold,
                 manifest_filter=manifest_filter,
                 lifecycle_state=lifecycle_state,
             )
-            result_items.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
-            return [
-                {
-                    "filename": s.get("name", ""),
-                    "similarity_score": s.get("similarity_score", 0.0),
-                }
-                for s in result_items
-                if s.get("name")
-            ]
+        except RuntimeError as e:
+            raise HTTPException(status_code=503, detail=str(e))
         except Exception as e:
             logger.error(f"Error searching vmcp servers: {e}")
             raise HTTPException(

--- a/src/skillberry_store/fast_api/vnfs_api.py
+++ b/src/skillberry_store/fast_api/vnfs_api.py
@@ -3,18 +3,14 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Annotated, Optional
+from typing import Annotated, Optional
 
 from fastapi import FastAPI, HTTPException, Query, Request
 from prometheus_client import Counter
 
 from skillberry_store.modules.lifecycle import LifecycleState
 from skillberry_store.schemas.vnfs_schema import VnfsSchema
-from skillberry_store.fast_api.search_filters import apply_search_filters
 from skillberry_store.services.vnfs_service import VnfsService
-
-if TYPE_CHECKING:
-    from skillberry_store.modules.description import Description
 
 logger = logging.getLogger(__name__)
 
@@ -29,9 +25,7 @@ search_vnfs_counter = Counter(f"{prom_prefix}search_counter", "vNFS search opera
 
 def register_vnfs_api(
     app: FastAPI,
-    sts_url: str,
     tags: str = "vnfs_servers",
-    vnfs_descriptions: Optional[Description] = None,
     service: Optional[VnfsService] = None,
 ):
     """Register all Virtual NFS Server API endpoints with the FastAPI application.
@@ -41,23 +35,18 @@ def register_vnfs_api(
 
     Args:
         app: The FastAPI application instance to register routes with.
-        sts_url: The Skillberry Store URL for server communication.
         tags: OpenAPI tag for grouping these endpoints (default: "vnfs_servers").
-        vnfs_descriptions: Optional Description instance for semantic search functionality.
-        service: Optional VnfsService instance. If None, a new instance will be created.
+        service: Optional VnfsService instance. When ``None``, the singleton
+            from :func:`skillberry_store.services.registry.get_service` is used.
 
     Returns:
         None. Endpoints are registered directly on the app instance.
     """
     if service is None:
-        from skillberry_store.modules.object_handler import get_object_handler
-        from skillberry_store.modules.vnfs_server_manager import VirtualNfsServerManager
+        from skillberry_store.services.registry import get_service
 
-        service = VnfsService(
-            get_object_handler("vnfs"),
-            VirtualNfsServerManager(sts_url=sts_url, app=app),
-            vnfs_descriptions,
-        )
+        service = get_service("vnfs")
+    assert service is not None  # narrowed for type checker
     app.state.vnfs_server_manager = service.server_manager
 
     @app.post(
@@ -257,7 +246,8 @@ def register_vnfs_api(
 
         Args:
             uuid_or_name: The UUID or name of the virtual NFS server to start.
-            request: FastAPI request object for extracting environment context.
+            request: FastAPI request object (kept for OpenAPI shape compatibility;
+                ``VnfsService.start`` does not need request context).
 
         Returns:
             dict: Success message with server name and port.
@@ -267,31 +257,17 @@ def register_vnfs_api(
         """
         logger.info(f"Request to start vnfs server: {uuid_or_name}")
         try:
-            vnfs_data = service.handler.read_dict(service._resolve_uuid(uuid_or_name))
-            server_name = vnfs_data.get("name", "")
-            server_uuid = vnfs_data.get("uuid", "")
-            try:
-                existing = service.server_manager.get_server(server_name, server_uuid)
-                if existing and existing.running:
-                    return {
-                        "message": f"vNFS server '{server_name}' is already running.",
-                        "port": existing.port,
-                    }
-            except Exception:
-                pass
-            schema = VnfsSchema.from_dict(vnfs_data)
-            server = service.server_manager.add_server(schema)
-            logger.info(f"vNFS server '{server_name}' started on port {server.port}")
-            return {
-                "message": f"vNFS server '{server_name}' started successfully.",
-                "port": server.port,
-            }
+            server, already_running = service.start(uuid_or_name)
+            message = (
+                f"vNFS server '{server.name}' is already running."
+                if already_running
+                else f"vNFS server '{server.name}' started successfully."
+            )
+            return {"message": message, "port": server.port}
         except KeyError as e:
             raise HTTPException(status_code=404, detail=str(e))
         except ValueError as e:
             raise HTTPException(status_code=404, detail=str(e))
-        except HTTPException:
-            raise
         except Exception as exc:
             logger.error(f"Error starting vnfs server '{uuid_or_name}': {exc}")
             raise HTTPException(
@@ -330,44 +306,16 @@ def register_vnfs_api(
         """
         logger.info(f"Request to search vnfs servers for: {search_term}")
         search_vnfs_counter.inc()
-        if not vnfs_descriptions:
-            raise HTTPException(
-                status_code=503, detail="vNFS server search is not available"
-            )
         try:
-            matched = vnfs_descriptions.search_description(
-                search_term=search_term, k=max_number_of_results
-            )
-            filtered = [
-                m
-                for m in matched
-                if float(m["similarity_score"]) <= similarity_threshold
-            ]
-            to_filter = []
-            for m in filtered:
-                vnfs_uuid = m.get("filename") or m.get("name")
-                if not vnfs_uuid:
-                    continue
-                try:
-                    d = service.handler.read_dict(vnfs_uuid)
-                    d["similarity_score"] = m.get("similarity_score", 0.0)
-                    to_filter.append(d)
-                except Exception as exc:
-                    logger.warning(f"Could not load vnfs '{vnfs_uuid}': {exc}")
-            result_items = apply_search_filters(
-                to_filter,
+            return service.search(
+                search_term=search_term,
+                max_number_of_results=max_number_of_results,
+                similarity_threshold=similarity_threshold,
                 manifest_filter=manifest_filter,
                 lifecycle_state=lifecycle_state,
             )
-            result_items.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
-            return [
-                {
-                    "filename": s.get("name", ""),
-                    "similarity_score": s.get("similarity_score", 0.0),
-                }
-                for s in result_items
-                if s.get("name")
-            ]
+        except RuntimeError as e:
+            raise HTTPException(status_code=503, detail=str(e))
         except Exception as exc:
             logger.error(f"Error searching vnfs servers: {exc}")
             raise HTTPException(

--- a/src/skillberry_store/fast_api/vnfs_api.py
+++ b/src/skillberry_store/fast_api/vnfs_api.py
@@ -2,25 +2,13 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Annotated, Optional
 
 from fastapi import FastAPI, HTTPException, Query, Request
-from prometheus_client import Counter
 
 from skillberry_store.modules.lifecycle import LifecycleState
 from skillberry_store.schemas.vnfs_schema import VnfsSchema
 from skillberry_store.services.vnfs_service import VnfsService
-
-logger = logging.getLogger(__name__)
-
-prom_prefix = "sts_fastapi_vnfs_"
-create_vnfs_counter = Counter(f"{prom_prefix}create_counter", "vNFS create operations")
-list_vnfs_counter = Counter(f"{prom_prefix}list_counter", "vNFS list operations")
-get_vnfs_counter = Counter(f"{prom_prefix}get_counter", "vNFS get operations")
-delete_vnfs_counter = Counter(f"{prom_prefix}delete_counter", "vNFS delete operations")
-update_vnfs_counter = Counter(f"{prom_prefix}update_counter", "vNFS update operations")
-search_vnfs_counter = Counter(f"{prom_prefix}search_counter", "vNFS search operations")
 
 
 def register_vnfs_api(
@@ -75,8 +63,6 @@ def register_vnfs_api(
             PortConflictError,
         )
 
-        logger.info(f"Request to create vnfs server: {vnfs.name}")
-        create_vnfs_counter.inc()
         try:
             result = service.create(vnfs.to_dict())
             return {
@@ -92,7 +78,6 @@ def register_vnfs_api(
         except ValueError as e:
             raise HTTPException(status_code=500, detail=str(e))
         except Exception as exc:
-            logger.error(f"Error creating vnfs server '{vnfs.name}': {exc}")
             raise HTTPException(
                 status_code=500, detail=f"Error creating vNFS server: {exc}"
             )
@@ -114,12 +99,9 @@ def register_vnfs_api(
         Raises:
             HTTPException: 500 if listing fails.
         """
-        logger.info("Request to list vnfs servers")
-        list_vnfs_counter.inc()
         try:
             return service.list_all(skill_uuid=skill_uuid)
         except Exception as exc:
-            logger.error(f"Error listing vnfs servers: {exc}")
             raise HTTPException(
                 status_code=500, detail=f"Error listing vNFS servers: {exc}"
             )
@@ -144,14 +126,11 @@ def register_vnfs_api(
         Raises:
             HTTPException: 404 if server not found, 500 for other errors.
         """
-        logger.info(f"Request to get vnfs server: {uuid_or_name}")
-        get_vnfs_counter.inc()
         try:
             return service.get(uuid_or_name)
         except KeyError as e:
             raise HTTPException(status_code=404, detail=str(e))
         except Exception as exc:
-            logger.error(f"Error retrieving vnfs server '{uuid_or_name}': {exc}")
             raise HTTPException(
                 status_code=500, detail=f"Error retrieving vNFS server: {exc}"
             )
@@ -175,15 +154,12 @@ def register_vnfs_api(
         Raises:
             HTTPException: 404 if server not found, 500 for other errors.
         """
-        logger.info(f"Request to delete vnfs server: {uuid_or_name}")
-        delete_vnfs_counter.inc()
         try:
             service.delete(uuid_or_name)
             return {"message": f"vNFS server '{uuid_or_name}' deleted successfully."}
         except KeyError as e:
             raise HTTPException(status_code=404, detail=str(e))
         except Exception as exc:
-            logger.error(f"Error deleting vnfs server '{uuid_or_name}': {exc}")
             raise HTTPException(
                 status_code=500, detail=f"Error deleting vNFS server: {exc}"
             )
@@ -212,8 +188,6 @@ def register_vnfs_api(
         Raises:
             HTTPException: 404 if server not found, 500 for other errors.
         """
-        logger.info(f"Request to update vnfs server: {uuid_or_name}")
-        update_vnfs_counter.inc()
         try:
             result = service.update(uuid_or_name, vnfs.to_dict())
             return {
@@ -223,7 +197,6 @@ def register_vnfs_api(
         except KeyError as e:
             raise HTTPException(status_code=404, detail=str(e))
         except Exception as exc:
-            logger.error(f"Error updating vnfs server '{uuid_or_name}': {exc}")
             raise HTTPException(
                 status_code=500, detail=f"Error updating vNFS server: {exc}"
             )
@@ -251,7 +224,6 @@ def register_vnfs_api(
         Raises:
             HTTPException: 404 if server or skill not found, 500 for other errors.
         """
-        logger.info(f"Request to start vnfs server: {uuid_or_name}")
         try:
             server, already_running = service.start(uuid_or_name)
             message = (
@@ -265,7 +237,6 @@ def register_vnfs_api(
         except ValueError as e:
             raise HTTPException(status_code=404, detail=str(e))
         except Exception as exc:
-            logger.error(f"Error starting vnfs server '{uuid_or_name}': {exc}")
             raise HTTPException(
                 status_code=500, detail=f"Error starting vNFS server: {exc}"
             )
@@ -300,8 +271,6 @@ def register_vnfs_api(
         Raises:
             HTTPException: 503 if search is not available, 500 for other errors.
         """
-        logger.info(f"Request to search vnfs servers for: {search_term}")
-        search_vnfs_counter.inc()
         try:
             return service.search(
                 search_term=search_term,
@@ -313,7 +282,6 @@ def register_vnfs_api(
         except RuntimeError as e:
             raise HTTPException(status_code=503, detail=str(e))
         except Exception as exc:
-            logger.error(f"Error searching vnfs servers: {exc}")
             raise HTTPException(
                 status_code=500, detail=f"Error searching vNFS servers: {exc}"
             )

--- a/src/skillberry_store/fast_api/vnfs_api.py
+++ b/src/skillberry_store/fast_api/vnfs_api.py
@@ -70,6 +70,11 @@ def register_vnfs_api(
         Raises:
             HTTPException: 409 if server already exists or port conflict, 500 for other errors.
         """
+        from skillberry_store.services.exceptions import (
+            ObjectAlreadyExistsError,
+            PortConflictError,
+        )
+
         logger.info(f"Request to create vnfs server: {vnfs.name}")
         create_vnfs_counter.inc()
         try:
@@ -80,11 +85,12 @@ def register_vnfs_api(
                 "uuid": result["uuid"],
                 "port": result["port"],
             }
+        except ObjectAlreadyExistsError as e:
+            raise HTTPException(status_code=409, detail=str(e))
+        except PortConflictError as e:
+            raise HTTPException(status_code=409, detail=f"Port conflict: {e}")
         except ValueError as e:
-            status = (
-                409 if "already exists" in str(e) or "not available" in str(e) else 500
-            )
-            raise HTTPException(status_code=status, detail=str(e))
+            raise HTTPException(status_code=500, detail=str(e))
         except Exception as exc:
             logger.error(f"Error creating vnfs server '{vnfs.name}': {exc}")
             raise HTTPException(
@@ -111,17 +117,7 @@ def register_vnfs_api(
         logger.info("Request to list vnfs servers")
         list_vnfs_counter.inc()
         try:
-            result = service.list_all()
-            if skill_uuid:
-                servers = result["virtual_nfs_servers"]
-                result = {
-                    "virtual_nfs_servers": {
-                        k: v
-                        for k, v in servers.items()
-                        if v.get("skill_uuid") == skill_uuid
-                    }
-                }
-            return result
+            return service.list_all(skill_uuid=skill_uuid)
         except Exception as exc:
             logger.error(f"Error listing vnfs servers: {exc}")
             raise HTTPException(

--- a/src/skillberry_store/modules/vmcp_server.py
+++ b/src/skillberry_store/modules/vmcp_server.py
@@ -494,13 +494,8 @@ class VirtualMcpServer:
             raise ValueError(f"Tool {tool_name} not found")
 
         try:
-            from skillberry_store.tools.configure import (
-                get_files_directory_path,
-                get_tools_directory,
-            )
-            from skillberry_store.modules.file_handler import FileHandler
             from skillberry_store.modules.file_executor import FileExecutor
-            from skillberry_store.fast_api.tools_api import find_tool_dependencies
+            from skillberry_store.services.registry import get_service
 
             # Use the manifest cached at server creation time so that a later overwrite of the
             # tool JSON file (e.g. by an MCP wrapper with the same name) cannot cause
@@ -526,13 +521,10 @@ class VirtualMcpServer:
             if not isinstance(module_content, str):
                 raise ValueError(f"Could not read module for tool '{tool_name}'")
 
-            # Load tool dependencies recursively using the shared function
+            # Load tool dependencies recursively via the shared service method.
             dependencies = tool_dict.get("dependencies", [])
-            tools_handler = FileHandler(get_tools_directory())
-            tool_dep_ids = find_tool_dependencies(
-                dependencies=dependencies,
-                tool_handler=self.tools_handler,
-                tool_uuid=tool_uuid,
+            tool_dep_ids = get_service("tool").find_dependencies(
+                dependencies, tool_uuid
             )
 
             dep_dicts = self.tools_handler.read_dicts(list(tool_dep_ids))

--- a/src/skillberry_store/modules/vmcp_server.py
+++ b/src/skillberry_store/modules/vmcp_server.py
@@ -4,11 +4,33 @@ import socket
 import time
 
 import requests
+from prometheus_client import Counter, Histogram
 from pydantic import Field
 from typing import Annotated, Any, List, Optional
 
 from mcp.server.fastmcp import FastMCP
 from skillberry_store.modules.object_handler import get_object_handler
+
+
+# observability - metrics for runtime tool invocation inside the VMCP server.
+# These belong here (not in the FastAPI layer) because they describe runtime
+# behaviour of the running VMCP server, not HTTP requests.
+_prom_prefix = "sts_vmcp_runtime_"
+invoke_vmcp_tool_counter = Counter(
+    f"{_prom_prefix}invoke_vmcp_tool_counter",
+    "Count number of vmcp tool invoke operations",
+    ["server_name", "tool_name"],
+)
+invoke_successfully_vmcp_tool_counter = Counter(
+    f"{_prom_prefix}invoke_successfully_vmcp_tool_counter",
+    "Count number of vmcp tool invoked successfully operations",
+    ["server_name", "tool_name"],
+)
+invoke_successfully_vmcp_tool_latency = Histogram(
+    f"{_prom_prefix}invoke_successfully_vmcp_tool_latency",
+    "Histogram of invoke vmcp tool successfully latencies",
+    ["server_name", "tool_name"],
+)
 
 
 def _patch_sse_starlette_for_multi_loop() -> None:
@@ -476,13 +498,6 @@ class VirtualMcpServer:
         Returns:
             result: The result of the tool invocation.
         """
-        # Import metrics here to avoid circular imports
-        from skillberry_store.fast_api.vmcp_api import (
-            invoke_vmcp_tool_counter,
-            invoke_successfully_vmcp_tool_counter,
-            invoke_successfully_vmcp_tool_latency,
-        )
-
         # Record invocation attempt
         invoke_vmcp_tool_counter.labels(
             server_name=self.name, tool_name=tool_name

--- a/src/skillberry_store/modules/vmcp_server.py
+++ b/src/skillberry_store/modules/vmcp_server.py
@@ -11,7 +11,6 @@ from typing import Annotated, Any, List, Optional
 from mcp.server.fastmcp import FastMCP
 from skillberry_store.modules.object_handler import get_object_handler
 
-
 # observability - metrics for runtime tool invocation inside the VMCP server.
 # These belong here (not in the FastAPI layer) because they describe runtime
 # behaviour of the running VMCP server, not HTTP requests.

--- a/src/skillberry_store/plugins/events.py
+++ b/src/skillberry_store/plugins/events.py
@@ -115,16 +115,29 @@ def emit_event(event_name: str, **kwargs):
     Returns immediately. Handlers run concurrently on the running event loop.
     If a handler raises, the error is logged and other handlers still run.
 
+    When no event loop is running (e.g., a synchronous caller from a unit test
+    or CLI), handlers are skipped silently — they are fire-and-forget by design.
+
     Args:
         event_name: Name of the event (e.g., "content_added:tool")
         **kwargs: Arguments to pass to event handlers
     """
     handlers = _event_handlers.get(event_name, [])
+    if not handlers:
+        return
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        logger.debug(
+            f"emit_event({event_name!r}): no running event loop, "
+            f"skipping {len(handlers)} handler(s)"
+        )
+        return
     for handler in handlers:
         owner = _handler_owners.get(handler)
         if owner is not None and _enabled_resolver is not None and not _enabled_resolver(owner):
             continue
-        task = asyncio.create_task(_run_handler(handler, **kwargs))
+        task = loop.create_task(_run_handler(handler, **kwargs))
         _background_tasks.add(task)
         task.add_done_callback(_background_tasks.discard)
 

--- a/src/skillberry_store/services/exceptions.py
+++ b/src/skillberry_store/services/exceptions.py
@@ -1,0 +1,18 @@
+"""Service-layer exception types shared across services."""
+
+
+class ObjectAlreadyExistsError(ValueError):
+    """Raised when an object with the given identifier already exists.
+
+    Subclasses ``ValueError`` so legacy callers that catch ``ValueError`` for
+    duplicate-object detection continue to work.
+    """
+
+
+class PortConflictError(ValueError):
+    """Raised when a runtime server cannot bind because the requested port
+    (or the auto-allocated port) is already in use or otherwise unavailable.
+
+    Subclasses ``ValueError`` so legacy callers that catch ``ValueError`` for
+    creation failures continue to work.
+    """

--- a/src/skillberry_store/services/registry.py
+++ b/src/skillberry_store/services/registry.py
@@ -1,0 +1,124 @@
+"""Service registry: singleton access to *Service instances.
+
+Mirrors the object-handler registry in ``skillberry_store.modules.object_handler``.
+Initialize once at server startup with ``initialize_services(...)``; thereafter,
+``get_service(<type>)`` returns the singleton for that object type.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+if TYPE_CHECKING:
+    from skillberry_store.modules.description import Description
+    from skillberry_store.modules.vmcp_server_manager import VirtualMcpServerManager
+    from skillberry_store.modules.vnfs_server_manager import VirtualNfsServerManager
+
+logger = logging.getLogger(__name__)
+
+_services: Dict[str, Any] = {}
+_initialized = False
+
+
+def initialize_services(
+    *,
+    tools_descriptions: Optional["Description"] = None,
+    snippets_descriptions: Optional["Description"] = None,
+    skills_descriptions: Optional["Description"] = None,
+    vmcp_descriptions: Optional["Description"] = None,
+    vnfs_descriptions: Optional["Description"] = None,
+    vmcp_server_manager: Optional["VirtualMcpServerManager"] = None,
+    vnfs_server_manager: Optional["VirtualNfsServerManager"] = None,
+) -> None:
+    """Initialize all service singletons. Idempotent.
+
+    Each service is keyed by its object type ("tool", "snippet", "skill",
+    "vmcp", "vnfs") and uses the singleton object handler from
+    ``get_object_handler``.
+
+    Args:
+        tools_descriptions: Optional Description for tools.
+        snippets_descriptions: Optional Description for snippets.
+        skills_descriptions: Optional Description for skills.
+        vmcp_descriptions: Optional Description for VMCP servers.
+        vnfs_descriptions: Optional Description for vNFS servers.
+        vmcp_server_manager: Required ``VirtualMcpServerManager`` for the
+            VMCP service.
+        vnfs_server_manager: Required ``VirtualNfsServerManager`` for the
+            vNFS service.
+    """
+    global _initialized
+    if _initialized:
+        logger.warning("Services already initialized, skipping")
+        return
+
+    from skillberry_store.modules.object_handler import get_object_handler
+    from skillberry_store.services.skills_service import SkillsService
+    from skillberry_store.services.snippets_service import SnippetsService
+    from skillberry_store.services.tools_service import ToolsService
+    from skillberry_store.services.vmcp_service import VmcpService
+    from skillberry_store.services.vnfs_service import VnfsService
+
+    _services["tool"] = ToolsService(
+        get_object_handler("tool"),
+        tools_descriptions,
+    )
+    _services["snippet"] = SnippetsService(
+        get_object_handler("snippet"),
+        snippets_descriptions,
+    )
+    _services["skill"] = SkillsService(
+        handler=get_object_handler("skill"),
+        descriptions=skills_descriptions,
+    )
+    _services["vmcp"] = VmcpService(
+        get_object_handler("vmcp"),
+        vmcp_server_manager,
+        vmcp_descriptions,
+    )
+    _services["vnfs"] = VnfsService(
+        get_object_handler("vnfs"),
+        vnfs_server_manager,
+        vnfs_descriptions,
+    )
+    _initialized = True
+    logger.info(
+        f"Initialized {len(_services)} services: {list(_services.keys())}"
+    )
+
+
+def get_service(service_type: str) -> Any:
+    """Return the singleton service for ``service_type``.
+
+    Args:
+        service_type: One of "tool", "snippet", "skill", "vmcp", "vnfs".
+
+    Returns:
+        The singleton service instance.
+
+    Raises:
+        RuntimeError: If services have not been initialized.
+        ValueError: If the service type is not recognized.
+    """
+    if not _initialized:
+        raise RuntimeError(
+            "Services not initialized. Call initialize_services(...) first."
+        )
+    if service_type not in _services:
+        raise ValueError(
+            f"Unknown service type: '{service_type}'. "
+            f"Valid types: {list(_services.keys())}"
+        )
+    return _services[service_type]
+
+
+def clear_services() -> None:
+    """Clear all services. Useful for testing.
+
+    Resets the global state so the registry can be reinitialized. Should
+    primarily be used in test cleanup.
+    """
+    global _initialized
+    _services.clear()
+    _initialized = False

--- a/src/skillberry_store/services/skills_service.py
+++ b/src/skillberry_store/services/skills_service.py
@@ -11,41 +11,51 @@ from skillberry_store.utils.utils import generate_or_validate_uuid
 
 if TYPE_CHECKING:
     from skillberry_store.modules.description import Description
+    from skillberry_store.modules.lifecycle import LifecycleState
 
 logger = logging.getLogger(__name__)
 
 
+class GithubApiError(Exception):
+    """Error returned from a GitHub API call.
+
+    Carries the upstream HTTP ``status_code`` so callers can surface a faithful
+    error to their own clients without becoming FastAPI-aware.
+    """
+
+    def __init__(self, status_code: int, message: str):
+        super().__init__(message)
+        self.status_code = status_code
+        self.message = message
+
+
 class SkillsService:
     """Service layer for skill CRUD operations.
-    
+
     Provides business logic for managing skills, which are high-level compositions
-    that group related tools and snippets together.
-    
+    that group related tools and snippets together. Sibling-service operations
+    (e.g. resolving tool/snippet objects in :meth:`populate_objects`,
+    :meth:`import_anthropic`, :meth:`export_anthropic`, and :meth:`delete`'s
+    cascade path) are routed through
+    :func:`skillberry_store.services.registry.get_service`.
+
     Attributes:
         handler: ObjectHandler for skill persistence operations.
-        tools_handler: ObjectHandler for resolving tool references.
-        snippets_handler: ObjectHandler for resolving snippet references.
         descriptions: Optional Description instance for semantic search indexing.
     """
-    
+
     def __init__(
         self,
         handler: ObjectHandler,
-        tools_handler: ObjectHandler,
-        snippets_handler: ObjectHandler,
         descriptions: Optional[Description] = None,
     ):
         """Initialize the SkillsService.
-        
+
         Args:
             handler: ObjectHandler instance for skill operations.
-            tools_handler: ObjectHandler instance for tool operations.
-            snippets_handler: ObjectHandler instance for snippet operations.
             descriptions: Optional Description instance for managing skill descriptions.
         """
         self.handler = handler
-        self.tools_handler = tools_handler
-        self.snippets_handler = snippets_handler
         self.descriptions = descriptions
 
     def _resolve_uuid(self, uuid_or_name: str) -> str:
@@ -69,24 +79,30 @@ class SkillsService:
 
     def populate_objects(self, skill_dict: Dict[str, Any]) -> Dict[str, Any]:
         """Populate full tool and snippet objects from their UUIDs.
-        
-        Resolves tool_uuids and snippet_uuids to their complete metadata objects
-        and adds them as 'tools' and 'snippets' lists in the skill dictionary.
-        
+
+        Resolves ``tool_uuids`` and ``snippet_uuids`` to their complete metadata
+        objects via the sibling :class:`ToolsService` / :class:`SnippetsService`
+        singletons (obtained from
+        :func:`skillberry_store.services.registry.get_service`) and adds them
+        as ``tools`` and ``snippets`` lists in the skill dictionary.
+
         Args:
             skill_dict: Skill dictionary containing tool_uuids and snippet_uuids.
-            
+
         Returns:
             Dict[str, Any]: The skill dictionary with 'tools' and 'snippets' populated.
-            
+
         Raises:
             RuntimeError: If any referenced tool or snippet is missing or invalid.
         """
+        from skillberry_store.services.registry import get_service
+
         if skill_dict.get("tool_uuids"):
             try:
-                skill_dict["tools"] = self.tools_handler.read_dicts(
-                    skill_dict["tool_uuids"]
-                )
+                tools_service = get_service("tool")
+                skill_dict["tools"] = [
+                    tools_service.get(uuid) for uuid in skill_dict["tool_uuids"]
+                ]
             except Exception as e:
                 raise RuntimeError(
                     f"Skill '{skill_dict.get('name')}' references missing tools: {e}"
@@ -95,9 +111,10 @@ class SkillsService:
             skill_dict["tools"] = []
         if skill_dict.get("snippet_uuids"):
             try:
-                skill_dict["snippets"] = self.snippets_handler.read_dicts(
-                    skill_dict["snippet_uuids"]
-                )
+                snippets_service = get_service("snippet")
+                skill_dict["snippets"] = [
+                    snippets_service.get(uuid) for uuid in skill_dict["snippet_uuids"]
+                ]
             except Exception as e:
                 raise RuntimeError(
                     f"Skill '{skill_dict.get('name')}' references missing snippets: {e}"
@@ -183,10 +200,10 @@ class SkillsService:
 
     def list_all(self, filters: Optional[Dict] = None) -> List[Dict[str, Any]]:
         """List all skills with optional filtering and populated objects.
-        
+
         Args:
             filters: Optional dictionary of field:value pairs to filter by.
-            
+
         Returns:
             List[Dict[str, Any]]: List of skill metadata dictionaries with tools and snippets populated,
                                   sorted by modified_at descending.
@@ -203,6 +220,83 @@ class SkillsService:
                 item.setdefault("snippets", [])
         items.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
         return items
+
+    def search(
+        self,
+        search_term: str,
+        max_number_of_results: int = 5,
+        similarity_threshold: float = 1.0,
+        manifest_filter: str = ".",
+        lifecycle_state: Optional["LifecycleState"] = None,
+    ) -> List[Dict[str, Any]]:
+        """Search skills by semantic similarity to a search term.
+
+        Performs a vector-similarity search over skill descriptions, then filters
+        by similarity threshold, manifest properties, and lifecycle state, and
+        returns matched names with similarity scores sorted by ``modified_at``
+        (most recent first).
+
+        Args:
+            search_term: Free-text query to match against skill descriptions.
+            max_number_of_results: Upper bound on candidates returned by the
+                vector index before threshold filtering.
+            similarity_threshold: Maximum allowed similarity score (lower is
+                more similar). Candidates above this score are discarded.
+            manifest_filter: Manifest property filter expression
+                (e.g. ``"tags:python"``, ``"state:approved"``).
+            lifecycle_state: Lifecycle state filter. Defaults to
+                ``LifecycleState.ANY`` when ``None`` is passed.
+
+        Returns:
+            List[Dict[str, Any]]: Matches, each ``{"filename": <name>, "similarity_score": <float>}``.
+
+        Raises:
+            RuntimeError: If the service was constructed without a
+                ``Description`` instance (search index unavailable).
+        """
+        from skillberry_store.modules.lifecycle import LifecycleState
+        from skillberry_store.fast_api.search_filters import apply_search_filters
+
+        if lifecycle_state is None:
+            lifecycle_state = LifecycleState.ANY
+        if not self.descriptions:
+            raise RuntimeError(
+                "Skill search is not available - descriptions not initialized"
+            )
+
+        matched_entities = self.descriptions.search_description(
+            search_term=search_term, k=max_number_of_results
+        )
+        filtered_matched = [
+            m
+            for m in matched_entities
+            if float(m["similarity_score"]) <= similarity_threshold
+        ]
+        candidates: List[Dict[str, Any]] = []
+        for matched in filtered_matched:
+            skill_uuid = matched.get("filename")
+            if not skill_uuid:
+                continue
+            try:
+                skill_dict = self.handler.read_dict(skill_uuid)
+                skill_dict["similarity_score"] = matched.get("similarity_score", 0.0)
+                candidates.append(skill_dict)
+            except Exception as e:
+                logger.warning(f"Could not load skill {skill_uuid}: {e}")
+        filtered_skills = apply_search_filters(
+            candidates,
+            manifest_filter=manifest_filter,
+            lifecycle_state=lifecycle_state,
+        )
+        filtered_skills.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
+        return [
+            {
+                "filename": s.get("name", ""),
+                "similarity_score": s.get("similarity_score", 0.0),
+            }
+            for s in filtered_skills
+            if s.get("name")
+        ]
 
     def update(self, uuid_or_name: str, data: Dict[str, Any]) -> Dict[str, Any]:
         """Update an existing skill's metadata.
@@ -241,24 +335,433 @@ class SkillsService:
         logger.info(f"Skill '{uuid_or_name}' updated")
         return merged
 
-    def delete(self, uuid_or_name: str) -> None:
-        """Delete a skill.
-        
-        Removes the skill metadata, cache entries, and description indexes.
-        Does not delete referenced tools or snippets.
-        
+    def detect_anthropic_skills(
+        self,
+        source_type: str,
+        github_url: Optional[str] = None,
+        folder_path: Optional[str] = None,
+        override_token: Optional[str] = None,
+        anonymous: bool = True,
+    ) -> List[str]:
+        """Detect child skill directories in a parent location.
+
+        Scans a parent location (GitHub URL or local folder) and returns the
+        names of subdirectories that contain a ``SKILL.md`` file.
+
+        Args:
+            source_type: ``"url"`` or ``"folder"``.
+            github_url: GitHub repository URL. Required when
+                ``source_type == "url"``.
+            folder_path: Local folder path. Required when
+                ``source_type == "folder"``. Must resolve to a path within the
+                current user's home directory.
+            override_token: Optional auth token forwarded to the
+                per-endpoint auth resolver.
+            anonymous: Whether to attempt anonymous GitHub access.
+
+        Returns:
+            List[str]: Names of subdirectories that contain ``SKILL.md``.
+
+        Raises:
+            ValueError: If inputs are invalid (missing required field, bad
+                ``source_type``, folder outside home, folder does not exist or
+                is not a directory).
+            ReauthRequired: If interactive re-authentication is needed for the
+                GitHub endpoint. Propagated untouched from the auth resolver.
+            GithubApiError: If GitHub returns a non-OK response while listing
+                the parent or child directories.
+            RuntimeError: For unexpected filesystem errors while reading the
+                local folder.
+        """
+        import os
+        import re
+
+        import requests
+
+        from skillberry_store.tools.endpoint_auth import resolve_auth_headers
+
+        skill_paths: List[str] = []
+
+        if source_type == "url":
+            if not github_url:
+                raise ValueError("github_url is required for source_type='url'")
+            auth_headers = resolve_auth_headers(
+                github_url,
+                override_token=override_token,
+                anonymous=anonymous,
+            )
+            api_url = github_url.replace("github.com", "api.github.com/repos")
+            api_url = re.sub(r"/tree/(main|master)/", r"/contents/", api_url)
+            logger.info(f"Fetching directory listing from: {api_url}")
+            response = requests.get(api_url, headers=auth_headers, timeout=30)
+            if not response.ok:
+                raise GithubApiError(
+                    response.status_code,
+                    f"GitHub API error: {response.text or response.reason}",
+                )
+            items = response.json()
+            for item in items:
+                if item["type"] == "dir":
+                    dir_name = item["name"]
+                    dir_api_url = item["url"]
+                    try:
+                        dir_response = requests.get(
+                            dir_api_url, headers=auth_headers, timeout=30
+                        )
+                        if dir_response.ok:
+                            dir_items = dir_response.json()
+                            has_skill_md = any(
+                                f["name"].upper() == "SKILL.MD"
+                                and f["type"] == "file"
+                                for f in dir_items
+                            )
+                            if has_skill_md:
+                                skill_paths.append(dir_name)
+                                logger.info(f"Found skill directory: {dir_name}")
+                    except Exception as e:
+                        logger.warning(f"Failed to check directory {dir_name}: {e}")
+        elif source_type == "folder":
+            if not folder_path:
+                raise ValueError(
+                    "folder_path is required for source_type='folder'"
+                )
+            home_dir = os.path.realpath(os.path.expanduser("~"))
+            abs_input = os.path.realpath(folder_path)
+            if not (
+                abs_input == home_dir or abs_input.startswith(home_dir + os.sep)
+            ):
+                raise ValueError(
+                    "folder_path must be within the current user's home directory"
+                )
+            if abs_input == home_dir:
+                safe_root = home_dir
+            else:
+                rel = abs_input[len(home_dir) + len(os.sep) :]
+                clean_parts = [os.path.basename(p) for p in rel.split(os.sep) if p]
+                safe_root = os.path.join(home_dir, *clean_parts)
+            if not os.path.exists(safe_root):
+                raise ValueError("Folder does not exist")
+            if not os.path.isdir(safe_root):
+                raise ValueError("Path is not a directory")
+            try:
+                for entry in os.listdir(safe_root):  # lgtm[py/path-injection]
+                    if entry != os.path.basename(entry):
+                        continue
+                    entry_path = os.path.join(safe_root, entry)
+                    if os.path.realpath(entry_path).startswith(
+                        safe_root + os.sep
+                    ) and os.path.isdir(entry_path):
+                        skill_md_path = os.path.join(entry_path, "SKILL.md")
+                        if os.path.isfile(skill_md_path):
+                            skill_paths.append(entry)
+                            logger.info(f"Found skill directory: {entry}")
+            except Exception as e:
+                raise RuntimeError(f"Error reading directory: {str(e)}")
+        else:
+            raise ValueError(
+                f"Invalid source_type: {source_type}. Must be 'url' or 'folder'"
+            )
+        logger.info(f"Detected {len(skill_paths)} skill directories")
+        return skill_paths
+
+    def export_anthropic(self, uuid_or_name: str) -> bytes:
+        """Export a skill to the Anthropic format as a ZIP byte payload.
+
+        Resolves the skill, gathers its tools (with their module contents) and
+        snippets via the sibling :class:`ToolsService` / :class:`SnippetsService`
+        singletons (obtained from
+        :func:`skillberry_store.services.registry.get_service`), and produces a
+        ZIP archive in the Anthropic skill layout.
+
+        Args:
+            uuid_or_name: Skill UUID or name to export.
+
+        Returns:
+            bytes: The ZIP archive contents. Caller is responsible for setting
+                content disposition / media type.
+
+        Raises:
+            KeyError: If the skill is not found.
+        """
+        from skillberry_store.services.registry import get_service
+        from skillberry_store.tools.anthropic.exporter import (
+            export_skill_to_anthropic_format,
+        )
+
+        skill_uuid = self._resolve_uuid(uuid_or_name)
+        skill_dict = self._safe_read(skill_uuid, uuid_or_name)
+        tools_service = get_service("tool")
+        snippets_service = get_service("snippet")
+
+        tools: List[Dict[str, Any]] = []
+        tool_modules: Dict[str, str] = {}
+        for tool_uuid in skill_dict.get("tool_uuids") or []:
+            tool_dict = tools_service.get(tool_uuid)
+            tools.append(tool_dict)
+            tool_name = tool_dict.get("name")
+            module_name = tool_dict.get("module_name")
+            if tool_name and module_name:
+                try:
+                    tool_modules[tool_name] = tools_service.get_module(tool_uuid)
+                except Exception as e:
+                    logger.warning(
+                        f"Could not read module for tool {tool_name}: {e}"
+                    )
+
+        snippets: List[Dict[str, Any]] = [
+            snippets_service.get(snippet_uuid)
+            for snippet_uuid in skill_dict.get("snippet_uuids") or []
+        ]
+
+        return export_skill_to_anthropic_format(
+            skill=skill_dict,
+            tools=tools,
+            snippets=snippets,
+            tool_modules=tool_modules,
+        )
+
+    def import_anthropic(
+        self,
+        source_type: str,
+        source_data: Any,
+        snippet_mode: str = "file",
+        treat_all_as_documents: bool = False,
+        tags: Optional[List[str]] = None,
+        override_token: Optional[str] = None,
+        anonymous: bool = True,
+        github_url: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Import an Anthropic skill into the store.
+
+        Imports tools, snippets, and the skill manifest from an Anthropic skill
+        source (URL, ZIP bytes, or folder path), creating each item via its
+        respective service. Cross-tool dependencies within the imported batch
+        are resolved by passing the batch's name->UUID map to
+        ``ToolsService.create`` via its ``extra_name_to_uuid`` parameter, so
+        no dependency detection is duplicated here.
+
+        Args:
+            source_type: ``"url"``, ``"zip"``, or ``"folder"``.
+            source_data: GitHub URL (str), ZIP bytes (bytes), or folder path (str).
+            snippet_mode: ``"file"`` or ``"paragraph"`` for snippet import mode.
+            treat_all_as_documents: If True, treat all files as document snippets.
+            tags: Additional tags applied to the skill, every imported tool, and
+                every imported snippet.
+            override_token: Optional auth token forwarded to the per-endpoint
+                auth resolver.
+            anonymous: Whether to attempt anonymous access.
+            github_url: Original GitHub URL (for origin tracking) when
+                ``source_type == "url"``. When set, the resulting skill's
+                ``extra.origin`` is populated with parsed GitHub coordinates.
+
+        Returns:
+            Dict[str, Any]: ``{"skill_name", "skill_uuid", "tools_created",
+                "snippets_created", "ignored_files"}``.
+
+        Raises:
+            ReauthRequired: If interactive re-authentication is required for
+                the import source's endpoint.
+        """
+        from skillberry_store.services.registry import get_service
+        from skillberry_store.tools.anthropic.importer import (
+            import_from_anthropic_skill,
+            parse_github_origin,
+        )
+
+        tags = tags or []
+        tools_service = get_service("tool")
+        snippets_service = get_service("snippet")
+
+        (
+            skill_name,
+            skill_description,
+            imported_tools,
+            imported_snippets,
+            ignored_files,
+        ) = import_from_anthropic_skill(
+            source_type=source_type,
+            source_data=source_data,
+            snippet_mode=snippet_mode,
+            treat_all_as_documents=treat_all_as_documents,
+            override_token=override_token,
+            anonymous=anonymous,
+        )
+
+        # Pre-allocate tool UUIDs so cross-tool deps within this batch can be
+        # resolved by ToolsService.create's auto-detection.
+        all_tool_names: Dict[str, str] = {}
+        for tool in imported_tools:
+            tool.uuid = generate_or_validate_uuid(None)
+            all_tool_names[tool.name] = tool.uuid
+
+        created_tool_uuids: List[str] = []
+        for tool in imported_tools:
+            try:
+                tool_dict = tool.to_dict()
+                tool_name = tool_dict["name"]
+                ext = (
+                    ".py" if tool_dict["programmingLanguage"] == "python" else ".sh"
+                )
+                module_filename = f"{tool_name}{ext}"
+                tool_tags = tool_dict["tags"].copy() if tool_dict["tags"] else []
+                for tag in tags:
+                    if tag and tag not in tool_tags:
+                        tool_tags.append(tag)
+                tool_data: Dict[str, Any] = {
+                    "uuid": tool.uuid,
+                    "name": tool_name,
+                    "version": tool_dict["version"],
+                    "description": tool_dict["description"],
+                    "tags": tool_tags,
+                    "programming_language": tool_dict["programmingLanguage"],
+                    "packaging_format": "code",
+                    "state": "approved",
+                }
+                if tool_dict.get("params"):
+                    tool_data["params"] = tool_dict["params"]
+                if tool_dict.get("returns"):
+                    tool_data["returns"] = tool_dict["returns"]
+                tools_service.create(
+                    tool_data,
+                    module_content=tool_dict["moduleContent"],
+                    module_filename=module_filename,
+                    extra_name_to_uuid=all_tool_names,
+                )
+                created_tool_uuids.append(tool.uuid)
+            except Exception as e:
+                logger.error(f"Failed to create tool {tool.name}: {e}")
+
+        created_snippet_uuids: List[str] = []
+        for snippet in imported_snippets:
+            try:
+                snippet_dict = snippet.to_dict()
+                snippet_tags = (
+                    snippet_dict["tags"].copy() if snippet_dict["tags"] else []
+                )
+                for tag in tags:
+                    if tag and tag not in snippet_tags:
+                        snippet_tags.append(tag)
+                snippet_data = {
+                    "name": snippet_dict["name"],
+                    "version": snippet_dict["version"],
+                    "description": snippet_dict["description"],
+                    "content": snippet_dict["content"],
+                    "tags": snippet_tags,
+                    "content_type": "text/plain",
+                    "state": "approved",
+                }
+                result = snippets_service.create(snippet_data)
+                created_snippet_uuids.append(result["uuid"])
+            except Exception as e:
+                logger.error(f"Failed to create snippet {snippet.name}: {e}")
+
+        skill_tags = ["anthropic", "imported"]
+        for tag in tags:
+            if tag and tag not in skill_tags:
+                skill_tags.append(tag)
+
+        skill_extra: Dict[str, Any] = {}
+        if source_type == "url" and github_url:
+            origin = parse_github_origin(github_url)
+            skill_extra["origin"] = {
+                "type": "github" if origin else "url",
+                "url": github_url,
+                **(origin or {}),
+            }
+
+        skill_data: Dict[str, Any] = {
+            "name": skill_name,
+            "version": "1.0.0",
+            "description": skill_description,
+            "tags": skill_tags,
+            "tool_uuids": created_tool_uuids,
+            "snippet_uuids": created_snippet_uuids,
+            "state": "approved",
+            "extra": skill_extra,
+        }
+        skill_result = self.create(skill_data)
+
+        return {
+            "skill_name": skill_result.get("name", skill_name),
+            "skill_uuid": skill_result.get("uuid"),
+            "tools_created": len(created_tool_uuids),
+            "snippets_created": len(created_snippet_uuids),
+            "ignored_files": ignored_files,
+        }
+
+    def delete(
+        self,
+        uuid_or_name: str,
+        delete_tools: bool = False,
+        delete_snippets: bool = False,
+    ) -> Dict[str, List[str]]:
+        """Delete a skill, optionally cascading to its unshared tools and snippets.
+
+        Removes the skill metadata, cache entries, and description indexes. When
+        ``delete_tools`` (resp. ``delete_snippets``) is True, also deletes any tool
+        (resp. snippet) referenced by this skill that is not referenced by any
+        other skill. Sibling services are obtained from
+        :func:`skillberry_store.services.registry.get_service`.
+
         Args:
             uuid_or_name: Skill UUID or name to delete.
-            
+            delete_tools: If True, cascade-delete tools that are not referenced
+                by any other skill.
+            delete_snippets: If True, cascade-delete snippets that are not
+                referenced by any other skill.
+
+        Returns:
+            Dict[str, List[str]]: ``{"deleted_tools": [...], "deleted_snippets": [...]}``
+                — UUIDs of cascade-deleted tools and snippets. Both lists are
+                empty when no cascade is requested or no unshared item is
+                found.
+
         Raises:
             KeyError: If skill not found.
         """
+        from skillberry_store.services.registry import get_service
+
         uuid = self._resolve_uuid(uuid_or_name)
+        skill: Optional[Dict[str, Any]] = None
         try:
-            d = self.handler.read_dict(uuid)
-            name, parent = d.get("name"), d.get("parent")
+            skill = self.handler.read_dict(uuid)
         except Exception:
-            name, parent = None, None
+            pass
+        deleted_tools: List[str] = []
+        deleted_snippets: List[str] = []
+        if skill is not None and (delete_tools or delete_snippets):
+            tools_service = get_service("tool")
+            snippets_service = get_service("snippet")
+            skill_uuid = skill.get("uuid") or uuid
+            all_skills = self.handler.list_all_dicts()
+            shared_tool_uuids: set = set()
+            shared_snippet_uuids: set = set()
+            for s in all_skills:
+                if s.get("uuid") != skill_uuid:
+                    shared_tool_uuids.update(s.get("tool_uuids") or [])
+                    shared_snippet_uuids.update(s.get("snippet_uuids") or [])
+            if delete_tools:
+                for tool_uuid in skill.get("tool_uuids") or []:
+                    if tool_uuid not in shared_tool_uuids:
+                        try:
+                            tools_service.delete(tool_uuid)
+                            deleted_tools.append(tool_uuid)
+                        except Exception as e:
+                            logger.warning(
+                                f"Could not cascade-delete tool {tool_uuid}: {e}"
+                            )
+            if delete_snippets:
+                for snippet_uuid in skill.get("snippet_uuids") or []:
+                    if snippet_uuid not in shared_snippet_uuids:
+                        try:
+                            snippets_service.delete(snippet_uuid)
+                            deleted_snippets.append(snippet_uuid)
+                        except Exception as e:
+                            logger.warning(
+                                f"Could not cascade-delete snippet {snippet_uuid}: {e}"
+                            )
+        name = (skill or {}).get("name")
+        parent = (skill or {}).get("parent")
         if uuid and name:
             self.handler.update_cache(
                 uuid, new_name=None, old_name=name, old_parent=parent
@@ -270,3 +773,4 @@ class SkillsService:
             except Exception as e:
                 logger.warning(f"Could not delete skill description for {uuid}: {e}")
         logger.info(f"Skill '{uuid_or_name}' deleted")
+        return {"deleted_tools": deleted_tools, "deleted_snippets": deleted_snippets}

--- a/src/skillberry_store/services/skills_service.py
+++ b/src/skillberry_store/services/skills_service.py
@@ -6,7 +6,14 @@ import logging
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+from prometheus_client import Counter
+
 from skillberry_store.modules.object_handler import ObjectHandler
+from skillberry_store.plugins.events import (
+    emit_content_added,
+    emit_content_deleted,
+    emit_content_updated,
+)
 from skillberry_store.utils.utils import generate_or_validate_uuid
 
 if TYPE_CHECKING:
@@ -14,6 +21,39 @@ if TYPE_CHECKING:
     from skillberry_store.modules.lifecycle import LifecycleState
 
 logger = logging.getLogger(__name__)
+
+# observability - metrics
+prom_prefix = "sts_service_skills_"
+create_skill_counter = Counter(
+    f"{prom_prefix}create_skill_counter", "Count number of skill create operations"
+)
+list_skills_counter = Counter(
+    f"{prom_prefix}list_skills_counter", "Count number of skill list operations"
+)
+get_skill_counter = Counter(
+    f"{prom_prefix}get_skill_counter", "Count number of skill get operations"
+)
+delete_skill_counter = Counter(
+    f"{prom_prefix}delete_skill_counter", "Count number of skill delete operations"
+)
+update_skill_counter = Counter(
+    f"{prom_prefix}update_skill_counter", "Count number of skill update operations"
+)
+search_skills_counter = Counter(
+    f"{prom_prefix}search_skills_counter", "Count number of skill search operations"
+)
+detect_anthropic_skills_counter = Counter(
+    f"{prom_prefix}detect_anthropic_skills_counter",
+    "Count number of detect-anthropic-skills operations",
+)
+import_anthropic_skill_counter = Counter(
+    f"{prom_prefix}import_anthropic_skill_counter",
+    "Count number of import-anthropic-skill operations",
+)
+export_anthropic_skill_counter = Counter(
+    f"{prom_prefix}export_anthropic_skill_counter",
+    "Count number of export-anthropic-skill operations",
+)
 
 
 class GithubApiError(Exception):
@@ -138,23 +178,31 @@ class SkillsService:
         Raises:
             ValueError: If skill with the same UUID already exists.
         """
-        data["uuid"] = generate_or_validate_uuid(data.get("uuid"))
-        if self.handler.object_exists(data["uuid"]):
-            raise ValueError(f"Skill with UUID '{data['uuid']}' already exists")
-        now = datetime.now(timezone.utc).isoformat()
-        data.setdefault("created_at", now)
-        data["modified_at"] = now
-        if data.get("name"):
-            data["parent"] = self.handler.get_cache_parent_for_head(
-                data["uuid"], data["name"]
-            )
-        self.handler.write_dict(data["uuid"], data)
-        if data.get("name"):
-            self.handler.update_cache(data["uuid"], new_name=data["name"])
-        if self.descriptions and data.get("description"):
-            self.descriptions.write_description(data["uuid"], data["description"])
-        logger.info(f"Skill '{data.get('name')}' created with UUID {data['uuid']}")
-        return data
+        create_skill_counter.inc()
+        try:
+            data["uuid"] = generate_or_validate_uuid(data.get("uuid"))
+            if self.handler.object_exists(data["uuid"]):
+                raise ValueError(f"Skill with UUID '{data['uuid']}' already exists")
+            now = datetime.now(timezone.utc).isoformat()
+            data.setdefault("created_at", now)
+            data["modified_at"] = now
+            if data.get("name"):
+                data["parent"] = self.handler.get_cache_parent_for_head(
+                    data["uuid"], data["name"]
+                )
+            self.handler.write_dict(data["uuid"], data)
+            if data.get("name"):
+                self.handler.update_cache(data["uuid"], new_name=data["name"])
+            if self.descriptions and data.get("description"):
+                self.descriptions.write_description(data["uuid"], data["description"])
+            emit_content_added("skill", data["uuid"])
+            logger.info(f"Skill '{data.get('name')}' created with UUID {data['uuid']}")
+            return data
+        except ValueError:
+            raise
+        except Exception as e:
+            logger.error(f"Error creating skill '{data.get('name')}': {e}")
+            raise
 
     def _safe_read(self, uuid: str, label: str) -> Dict[str, Any]:
         """Safely read a skill dictionary with error handling.
@@ -178,25 +226,32 @@ class SkillsService:
 
     def get(self, uuid_or_name: str) -> Dict[str, Any]:
         """Get skill metadata by UUID or name with populated tool and snippet objects.
-        
+
         Args:
             uuid_or_name: Skill UUID or name.
-            
+
         Returns:
             Dict[str, Any]: Skill metadata dictionary with 'tools' and 'snippets' populated.
-            
+
         Raises:
             KeyError: If skill not found.
         """
-        uuid = self._resolve_uuid(uuid_or_name)
-        skill = self._safe_read(uuid, uuid_or_name)
+        get_skill_counter.inc()
         try:
-            return self.populate_objects(skill)
-        except RuntimeError as e:
-            logger.warning(str(e))
-            skill.setdefault("tools", [])
-            skill.setdefault("snippets", [])
-            return skill
+            uuid = self._resolve_uuid(uuid_or_name)
+            skill = self._safe_read(uuid, uuid_or_name)
+            try:
+                return self.populate_objects(skill)
+            except RuntimeError as e:
+                logger.warning(str(e))
+                skill.setdefault("tools", [])
+                skill.setdefault("snippets", [])
+                return skill
+        except KeyError:
+            raise
+        except Exception as e:
+            logger.error(f"Error retrieving skill '{uuid_or_name}': {e}")
+            raise
 
     def list_all(self, filters: Optional[Dict] = None) -> List[Dict[str, Any]]:
         """List all skills with optional filtering and populated objects.
@@ -208,18 +263,25 @@ class SkillsService:
             List[Dict[str, Any]]: List of skill metadata dictionaries with tools and snippets populated,
                                   sorted by modified_at descending.
         """
-        items = self.handler.list_all_dicts()
-        if filters:
-            items = [i for i in items if all(i.get(k) == v for k, v in filters.items())]
-        for item in items:
-            try:
-                self.populate_objects(item)
-            except RuntimeError as e:
-                logger.warning(str(e))
-                item.setdefault("tools", [])
-                item.setdefault("snippets", [])
-        items.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
-        return items
+        list_skills_counter.inc()
+        try:
+            items = self.handler.list_all_dicts()
+            if filters:
+                items = [
+                    i for i in items if all(i.get(k) == v for k, v in filters.items())
+                ]
+            for item in items:
+                try:
+                    self.populate_objects(item)
+                except RuntimeError as e:
+                    logger.warning(str(e))
+                    item.setdefault("tools", [])
+                    item.setdefault("snippets", [])
+            items.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
+            return items
+        except Exception as e:
+            logger.error(f"Error listing skills: {e}")
+            raise
 
     def search(
         self,
@@ -257,83 +319,100 @@ class SkillsService:
         from skillberry_store.modules.lifecycle import LifecycleState
         from skillberry_store.fast_api.search_filters import apply_search_filters
 
-        if lifecycle_state is None:
-            lifecycle_state = LifecycleState.ANY
-        if not self.descriptions:
-            raise RuntimeError(
-                "Skill search is not available - descriptions not initialized"
-            )
+        search_skills_counter.inc()
+        try:
+            if lifecycle_state is None:
+                lifecycle_state = LifecycleState.ANY
+            if not self.descriptions:
+                raise RuntimeError(
+                    "Skill search is not available - descriptions not initialized"
+                )
 
-        matched_entities = self.descriptions.search_description(
-            search_term=search_term, k=max_number_of_results
-        )
-        filtered_matched = [
-            m
-            for m in matched_entities
-            if float(m["similarity_score"]) <= similarity_threshold
-        ]
-        candidates: List[Dict[str, Any]] = []
-        for matched in filtered_matched:
-            skill_uuid = matched.get("filename")
-            if not skill_uuid:
-                continue
-            try:
-                skill_dict = self.handler.read_dict(skill_uuid)
-                skill_dict["similarity_score"] = matched.get("similarity_score", 0.0)
-                candidates.append(skill_dict)
-            except Exception as e:
-                logger.warning(f"Could not load skill {skill_uuid}: {e}")
-        filtered_skills = apply_search_filters(
-            candidates,
-            manifest_filter=manifest_filter,
-            lifecycle_state=lifecycle_state,
-        )
-        filtered_skills.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
-        return [
-            {
-                "filename": s.get("name", ""),
-                "similarity_score": s.get("similarity_score", 0.0),
-            }
-            for s in filtered_skills
-            if s.get("name")
-        ]
+            matched_entities = self.descriptions.search_description(
+                search_term=search_term, k=max_number_of_results
+            )
+            filtered_matched = [
+                m
+                for m in matched_entities
+                if float(m["similarity_score"]) <= similarity_threshold
+            ]
+            candidates: List[Dict[str, Any]] = []
+            for matched in filtered_matched:
+                skill_uuid = matched.get("filename")
+                if not skill_uuid:
+                    continue
+                try:
+                    skill_dict = self.handler.read_dict(skill_uuid)
+                    skill_dict["similarity_score"] = matched.get(
+                        "similarity_score", 0.0
+                    )
+                    candidates.append(skill_dict)
+                except Exception as e:
+                    logger.warning(f"Could not load skill {skill_uuid}: {e}")
+            filtered_skills = apply_search_filters(
+                candidates,
+                manifest_filter=manifest_filter,
+                lifecycle_state=lifecycle_state,
+            )
+            filtered_skills.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
+            return [
+                {
+                    "filename": s.get("name", ""),
+                    "similarity_score": s.get("similarity_score", 0.0),
+                }
+                for s in filtered_skills
+                if s.get("name")
+            ]
+        except RuntimeError:
+            raise
+        except Exception as e:
+            logger.error(f"Error searching skills: {e}")
+            raise
 
     def update(self, uuid_or_name: str, data: Dict[str, Any]) -> Dict[str, Any]:
         """Update an existing skill's metadata.
-        
+
         Merges new data with existing skill data, updates timestamps, caches,
         and description indexes as needed.
-        
+
         Args:
             uuid_or_name: Skill UUID or name to update.
             data: Dictionary of fields to update.
-            
+
         Returns:
             Dict[str, Any]: The updated skill metadata.
-            
+
         Raises:
             KeyError: If skill not found.
         """
-        uuid = self._resolve_uuid(uuid_or_name)
-        existing = self.handler.read_dict(uuid)
-        old_name = existing.get("name")
-        old_parent = existing.get("parent")
-        new_name = data.get("name") or old_name
-        if new_name:
-            data["parent"] = self.handler.get_cache_parent_for_head(uuid, new_name)
-        merged = {**existing, **data}
-        merged["uuid"] = existing.get("uuid", uuid)
-        merged["created_at"] = existing.get("created_at")
-        merged["modified_at"] = datetime.now(timezone.utc).isoformat()
-        self.handler.write_dict(uuid, merged)
-        if new_name:
-            self.handler.update_cache(
-                uuid, new_name=new_name, old_name=old_name, old_parent=old_parent
-            )
-        if self.descriptions and merged.get("description"):
-            self.descriptions.write_description(uuid, merged["description"])
-        logger.info(f"Skill '{uuid_or_name}' updated")
-        return merged
+        update_skill_counter.inc()
+        try:
+            uuid = self._resolve_uuid(uuid_or_name)
+            existing = self.handler.read_dict(uuid)
+            old_name = existing.get("name")
+            old_parent = existing.get("parent")
+            new_name = data.get("name") or old_name
+            if new_name:
+                data["parent"] = self.handler.get_cache_parent_for_head(uuid, new_name)
+            merged = {**existing, **data}
+            merged["uuid"] = existing.get("uuid", uuid)
+            merged["created_at"] = existing.get("created_at")
+            merged["modified_at"] = datetime.now(timezone.utc).isoformat()
+            self.handler.write_dict(uuid, merged)
+            if new_name:
+                self.handler.update_cache(
+                    uuid, new_name=new_name, old_name=old_name, old_parent=old_parent
+                )
+            if self.descriptions and merged.get("description"):
+                self.descriptions.write_description(uuid, merged["description"])
+            emit_content_updated("skill", uuid)
+            logger.info(f"Skill '{uuid_or_name}' updated")
+            return merged
+        except KeyError:
+            raise
+        except Exception as e:
+            logger.error(f"Error updating skill '{uuid_or_name}': {e}")
+            raise
 
     def detect_anthropic_skills(
         self,
@@ -378,91 +457,109 @@ class SkillsService:
 
         import requests
 
-        from skillberry_store.tools.endpoint_auth import resolve_auth_headers
+        from skillberry_store.tools.endpoint_auth import (
+            ReauthRequired,
+            resolve_auth_headers,
+        )
 
-        skill_paths: List[str] = []
+        detect_anthropic_skills_counter.inc()
+        logger.info(f"Request to detect Anthropic skills from {source_type}")
+        try:
+            skill_paths: List[str] = []
 
-        if source_type == "url":
-            if not github_url:
-                raise ValueError("github_url is required for source_type='url'")
-            auth_headers = resolve_auth_headers(
-                github_url,
-                override_token=override_token,
-                anonymous=anonymous,
-            )
-            api_url = github_url.replace("github.com", "api.github.com/repos")
-            api_url = re.sub(r"/tree/(main|master)/", r"/contents/", api_url)
-            logger.info(f"Fetching directory listing from: {api_url}")
-            response = requests.get(api_url, headers=auth_headers, timeout=30)
-            if not response.ok:
-                raise GithubApiError(
-                    response.status_code,
-                    f"GitHub API error: {response.text or response.reason}",
+            if source_type == "url":
+                if not github_url:
+                    raise ValueError("github_url is required for source_type='url'")
+                auth_headers = resolve_auth_headers(
+                    github_url,
+                    override_token=override_token,
+                    anonymous=anonymous,
                 )
-            items = response.json()
-            for item in items:
-                if item["type"] == "dir":
-                    dir_name = item["name"]
-                    dir_api_url = item["url"]
-                    try:
-                        dir_response = requests.get(
-                            dir_api_url, headers=auth_headers, timeout=30
-                        )
-                        if dir_response.ok:
-                            dir_items = dir_response.json()
-                            has_skill_md = any(
-                                f["name"].upper() == "SKILL.MD"
-                                and f["type"] == "file"
-                                for f in dir_items
+                api_url = github_url.replace("github.com", "api.github.com/repos")
+                api_url = re.sub(r"/tree/(main|master)/", r"/contents/", api_url)
+                logger.info(f"Fetching directory listing from: {api_url}")
+                response = requests.get(api_url, headers=auth_headers, timeout=30)
+                if not response.ok:
+                    raise GithubApiError(
+                        response.status_code,
+                        f"GitHub API error: {response.text or response.reason}",
+                    )
+                items = response.json()
+                for item in items:
+                    if item["type"] == "dir":
+                        dir_name = item["name"]
+                        dir_api_url = item["url"]
+                        try:
+                            dir_response = requests.get(
+                                dir_api_url, headers=auth_headers, timeout=30
                             )
-                            if has_skill_md:
-                                skill_paths.append(dir_name)
-                                logger.info(f"Found skill directory: {dir_name}")
-                    except Exception as e:
-                        logger.warning(f"Failed to check directory {dir_name}: {e}")
-        elif source_type == "folder":
-            if not folder_path:
-                raise ValueError(
-                    "folder_path is required for source_type='folder'"
-                )
-            home_dir = os.path.realpath(os.path.expanduser("~"))
-            abs_input = os.path.realpath(folder_path)
-            if not (
-                abs_input == home_dir or abs_input.startswith(home_dir + os.sep)
-            ):
-                raise ValueError(
-                    "folder_path must be within the current user's home directory"
-                )
-            if abs_input == home_dir:
-                safe_root = home_dir
+                            if dir_response.ok:
+                                dir_items = dir_response.json()
+                                has_skill_md = any(
+                                    f["name"].upper() == "SKILL.MD"
+                                    and f["type"] == "file"
+                                    for f in dir_items
+                                )
+                                if has_skill_md:
+                                    skill_paths.append(dir_name)
+                                    logger.info(
+                                        f"Found skill directory: {dir_name}"
+                                    )
+                        except Exception as e:
+                            logger.warning(
+                                f"Failed to check directory {dir_name}: {e}"
+                            )
+            elif source_type == "folder":
+                if not folder_path:
+                    raise ValueError(
+                        "folder_path is required for source_type='folder'"
+                    )
+                home_dir = os.path.realpath(os.path.expanduser("~"))
+                abs_input = os.path.realpath(folder_path)
+                if not (
+                    abs_input == home_dir
+                    or abs_input.startswith(home_dir + os.sep)
+                ):
+                    raise ValueError(
+                        "folder_path must be within the current user's home directory"
+                    )
+                if abs_input == home_dir:
+                    safe_root = home_dir
+                else:
+                    rel = abs_input[len(home_dir) + len(os.sep) :]
+                    clean_parts = [
+                        os.path.basename(p) for p in rel.split(os.sep) if p
+                    ]
+                    safe_root = os.path.join(home_dir, *clean_parts)
+                if not os.path.exists(safe_root):
+                    raise ValueError("Folder does not exist")
+                if not os.path.isdir(safe_root):
+                    raise ValueError("Path is not a directory")
+                try:
+                    for entry in os.listdir(safe_root):  # lgtm[py/path-injection]
+                        if entry != os.path.basename(entry):
+                            continue
+                        entry_path = os.path.join(safe_root, entry)
+                        if os.path.realpath(entry_path).startswith(
+                            safe_root + os.sep
+                        ) and os.path.isdir(entry_path):
+                            skill_md_path = os.path.join(entry_path, "SKILL.md")
+                            if os.path.isfile(skill_md_path):
+                                skill_paths.append(entry)
+                                logger.info(f"Found skill directory: {entry}")
+                except Exception as e:
+                    raise RuntimeError(f"Error reading directory: {str(e)}")
             else:
-                rel = abs_input[len(home_dir) + len(os.sep) :]
-                clean_parts = [os.path.basename(p) for p in rel.split(os.sep) if p]
-                safe_root = os.path.join(home_dir, *clean_parts)
-            if not os.path.exists(safe_root):
-                raise ValueError("Folder does not exist")
-            if not os.path.isdir(safe_root):
-                raise ValueError("Path is not a directory")
-            try:
-                for entry in os.listdir(safe_root):  # lgtm[py/path-injection]
-                    if entry != os.path.basename(entry):
-                        continue
-                    entry_path = os.path.join(safe_root, entry)
-                    if os.path.realpath(entry_path).startswith(
-                        safe_root + os.sep
-                    ) and os.path.isdir(entry_path):
-                        skill_md_path = os.path.join(entry_path, "SKILL.md")
-                        if os.path.isfile(skill_md_path):
-                            skill_paths.append(entry)
-                            logger.info(f"Found skill directory: {entry}")
-            except Exception as e:
-                raise RuntimeError(f"Error reading directory: {str(e)}")
-        else:
-            raise ValueError(
-                f"Invalid source_type: {source_type}. Must be 'url' or 'folder'"
-            )
-        logger.info(f"Detected {len(skill_paths)} skill directories")
-        return skill_paths
+                raise ValueError(
+                    f"Invalid source_type: {source_type}. Must be 'url' or 'folder'"
+                )
+            logger.info(f"Detected {len(skill_paths)} skill directories")
+            return skill_paths
+        except (ValueError, ReauthRequired, GithubApiError, RuntimeError):
+            raise
+        except Exception as e:
+            logger.error(f"Error detecting Anthropic skills: {e}")
+            raise
 
     def export_anthropic(self, uuid_or_name: str) -> bytes:
         """Export a skill to the Anthropic format as a ZIP byte payload.
@@ -488,37 +585,51 @@ class SkillsService:
             export_skill_to_anthropic_format,
         )
 
-        skill_uuid = self._resolve_uuid(uuid_or_name)
-        skill_dict = self._safe_read(skill_uuid, uuid_or_name)
-        tools_service = get_service("tool")
-        snippets_service = get_service("snippet")
+        export_anthropic_skill_counter.inc()
+        logger.info(f"Request to export skill to Anthropic format: {uuid_or_name}")
+        try:
+            skill_uuid = self._resolve_uuid(uuid_or_name)
+            skill_dict = self._safe_read(skill_uuid, uuid_or_name)
+            tools_service = get_service("tool")
+            snippets_service = get_service("snippet")
 
-        tools: List[Dict[str, Any]] = []
-        tool_modules: Dict[str, str] = {}
-        for tool_uuid in skill_dict.get("tool_uuids") or []:
-            tool_dict = tools_service.get(tool_uuid)
-            tools.append(tool_dict)
-            tool_name = tool_dict.get("name")
-            module_name = tool_dict.get("module_name")
-            if tool_name and module_name:
-                try:
-                    tool_modules[tool_name] = tools_service.get_module(tool_uuid)
-                except Exception as e:
-                    logger.warning(
-                        f"Could not read module for tool {tool_name}: {e}"
-                    )
+            tools: List[Dict[str, Any]] = []
+            tool_modules: Dict[str, str] = {}
+            for tool_uuid in skill_dict.get("tool_uuids") or []:
+                tool_dict = tools_service.get(tool_uuid)
+                tools.append(tool_dict)
+                tool_name = tool_dict.get("name")
+                module_name = tool_dict.get("module_name")
+                if tool_name and module_name:
+                    try:
+                        tool_modules[tool_name] = tools_service.get_module(tool_uuid)
+                    except Exception as e:
+                        logger.warning(
+                            f"Could not read module for tool {tool_name}: {e}"
+                        )
 
-        snippets: List[Dict[str, Any]] = [
-            snippets_service.get(snippet_uuid)
-            for snippet_uuid in skill_dict.get("snippet_uuids") or []
-        ]
+            snippets: List[Dict[str, Any]] = [
+                snippets_service.get(snippet_uuid)
+                for snippet_uuid in skill_dict.get("snippet_uuids") or []
+            ]
 
-        return export_skill_to_anthropic_format(
-            skill=skill_dict,
-            tools=tools,
-            snippets=snippets,
-            tool_modules=tool_modules,
-        )
+            zip_content = export_skill_to_anthropic_format(
+                skill=skill_dict,
+                tools=tools,
+                snippets=snippets,
+                tool_modules=tool_modules,
+            )
+            logger.info(
+                f"Successfully exported skill '{uuid_or_name}' to Anthropic format"
+            )
+            return zip_content
+        except KeyError:
+            raise
+        except Exception as e:
+            logger.error(
+                f"Error exporting skill '{uuid_or_name}' to Anthropic format: {e}"
+            )
+            raise
 
     def import_anthropic(
         self,
@@ -570,141 +681,158 @@ class SkillsService:
             import_from_anthropic_skill,
             parse_github_origin,
         )
+        from skillberry_store.tools.endpoint_auth import ReauthRequired
 
-        if source_type not in ("url", "zip", "folder"):
-            raise ValueError(
-                f"Invalid source_type: {source_type}. Must be 'url', 'zip', or 'folder'"
+        import_anthropic_skill_counter.inc()
+        logger.info(f"Request to import Anthropic skill from {source_type}")
+        try:
+            if source_type not in ("url", "zip", "folder"):
+                raise ValueError(
+                    f"Invalid source_type: {source_type}. Must be 'url', 'zip', or 'folder'"
+                )
+            if not source_data:
+                required_field = {
+                    "url": "github_url",
+                    "zip": "zip_file",
+                    "folder": "folder_path",
+                }[source_type]
+                raise ValueError(
+                    f"{required_field} is required for source_type='{source_type}'"
+                )
+
+            tags = tags or []
+            tools_service = get_service("tool")
+            snippets_service = get_service("snippet")
+
+            (
+                skill_name,
+                skill_description,
+                imported_tools,
+                imported_snippets,
+                ignored_files,
+            ) = import_from_anthropic_skill(
+                source_type=source_type,
+                source_data=source_data,
+                snippet_mode=snippet_mode,
+                treat_all_as_documents=treat_all_as_documents,
+                override_token=override_token,
+                anonymous=anonymous,
             )
-        if not source_data:
-            required_field = {
-                "url": "github_url",
-                "zip": "zip_file",
-                "folder": "folder_path",
-            }[source_type]
-            raise ValueError(
-                f"{required_field} is required for source_type='{source_type}'"
-            )
 
-        tags = tags or []
-        tools_service = get_service("tool")
-        snippets_service = get_service("snippet")
+            # Pre-allocate tool UUIDs so cross-tool deps within this batch can be
+            # resolved by ToolsService.create's auto-detection.
+            all_tool_names: Dict[str, str] = {}
+            for tool in imported_tools:
+                tool.uuid = generate_or_validate_uuid(None)
+                all_tool_names[tool.name] = tool.uuid
 
-        (
-            skill_name,
-            skill_description,
-            imported_tools,
-            imported_snippets,
-            ignored_files,
-        ) = import_from_anthropic_skill(
-            source_type=source_type,
-            source_data=source_data,
-            snippet_mode=snippet_mode,
-            treat_all_as_documents=treat_all_as_documents,
-            override_token=override_token,
-            anonymous=anonymous,
-        )
+            created_tool_uuids: List[str] = []
+            for tool in imported_tools:
+                try:
+                    tool_dict = tool.to_dict()
+                    tool_name = tool_dict["name"]
+                    ext = (
+                        ".py"
+                        if tool_dict["programmingLanguage"] == "python"
+                        else ".sh"
+                    )
+                    module_filename = f"{tool_name}{ext}"
+                    tool_tags = (
+                        tool_dict["tags"].copy() if tool_dict["tags"] else []
+                    )
+                    for tag in tags:
+                        if tag and tag not in tool_tags:
+                            tool_tags.append(tag)
+                    tool_data: Dict[str, Any] = {
+                        "uuid": tool.uuid,
+                        "name": tool_name,
+                        "version": tool_dict["version"],
+                        "description": tool_dict["description"],
+                        "tags": tool_tags,
+                        "programming_language": tool_dict["programmingLanguage"],
+                        "packaging_format": "code",
+                        "state": "approved",
+                    }
+                    if tool_dict.get("params"):
+                        tool_data["params"] = tool_dict["params"]
+                    if tool_dict.get("returns"):
+                        tool_data["returns"] = tool_dict["returns"]
+                    tools_service.create(
+                        tool_data,
+                        module_content=tool_dict["moduleContent"],
+                        module_filename=module_filename,
+                        extra_name_to_uuid=all_tool_names,
+                    )
+                    created_tool_uuids.append(tool.uuid)
+                except Exception as e:
+                    logger.error(f"Failed to create tool {tool.name}: {e}")
 
-        # Pre-allocate tool UUIDs so cross-tool deps within this batch can be
-        # resolved by ToolsService.create's auto-detection.
-        all_tool_names: Dict[str, str] = {}
-        for tool in imported_tools:
-            tool.uuid = generate_or_validate_uuid(None)
-            all_tool_names[tool.name] = tool.uuid
+            created_snippet_uuids: List[str] = []
+            for snippet in imported_snippets:
+                try:
+                    snippet_dict = snippet.to_dict()
+                    snippet_tags = (
+                        snippet_dict["tags"].copy() if snippet_dict["tags"] else []
+                    )
+                    for tag in tags:
+                        if tag and tag not in snippet_tags:
+                            snippet_tags.append(tag)
+                    snippet_data = {
+                        "name": snippet_dict["name"],
+                        "version": snippet_dict["version"],
+                        "description": snippet_dict["description"],
+                        "content": snippet_dict["content"],
+                        "tags": snippet_tags,
+                        "content_type": "text/plain",
+                        "state": "approved",
+                    }
+                    result = snippets_service.create(snippet_data)
+                    created_snippet_uuids.append(result["uuid"])
+                except Exception as e:
+                    logger.error(f"Failed to create snippet {snippet.name}: {e}")
 
-        created_tool_uuids: List[str] = []
-        for tool in imported_tools:
-            try:
-                tool_dict = tool.to_dict()
-                tool_name = tool_dict["name"]
-                ext = (
-                    ".py" if tool_dict["programmingLanguage"] == "python" else ".sh"
-                )
-                module_filename = f"{tool_name}{ext}"
-                tool_tags = tool_dict["tags"].copy() if tool_dict["tags"] else []
-                for tag in tags:
-                    if tag and tag not in tool_tags:
-                        tool_tags.append(tag)
-                tool_data: Dict[str, Any] = {
-                    "uuid": tool.uuid,
-                    "name": tool_name,
-                    "version": tool_dict["version"],
-                    "description": tool_dict["description"],
-                    "tags": tool_tags,
-                    "programming_language": tool_dict["programmingLanguage"],
-                    "packaging_format": "code",
-                    "state": "approved",
+            skill_tags = ["anthropic", "imported"]
+            for tag in tags:
+                if tag and tag not in skill_tags:
+                    skill_tags.append(tag)
+
+            skill_extra: Dict[str, Any] = {}
+            if source_type == "url" and github_url:
+                origin = parse_github_origin(github_url)
+                skill_extra["origin"] = {
+                    "type": "github" if origin else "url",
+                    "url": github_url,
+                    **(origin or {}),
                 }
-                if tool_dict.get("params"):
-                    tool_data["params"] = tool_dict["params"]
-                if tool_dict.get("returns"):
-                    tool_data["returns"] = tool_dict["returns"]
-                tools_service.create(
-                    tool_data,
-                    module_content=tool_dict["moduleContent"],
-                    module_filename=module_filename,
-                    extra_name_to_uuid=all_tool_names,
-                )
-                created_tool_uuids.append(tool.uuid)
-            except Exception as e:
-                logger.error(f"Failed to create tool {tool.name}: {e}")
 
-        created_snippet_uuids: List[str] = []
-        for snippet in imported_snippets:
-            try:
-                snippet_dict = snippet.to_dict()
-                snippet_tags = (
-                    snippet_dict["tags"].copy() if snippet_dict["tags"] else []
-                )
-                for tag in tags:
-                    if tag and tag not in snippet_tags:
-                        snippet_tags.append(tag)
-                snippet_data = {
-                    "name": snippet_dict["name"],
-                    "version": snippet_dict["version"],
-                    "description": snippet_dict["description"],
-                    "content": snippet_dict["content"],
-                    "tags": snippet_tags,
-                    "content_type": "text/plain",
-                    "state": "approved",
-                }
-                result = snippets_service.create(snippet_data)
-                created_snippet_uuids.append(result["uuid"])
-            except Exception as e:
-                logger.error(f"Failed to create snippet {snippet.name}: {e}")
-
-        skill_tags = ["anthropic", "imported"]
-        for tag in tags:
-            if tag and tag not in skill_tags:
-                skill_tags.append(tag)
-
-        skill_extra: Dict[str, Any] = {}
-        if source_type == "url" and github_url:
-            origin = parse_github_origin(github_url)
-            skill_extra["origin"] = {
-                "type": "github" if origin else "url",
-                "url": github_url,
-                **(origin or {}),
+            skill_data: Dict[str, Any] = {
+                "name": skill_name,
+                "version": "1.0.0",
+                "description": skill_description,
+                "tags": skill_tags,
+                "tool_uuids": created_tool_uuids,
+                "snippet_uuids": created_snippet_uuids,
+                "state": "approved",
+                "extra": skill_extra,
             }
+            skill_result = self.create(skill_data)
 
-        skill_data: Dict[str, Any] = {
-            "name": skill_name,
-            "version": "1.0.0",
-            "description": skill_description,
-            "tags": skill_tags,
-            "tool_uuids": created_tool_uuids,
-            "snippet_uuids": created_snippet_uuids,
-            "state": "approved",
-            "extra": skill_extra,
-        }
-        skill_result = self.create(skill_data)
-
-        return {
-            "skill_name": skill_result.get("name", skill_name),
-            "skill_uuid": skill_result.get("uuid"),
-            "tools_created": len(created_tool_uuids),
-            "snippets_created": len(created_snippet_uuids),
-            "ignored_files": ignored_files,
-        }
+            logger.info(
+                f"Successfully imported Anthropic skill: "
+                f"{skill_result.get('name', skill_name)}"
+            )
+            return {
+                "skill_name": skill_result.get("name", skill_name),
+                "skill_uuid": skill_result.get("uuid"),
+                "tools_created": len(created_tool_uuids),
+                "snippets_created": len(created_snippet_uuids),
+                "ignored_files": ignored_files,
+            }
+        except (ValueError, ReauthRequired):
+            raise
+        except Exception as e:
+            logger.error(f"Error importing Anthropic skill: {e}")
+            raise
 
     def delete(
         self,
@@ -737,60 +865,70 @@ class SkillsService:
         """
         from skillberry_store.services.registry import get_service
 
-        uuid = self._resolve_uuid(uuid_or_name)
-        skill: Optional[Dict[str, Any]] = None
+        delete_skill_counter.inc()
         try:
-            skill = self.handler.read_dict(uuid)
-        except Exception:
-            pass
-        deleted_tools: List[str] = []
-        deleted_snippets: List[str] = []
-        if skill is not None and (delete_tools or delete_snippets):
-            tools_service = get_service("tool")
-            snippets_service = get_service("snippet")
-            skill_uuid = skill.get("uuid") or uuid
-            all_skills = self.handler.list_all_dicts()
-            shared_tool_uuids: set = set()
-            shared_snippet_uuids: set = set()
-            for s in all_skills:
-                if s.get("uuid") != skill_uuid:
-                    shared_tool_uuids.update(s.get("tool_uuids") or [])
-                    shared_snippet_uuids.update(s.get("snippet_uuids") or [])
-            if delete_tools:
-                for tool_uuid in skill.get("tool_uuids") or []:
-                    if tool_uuid not in shared_tool_uuids:
-                        try:
-                            tools_service.delete(tool_uuid)
-                            deleted_tools.append(tool_uuid)
-                        except Exception as e:
-                            logger.warning(
-                                f"Could not cascade-delete tool {tool_uuid}: {e}"
-                            )
-            if delete_snippets:
-                for snippet_uuid in skill.get("snippet_uuids") or []:
-                    if snippet_uuid not in shared_snippet_uuids:
-                        try:
-                            snippets_service.delete(snippet_uuid)
-                            deleted_snippets.append(snippet_uuid)
-                        except Exception as e:
-                            logger.warning(
-                                f"Could not cascade-delete snippet {snippet_uuid}: {e}"
-                            )
-        name = (skill or {}).get("name")
-        parent = (skill or {}).get("parent")
-        if uuid and name:
-            self.handler.update_cache(
-                uuid, new_name=None, old_name=name, old_parent=parent
-            )
-        self.handler.delete_object(uuid)
-        if self.descriptions:
+            uuid = self._resolve_uuid(uuid_or_name)
+            skill: Optional[Dict[str, Any]] = None
             try:
-                self.descriptions.delete_description(uuid)
-            except Exception as e:
-                logger.warning(f"Could not delete skill description for {uuid}: {e}")
-        logger.info(f"Skill '{uuid_or_name}' deleted")
-        return {
-            "uuid": uuid,
-            "deleted_tools": deleted_tools,
-            "deleted_snippets": deleted_snippets,
-        }
+                skill = self.handler.read_dict(uuid)
+            except Exception:
+                pass
+            deleted_tools: List[str] = []
+            deleted_snippets: List[str] = []
+            if skill is not None and (delete_tools or delete_snippets):
+                tools_service = get_service("tool")
+                snippets_service = get_service("snippet")
+                skill_uuid = skill.get("uuid") or uuid
+                all_skills = self.handler.list_all_dicts()
+                shared_tool_uuids: set = set()
+                shared_snippet_uuids: set = set()
+                for s in all_skills:
+                    if s.get("uuid") != skill_uuid:
+                        shared_tool_uuids.update(s.get("tool_uuids") or [])
+                        shared_snippet_uuids.update(s.get("snippet_uuids") or [])
+                if delete_tools:
+                    for tool_uuid in skill.get("tool_uuids") or []:
+                        if tool_uuid not in shared_tool_uuids:
+                            try:
+                                tools_service.delete(tool_uuid)
+                                deleted_tools.append(tool_uuid)
+                            except Exception as e:
+                                logger.warning(
+                                    f"Could not cascade-delete tool {tool_uuid}: {e}"
+                                )
+                if delete_snippets:
+                    for snippet_uuid in skill.get("snippet_uuids") or []:
+                        if snippet_uuid not in shared_snippet_uuids:
+                            try:
+                                snippets_service.delete(snippet_uuid)
+                                deleted_snippets.append(snippet_uuid)
+                            except Exception as e:
+                                logger.warning(
+                                    f"Could not cascade-delete snippet {snippet_uuid}: {e}"
+                                )
+            name = (skill or {}).get("name")
+            parent = (skill or {}).get("parent")
+            if uuid and name:
+                self.handler.update_cache(
+                    uuid, new_name=None, old_name=name, old_parent=parent
+                )
+            self.handler.delete_object(uuid)
+            if self.descriptions:
+                try:
+                    self.descriptions.delete_description(uuid)
+                except Exception as e:
+                    logger.warning(
+                        f"Could not delete skill description for {uuid}: {e}"
+                    )
+            emit_content_deleted("skill", uuid)
+            logger.info(f"Skill '{uuid_or_name}' deleted")
+            return {
+                "uuid": uuid,
+                "deleted_tools": deleted_tools,
+                "deleted_snippets": deleted_snippets,
+            }
+        except KeyError:
+            raise
+        except Exception as e:
+            logger.error(f"Error deleting skill '{uuid_or_name}': {e}")
+            raise

--- a/src/skillberry_store/services/skills_service.py
+++ b/src/skillberry_store/services/skills_service.py
@@ -559,6 +559,9 @@ class SkillsService:
                 "snippets_created", "ignored_files"}``.
 
         Raises:
+            ValueError: If ``source_type`` is not one of ``"url"``, ``"zip"``,
+                or ``"folder"``, or if ``source_data`` is missing for the
+                given ``source_type``.
             ReauthRequired: If interactive re-authentication is required for
                 the import source's endpoint.
         """
@@ -567,6 +570,20 @@ class SkillsService:
             import_from_anthropic_skill,
             parse_github_origin,
         )
+
+        if source_type not in ("url", "zip", "folder"):
+            raise ValueError(
+                f"Invalid source_type: {source_type}. Must be 'url', 'zip', or 'folder'"
+            )
+        if not source_data:
+            required_field = {
+                "url": "github_url",
+                "zip": "zip_file",
+                "folder": "folder_path",
+            }[source_type]
+            raise ValueError(
+                f"{required_field} is required for source_type='{source_type}'"
+            )
 
         tags = tags or []
         tools_service = get_service("tool")
@@ -694,7 +711,7 @@ class SkillsService:
         uuid_or_name: str,
         delete_tools: bool = False,
         delete_snippets: bool = False,
-    ) -> Dict[str, List[str]]:
+    ) -> Dict[str, Any]:
         """Delete a skill, optionally cascading to its unshared tools and snippets.
 
         Removes the skill metadata, cache entries, and description indexes. When
@@ -711,10 +728,9 @@ class SkillsService:
                 referenced by any other skill.
 
         Returns:
-            Dict[str, List[str]]: ``{"deleted_tools": [...], "deleted_snippets": [...]}``
-                — UUIDs of cascade-deleted tools and snippets. Both lists are
-                empty when no cascade is requested or no unshared item is
-                found.
+            Dict[str, Any]: ``{"uuid": <deleted-skill-uuid>, "deleted_tools": [...],
+                "deleted_snippets": [...]}``. The two lists are empty when no
+                cascade is requested or no unshared item is found.
 
         Raises:
             KeyError: If skill not found.
@@ -773,4 +789,8 @@ class SkillsService:
             except Exception as e:
                 logger.warning(f"Could not delete skill description for {uuid}: {e}")
         logger.info(f"Skill '{uuid_or_name}' deleted")
-        return {"deleted_tools": deleted_tools, "deleted_snippets": deleted_snippets}
+        return {
+            "uuid": uuid,
+            "deleted_tools": deleted_tools,
+            "deleted_snippets": deleted_snippets,
+        }

--- a/src/skillberry_store/services/snippets_service.py
+++ b/src/skillberry_store/services/snippets_service.py
@@ -250,14 +250,17 @@ class SnippetsService:
         logger.info(f"Snippet '{uuid_or_name}' updated")
         return merged
 
-    def delete(self, uuid_or_name: str) -> None:
+    def delete(self, uuid_or_name: str) -> Dict[str, Any]:
         """Delete a snippet.
-        
+
         Removes the snippet metadata, cache entries, and description indexes.
-        
+
         Args:
             uuid_or_name: Snippet UUID or name to delete.
-            
+
+        Returns:
+            Dict[str, Any]: ``{"uuid": <deleted-snippet-uuid>}``.
+
         Raises:
             KeyError: If snippet not found.
         """
@@ -278,3 +281,4 @@ class SnippetsService:
             except Exception as e:
                 logger.warning(f"Could not delete snippet description for {uuid}: {e}")
         logger.info(f"Snippet '{uuid_or_name}' deleted")
+        return {"uuid": uuid}

--- a/src/skillberry_store/services/snippets_service.py
+++ b/src/skillberry_store/services/snippets_service.py
@@ -11,6 +11,7 @@ from skillberry_store.utils.utils import generate_or_validate_uuid
 
 if TYPE_CHECKING:
     from skillberry_store.modules.description import Description
+    from skillberry_store.modules.lifecycle import LifecycleState
 
 logger = logging.getLogger(__name__)
 
@@ -126,10 +127,10 @@ class SnippetsService:
 
     def list_all(self, filters: Optional[Dict] = None) -> List[Dict[str, Any]]:
         """List all snippets with optional filtering.
-        
+
         Args:
             filters: Optional dictionary of field:value pairs to filter by.
-            
+
         Returns:
             List[Dict[str, Any]]: List of snippet metadata dictionaries, sorted by modified_at descending.
         """
@@ -138,6 +139,79 @@ class SnippetsService:
             items = [i for i in items if all(i.get(k) == v for k, v in filters.items())]
         items.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
         return items
+
+    def search(
+        self,
+        search_term: str,
+        max_number_of_results: int = 5,
+        similarity_threshold: float = 1.0,
+        manifest_filter: str = ".",
+        lifecycle_state: Optional["LifecycleState"] = None,
+    ) -> List[Dict[str, Any]]:
+        """Search snippets by semantic similarity to a search term.
+
+        Performs a vector-similarity search over snippet descriptions, then filters
+        by similarity threshold, manifest properties, and lifecycle state, and
+        returns matched names with similarity scores sorted by ``modified_at``
+        (most recent first).
+
+        Args:
+            search_term: Free-text query to match against snippet descriptions.
+            max_number_of_results: Upper bound on candidates returned by the
+                vector index before threshold filtering.
+            similarity_threshold: Maximum allowed similarity score (lower is
+                more similar). Candidates above this score are discarded.
+            manifest_filter: Manifest property filter expression
+                (e.g. ``"tags:python"``, ``"state:approved"``).
+            lifecycle_state: Lifecycle state filter. Defaults to
+                ``LifecycleState.ANY`` when ``None`` is passed.
+
+        Returns:
+            List[Dict[str, Any]]: Matches, each ``{"filename": <name>, "similarity_score": <float>}``.
+
+        Raises:
+            RuntimeError: If the service was constructed without a
+                ``Description`` instance (search index unavailable).
+        """
+        from skillberry_store.modules.lifecycle import LifecycleState
+        from skillberry_store.fast_api.search_filters import apply_search_filters
+
+        if lifecycle_state is None:
+            lifecycle_state = LifecycleState.ANY
+        if not self.descriptions:
+            raise RuntimeError("Snippet search is not available")
+
+        matched = self.descriptions.search_description(
+            search_term=search_term, k=max_number_of_results
+        )
+        filtered = [
+            m for m in matched if float(m["similarity_score"]) <= similarity_threshold
+        ]
+        candidates: List[Dict[str, Any]] = []
+        for m in filtered:
+            name = m.get("filename") or m.get("name")
+            if not name:
+                continue
+            try:
+                d = self.get(name)
+                d["similarity_score"] = m.get("similarity_score", 0.0)
+                candidates.append(d)
+            except Exception:
+                pass
+        result_snippets = apply_search_filters(
+            candidates,
+            manifest_filter=manifest_filter,
+            lifecycle_state=lifecycle_state,
+        )
+        result_snippets.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
+        return [
+            {
+                "filename": s.get("name", ""),
+                "similarity_score": s.get("similarity_score", 0.0),
+            }
+            for s in result_snippets
+            if s.get("name")
+        ]
 
     def update(self, uuid_or_name: str, data: Dict[str, Any]) -> Dict[str, Any]:
         """Update an existing snippet's metadata and content.

--- a/src/skillberry_store/services/snippets_service.py
+++ b/src/skillberry_store/services/snippets_service.py
@@ -6,7 +6,14 @@ import logging
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+from prometheus_client import Counter
+
 from skillberry_store.modules.object_handler import ObjectHandler
+from skillberry_store.plugins.events import (
+    emit_content_added,
+    emit_content_deleted,
+    emit_content_updated,
+)
 from skillberry_store.utils.utils import generate_or_validate_uuid
 
 if TYPE_CHECKING:
@@ -14,6 +21,27 @@ if TYPE_CHECKING:
     from skillberry_store.modules.lifecycle import LifecycleState
 
 logger = logging.getLogger(__name__)
+
+# observability - metrics
+prom_prefix = "sts_service_snippets_"
+create_snippet_counter = Counter(
+    f"{prom_prefix}create_snippet_counter", "Count number of snippet create operations"
+)
+list_snippets_counter = Counter(
+    f"{prom_prefix}list_snippets_counter", "Count number of snippet list operations"
+)
+get_snippet_counter = Counter(
+    f"{prom_prefix}get_snippet_counter", "Count number of snippet get operations"
+)
+delete_snippet_counter = Counter(
+    f"{prom_prefix}delete_snippet_counter", "Count number of snippet delete operations"
+)
+update_snippet_counter = Counter(
+    f"{prom_prefix}update_snippet_counter", "Count number of snippet update operations"
+)
+search_snippets_counter = Counter(
+    f"{prom_prefix}search_snippets_counter", "Count number of snippet search operations"
+)
 
 
 class SnippetsService:
@@ -72,23 +100,35 @@ class SnippetsService:
         Raises:
             ValueError: If snippet with the same UUID already exists.
         """
-        data["uuid"] = generate_or_validate_uuid(data.get("uuid"))
-        if self.handler.object_exists(data["uuid"]):
-            raise ValueError(f"Snippet with UUID '{data['uuid']}' already exists")
-        now = datetime.now(timezone.utc).isoformat()
-        data.setdefault("created_at", now)
-        data["modified_at"] = now
-        if data.get("name"):
-            data["parent"] = self.handler.get_cache_parent_for_head(
-                data["uuid"], data["name"]
+        create_snippet_counter.inc()
+        try:
+            data["uuid"] = generate_or_validate_uuid(data.get("uuid"))
+            if self.handler.object_exists(data["uuid"]):
+                raise ValueError(
+                    f"Snippet with UUID '{data['uuid']}' already exists"
+                )
+            now = datetime.now(timezone.utc).isoformat()
+            data.setdefault("created_at", now)
+            data["modified_at"] = now
+            if data.get("name"):
+                data["parent"] = self.handler.get_cache_parent_for_head(
+                    data["uuid"], data["name"]
+                )
+            self.handler.write_dict(data["uuid"], data)
+            if data.get("name"):
+                self.handler.update_cache(data["uuid"], new_name=data["name"])
+            if self.descriptions and data.get("description"):
+                self.descriptions.write_description(data["uuid"], data["description"])
+            emit_content_added("snippet", data["uuid"])
+            logger.info(
+                f"Snippet '{data.get('name')}' created with UUID {data['uuid']}"
             )
-        self.handler.write_dict(data["uuid"], data)
-        if data.get("name"):
-            self.handler.update_cache(data["uuid"], new_name=data["name"])
-        if self.descriptions and data.get("description"):
-            self.descriptions.write_description(data["uuid"], data["description"])
-        logger.info(f"Snippet '{data.get('name')}' created with UUID {data['uuid']}")
-        return data
+            return data
+        except ValueError:
+            raise
+        except Exception as e:
+            logger.error(f"Error creating snippet '{data.get('name')}': {e}")
+            raise
 
     def _safe_read(self, uuid: str, label: str) -> Dict[str, Any]:
         """Safely read a snippet dictionary with error handling.
@@ -112,18 +152,25 @@ class SnippetsService:
 
     def get(self, uuid_or_name: str) -> Dict[str, Any]:
         """Get snippet metadata by UUID or name.
-        
+
         Args:
             uuid_or_name: Snippet UUID or name.
-            
+
         Returns:
             Dict[str, Any]: Snippet metadata dictionary.
-            
+
         Raises:
             KeyError: If snippet not found.
         """
-        uuid = self._resolve_uuid(uuid_or_name)
-        return self._safe_read(uuid, uuid_or_name)
+        get_snippet_counter.inc()
+        try:
+            uuid = self._resolve_uuid(uuid_or_name)
+            return self._safe_read(uuid, uuid_or_name)
+        except KeyError:
+            raise
+        except Exception as e:
+            logger.error(f"Error retrieving snippet '{uuid_or_name}': {e}")
+            raise
 
     def list_all(self, filters: Optional[Dict] = None) -> List[Dict[str, Any]]:
         """List all snippets with optional filtering.
@@ -134,11 +181,18 @@ class SnippetsService:
         Returns:
             List[Dict[str, Any]]: List of snippet metadata dictionaries, sorted by modified_at descending.
         """
-        items = self.handler.list_all_dicts()
-        if filters:
-            items = [i for i in items if all(i.get(k) == v for k, v in filters.items())]
-        items.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
-        return items
+        list_snippets_counter.inc()
+        try:
+            items = self.handler.list_all_dicts()
+            if filters:
+                items = [
+                    i for i in items if all(i.get(k) == v for k, v in filters.items())
+                ]
+            items.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
+            return items
+        except Exception as e:
+            logger.error(f"Error listing snippets: {e}")
+            raise
 
     def search(
         self,
@@ -176,79 +230,96 @@ class SnippetsService:
         from skillberry_store.modules.lifecycle import LifecycleState
         from skillberry_store.fast_api.search_filters import apply_search_filters
 
-        if lifecycle_state is None:
-            lifecycle_state = LifecycleState.ANY
-        if not self.descriptions:
-            raise RuntimeError("Snippet search is not available")
+        search_snippets_counter.inc()
+        try:
+            if lifecycle_state is None:
+                lifecycle_state = LifecycleState.ANY
+            if not self.descriptions:
+                raise RuntimeError("Snippet search is not available")
 
-        matched = self.descriptions.search_description(
-            search_term=search_term, k=max_number_of_results
-        )
-        filtered = [
-            m for m in matched if float(m["similarity_score"]) <= similarity_threshold
-        ]
-        candidates: List[Dict[str, Any]] = []
-        for m in filtered:
-            name = m.get("filename") or m.get("name")
-            if not name:
-                continue
-            try:
-                d = self.get(name)
-                d["similarity_score"] = m.get("similarity_score", 0.0)
-                candidates.append(d)
-            except Exception:
-                pass
-        result_snippets = apply_search_filters(
-            candidates,
-            manifest_filter=manifest_filter,
-            lifecycle_state=lifecycle_state,
-        )
-        result_snippets.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
-        return [
-            {
-                "filename": s.get("name", ""),
-                "similarity_score": s.get("similarity_score", 0.0),
-            }
-            for s in result_snippets
-            if s.get("name")
-        ]
+            matched = self.descriptions.search_description(
+                search_term=search_term, k=max_number_of_results
+            )
+            filtered = [
+                m
+                for m in matched
+                if float(m["similarity_score"]) <= similarity_threshold
+            ]
+            candidates: List[Dict[str, Any]] = []
+            for m in filtered:
+                name = m.get("filename") or m.get("name")
+                if not name:
+                    continue
+                try:
+                    d = self.get(name)
+                    d["similarity_score"] = m.get("similarity_score", 0.0)
+                    candidates.append(d)
+                except Exception:
+                    pass
+            result_snippets = apply_search_filters(
+                candidates,
+                manifest_filter=manifest_filter,
+                lifecycle_state=lifecycle_state,
+            )
+            result_snippets.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
+            return [
+                {
+                    "filename": s.get("name", ""),
+                    "similarity_score": s.get("similarity_score", 0.0),
+                }
+                for s in result_snippets
+                if s.get("name")
+            ]
+        except RuntimeError:
+            raise
+        except Exception as e:
+            logger.error(f"Error searching snippets: {e}")
+            raise
 
     def update(self, uuid_or_name: str, data: Dict[str, Any]) -> Dict[str, Any]:
         """Update an existing snippet's metadata and content.
-        
+
         Merges new data with existing snippet data, updates timestamps, caches,
         and description indexes as needed.
-        
+
         Args:
             uuid_or_name: Snippet UUID or name to update.
             data: Dictionary of fields to update.
-            
+
         Returns:
             Dict[str, Any]: The updated snippet metadata.
-            
+
         Raises:
             KeyError: If snippet not found.
         """
-        uuid = self._resolve_uuid(uuid_or_name)
-        existing = self.handler.read_dict(uuid)
-        old_name = existing.get("name")
-        old_parent = existing.get("parent")
-        new_name = data.get("name") or old_name
-        if new_name:
-            data["parent"] = self.handler.get_cache_parent_for_head(uuid, new_name)
-        merged = {**existing, **data}
-        merged["uuid"] = existing.get("uuid", uuid)
-        merged["created_at"] = existing.get("created_at")
-        merged["modified_at"] = datetime.now(timezone.utc).isoformat()
-        self.handler.write_dict(uuid, merged)
-        if new_name:
-            self.handler.update_cache(
-                uuid, new_name=new_name, old_name=old_name, old_parent=old_parent
-            )
-        if self.descriptions and merged.get("description"):
-            self.descriptions.write_description(uuid, merged["description"])
-        logger.info(f"Snippet '{uuid_or_name}' updated")
-        return merged
+        update_snippet_counter.inc()
+        try:
+            uuid = self._resolve_uuid(uuid_or_name)
+            existing = self.handler.read_dict(uuid)
+            old_name = existing.get("name")
+            old_parent = existing.get("parent")
+            new_name = data.get("name") or old_name
+            if new_name:
+                data["parent"] = self.handler.get_cache_parent_for_head(uuid, new_name)
+            merged = {**existing, **data}
+            merged["uuid"] = existing.get("uuid", uuid)
+            merged["created_at"] = existing.get("created_at")
+            merged["modified_at"] = datetime.now(timezone.utc).isoformat()
+            self.handler.write_dict(uuid, merged)
+            if new_name:
+                self.handler.update_cache(
+                    uuid, new_name=new_name, old_name=old_name, old_parent=old_parent
+                )
+            if self.descriptions and merged.get("description"):
+                self.descriptions.write_description(uuid, merged["description"])
+            emit_content_updated("snippet", uuid)
+            logger.info(f"Snippet '{uuid_or_name}' updated")
+            return merged
+        except KeyError:
+            raise
+        except Exception as e:
+            logger.error(f"Error updating snippet '{uuid_or_name}': {e}")
+            raise
 
     def delete(self, uuid_or_name: str) -> Dict[str, Any]:
         """Delete a snippet.
@@ -264,21 +335,31 @@ class SnippetsService:
         Raises:
             KeyError: If snippet not found.
         """
-        uuid = self._resolve_uuid(uuid_or_name)
+        delete_snippet_counter.inc()
         try:
-            d = self.handler.read_dict(uuid)
-            name, parent = d.get("name"), d.get("parent")
-        except Exception:
-            name, parent = None, None
-        if uuid and name:
-            self.handler.update_cache(
-                uuid, new_name=None, old_name=name, old_parent=parent
-            )
-        self.handler.delete_object(uuid)
-        if self.descriptions:
+            uuid = self._resolve_uuid(uuid_or_name)
             try:
-                self.descriptions.delete_description(uuid)
-            except Exception as e:
-                logger.warning(f"Could not delete snippet description for {uuid}: {e}")
-        logger.info(f"Snippet '{uuid_or_name}' deleted")
-        return {"uuid": uuid}
+                d = self.handler.read_dict(uuid)
+                name, parent = d.get("name"), d.get("parent")
+            except Exception:
+                name, parent = None, None
+            if uuid and name:
+                self.handler.update_cache(
+                    uuid, new_name=None, old_name=name, old_parent=parent
+                )
+            self.handler.delete_object(uuid)
+            if self.descriptions:
+                try:
+                    self.descriptions.delete_description(uuid)
+                except Exception as e:
+                    logger.warning(
+                        f"Could not delete snippet description for {uuid}: {e}"
+                    )
+            emit_content_deleted("snippet", uuid)
+            logger.info(f"Snippet '{uuid_or_name}' deleted")
+            return {"uuid": uuid}
+        except KeyError:
+            raise
+        except Exception as e:
+            logger.exception(f"Error deleting snippet '{uuid_or_name}': {e}")
+            raise

--- a/src/skillberry_store/services/tools_service.py
+++ b/src/skillberry_store/services/tools_service.py
@@ -13,6 +13,7 @@ from skillberry_store.tools.configure import is_auto_detect_dependencies_enabled
 
 if TYPE_CHECKING:
     from skillberry_store.modules.description import Description
+    from skillberry_store.modules.lifecycle import LifecycleState
 
 logger = logging.getLogger(__name__)
 
@@ -62,14 +63,14 @@ class ToolsService:
 
     def find_dependencies(self, dependencies: List[str], tool_uuid: str) -> Set[str]:
         """Recursively resolve all transitive dependency UUIDs.
-        
+
         Traverses the dependency tree to find all direct and indirect dependencies
         of a tool, avoiding circular dependencies.
-        
+
         Args:
             dependencies: List of direct dependency UUIDs.
             tool_uuid: UUID of the tool being analyzed (for logging).
-            
+
         Returns:
             Set[str]: Set of all dependency UUIDs (transitive closure).
         """
@@ -86,22 +87,100 @@ class ToolsService:
                 found.update(self.find_dependencies(nested, dep_uuid))
         return found
 
+    async def execute(
+        self,
+        uuid_or_name: str,
+        parameters: Optional[Dict[str, Any]] = None,
+        env_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Execute a tool by UUID or name.
+
+        Resolves the tool, loads its module (or generates an MCP stub), gathers
+        the transitive closure of its dependencies and their files, and runs
+        the tool through a ``FileExecutor``. Returns the execution output.
+
+        Args:
+            uuid_or_name: Tool UUID or name to execute.
+            parameters: Dictionary of parameters to pass to the tool. Defaults
+                to an empty dictionary if ``None``.
+            env_id: Optional environment ID for tool execution isolation.
+
+        Returns:
+            Dict[str, Any]: Tool execution output.
+
+        Raises:
+            KeyError: If the tool is not found, or the executor reports a
+                "not found" style error.
+            RuntimeError: If the executor reports any other error.
+        """
+        from skillberry_store.fast_api.server_utils import mcp_content_from_manifest
+        from skillberry_store.modules.file_executor import FileExecutor
+
+        tool_dict = self.get(uuid_or_name)
+        tool_uuid = tool_dict["uuid"]
+        tool_name = tool_dict.get("name", uuid_or_name)
+        if tool_dict.get("packaging_format") == "mcp":
+            module_content = mcp_content_from_manifest(tool_dict)
+        else:
+            module_content = self.get_module(uuid_or_name)
+        dep_uuids = self.find_dependencies(
+            tool_dict.get("dependencies", []), tool_uuid
+        )
+        dep_dicts = self.handler.read_dicts(list(dep_uuids))
+        dep_files = [
+            self.handler.read_file(m["uuid"], m["module_name"], raw_content=True)
+            for m in dep_dicts
+        ]
+        file_executor = FileExecutor(
+            name=tool_name,
+            file_content=module_content,
+            file_manifest=tool_dict,
+            dependent_file_contents=dep_files,
+            dependent_tools_as_dict=dep_dicts,
+        )
+        result = await file_executor.execute_file(
+            parameters=parameters or {}, env_id=env_id
+        )
+        if isinstance(result, dict) and "error" in result:
+            error_message = result.get("error", "Unknown Error")
+            if "not found" in error_message.lower():
+                raise KeyError(error_message)
+            raise RuntimeError(error_message)
+        logger.info(
+            f"Tool '{tool_name}' (UUID: {tool_uuid}) executed successfully"
+        )
+        return result
+
     def create(
-        self, data: Dict[str, Any], module_content: bytes, module_filename: str
+        self,
+        data: Dict[str, Any],
+        module_content: bytes,
+        module_filename: str,
+        extra_name_to_uuid: Optional[Dict[str, str]] = None,
     ) -> Dict[str, Any]:
         """Create a new tool with its module file.
-        
+
         Creates a tool entry with metadata and saves the associated module file.
-        Automatically detects dependencies if enabled and updates caches and indexes.
-        
+        Automatically detects dependencies if enabled and updates caches and
+        indexes.
+
         Args:
             data: Tool metadata dictionary (name, description, params, etc.).
+                If ``data`` already has ``dependencies``, auto-detection is
+                skipped.
             module_content: Binary content of the tool's module file.
             module_filename: Filename for the module (e.g., "tool.py").
-            
+            extra_name_to_uuid: Optional name->UUID map of tools that aren't
+                yet in the handler but should be considered "available" by
+                dependency auto-detection. Used by batch imports (e.g.
+                ``SkillsService.import_anthropic``) so one tool can declare a
+                dependency on another tool being created in the same batch.
+                When a detected dep name is in this map, its UUID is taken
+                from the map; otherwise the handler resolves it.
+
         Returns:
             Dict[str, Any]: The created tool data with UUID and timestamps.
-            
+
         Raises:
             ValueError: If tool with the same UUID already exists.
         """
@@ -125,12 +204,17 @@ class ToolsService:
                     else module_content
                 )
                 available = self.handler.get_existing_names()
+                if extra_name_to_uuid:
+                    available = available | set(extra_name_to_uuid.keys())
                 detected_names = detect_tool_dependencies(
                     content_str, data["name"], available
                 )
                 if detected_names:
                     data["dependencies"] = [
-                        self.handler.name_to_uuid(n) for n in detected_names
+                        extra_name_to_uuid[n]
+                        if extra_name_to_uuid and n in extra_name_to_uuid
+                        else self.handler.name_to_uuid(n)
+                        for n in detected_names
                     ]
             except Exception as e:
                 logger.warning(f"Failed to auto-detect dependencies: {e}")
@@ -201,10 +285,10 @@ class ToolsService:
 
     def list_all(self, filters: Optional[Dict] = None) -> List[Dict[str, Any]]:
         """List all tools with optional filtering.
-        
+
         Args:
             filters: Optional dictionary of field:value pairs to filter by.
-            
+
         Returns:
             List[Dict[str, Any]]: List of tool metadata dictionaries, sorted by modified_at descending.
         """
@@ -213,6 +297,84 @@ class ToolsService:
             items = [i for i in items if all(i.get(k) == v for k, v in filters.items())]
         items.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
         return items
+
+    def search(
+        self,
+        search_term: str,
+        max_number_of_results: int = 5,
+        similarity_threshold: float = 1.0,
+        manifest_filter: str = ".",
+        lifecycle_state: Optional["LifecycleState"] = None,
+    ) -> List[Dict[str, Any]]:
+        """Search tools by semantic similarity to a search term.
+
+        Performs a vector-similarity search over tool descriptions, then filters
+        by similarity threshold, manifest properties, and lifecycle state, and
+        returns matched names with similarity scores sorted by ``modified_at``
+        (most recent first).
+
+        Args:
+            search_term: Free-text query to match against tool descriptions.
+            max_number_of_results: Upper bound on candidates returned by the
+                vector index before threshold filtering.
+            similarity_threshold: Maximum allowed similarity score (lower is
+                more similar). Candidates above this score are discarded.
+            manifest_filter: Manifest property filter expression
+                (e.g. ``"tags:python"``, ``"state:approved"``). ``"."`` matches
+                all entities.
+            lifecycle_state: Lifecycle state filter. Defaults to
+                ``LifecycleState.ANY`` when ``None`` is passed.
+
+        Returns:
+            List[Dict[str, Any]]: Matches, each ``{"filename": <name>, "similarity_score": <float>}``.
+
+        Raises:
+            RuntimeError: If the service was constructed without a
+                ``Description`` instance (search index unavailable).
+        """
+        from skillberry_store.modules.lifecycle import LifecycleState
+        from skillberry_store.fast_api.search_filters import apply_search_filters
+
+        if lifecycle_state is None:
+            lifecycle_state = LifecycleState.ANY
+        if not self.descriptions:
+            raise RuntimeError(
+                "Tool search is not available - descriptions not initialized"
+            )
+
+        matched_entities = self.descriptions.search_description(
+            search_term=search_term, k=max_number_of_results
+        )
+        filtered_matched = [
+            m
+            for m in matched_entities
+            if float(m["similarity_score"]) <= similarity_threshold
+        ]
+        candidates: List[Dict[str, Any]] = []
+        for matched in filtered_matched:
+            tool_name = matched.get("filename") or matched.get("name")
+            if not tool_name:
+                continue
+            try:
+                tool_dict = self.get(tool_name)
+                tool_dict["similarity_score"] = matched.get("similarity_score", 0.0)
+                candidates.append(tool_dict)
+            except Exception as e:
+                logger.warning(f"Could not load tool {tool_name}: {e}")
+        filtered_tools = apply_search_filters(
+            candidates,
+            manifest_filter=manifest_filter,
+            lifecycle_state=lifecycle_state,
+        )
+        filtered_tools.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
+        return [
+            {
+                "filename": t.get("name", ""),
+                "similarity_score": t.get("similarity_score", 0.0),
+            }
+            for t in filtered_tools
+            if t.get("name")
+        ]
 
     def update(self, uuid_or_name: str, data: Dict[str, Any]) -> Dict[str, Any]:
         """Update an existing tool's metadata.
@@ -285,3 +447,152 @@ class ToolsService:
             except Exception as e:
                 logger.warning(f"Could not delete tool description for {uuid}: {e}")
         logger.info(f"Tool '{uuid_or_name}' deleted")
+
+    def add_from_python(
+        self,
+        file_bytes: bytes,
+        file_name: Optional[str] = None,
+        selected_func: Optional[str] = None,
+        update_existing: bool = False,
+    ) -> Dict[str, Any]:
+        """Create or update a tool from a Python source file.
+
+        Parses the file's docstring to extract function name, description,
+        parameters, and return type, then either creates a new tool or updates
+        an existing one with the same name.
+
+        For the create path, dependency auto-detection runs inside
+        :meth:`create`. For the update path, dependency auto-detection happens
+        here because :meth:`update` does not handle the module file or
+        re-detect dependencies.
+
+        Args:
+            file_bytes: Python file contents.
+            file_name: Original filename (used as ``module_name``). Falls back
+                to ``"<func_name>.py"`` when ``None``.
+            selected_func: Optional name of the specific function to extract.
+                If ``None``, the first function in the file is used.
+            update_existing: If True and a tool with the same name exists,
+                update it (re-writing its module file and refreshing its
+                manifest). Otherwise a new tool is created.
+
+        Returns:
+            Dict[str, Any]: ``{"message", "name", "uuid", "module_name",
+                "parameters", "description", "action"}`` where ``action`` is
+                ``"created"`` or ``"updated"``.
+
+        Raises:
+            ValueError: If the file cannot be parsed or its docstring is
+                missing a short description.
+        """
+        from skillberry_store.utils.python_utils import extract_docstring
+
+        try:
+            func_name, docstring_obj = extract_docstring(file_bytes, selected_func)
+        except Exception as e:
+            raise ValueError(
+                f"Failed to parse Python code or extract docstring: {e}. "
+                "Ensure the function has a properly formatted docstring with parameters."
+            )
+        description = docstring_obj.short_description
+        if not description:
+            raise ValueError("Function docstring must include a description.")
+
+        params_properties: Dict[str, Any] = {}
+        required_params: List[str] = []
+        for param in docstring_obj.params:
+            params_properties[param.arg_name] = {
+                "type": param.type_name if param.type_name else "string",
+                "description": param.description if param.description else "",
+            }
+            required_params.append(param.arg_name)
+
+        returns_dict: Optional[Dict[str, Any]] = None
+        if docstring_obj.returns:
+            returns_dict = {
+                "type": docstring_obj.returns.type_name or None,
+                "description": docstring_obj.returns.description or None,
+            }
+
+        module_filename = file_name if file_name else f"{func_name}.py"
+        existing_tool = self.handler.lookup_by_name(func_name)
+
+        if update_existing and existing_tool:
+            tool_uuid = generate_or_validate_uuid(existing_tool.get("uuid"))
+            self.handler.write_file(tool_uuid, module_filename, file_bytes)
+            data: Dict[str, Any] = {
+                "name": func_name,
+                "uuid": tool_uuid,
+                "description": description,
+                "programming_language": "python",
+                "packaging_format": "code",
+                "module_name": module_filename,
+                "version": "0.0.1",
+                "state": "approved",
+                "params": {
+                    "type": "object",
+                    "properties": params_properties,
+                    "required": required_params,
+                    "optional": [],
+                },
+            }
+            if returns_dict:
+                data["returns"] = returns_dict
+            if is_auto_detect_dependencies_enabled():
+                try:
+                    content_str = (
+                        file_bytes.decode("utf-8")
+                        if isinstance(file_bytes, bytes)
+                        else file_bytes
+                    )
+                    available = self.handler.get_existing_names()
+                    detected = detect_tool_dependencies(
+                        content_str, func_name, available
+                    )
+                    if detected:
+                        data["dependencies"] = [
+                            self.handler.name_to_uuid(n) for n in detected
+                        ]
+                except Exception as e:
+                    logger.warning(f"Failed to auto-detect dependencies: {e}")
+            self.update(tool_uuid, data)
+            return {
+                "message": f"Tool '{func_name}' updated successfully.",
+                "name": func_name,
+                "uuid": tool_uuid,
+                "module_name": module_filename,
+                "parameters": params_properties,
+                "description": description,
+                "action": "updated",
+            }
+
+        data = {
+            "name": func_name,
+            "description": description,
+            "programming_language": "python",
+            "packaging_format": "code",
+            "version": "0.0.1",
+            "state": "approved",
+            "params": {
+                "type": "object",
+                "properties": params_properties,
+                "required": required_params,
+                "optional": [],
+            },
+        }
+        if returns_dict:
+            data["returns"] = returns_dict
+        result = self.create(
+            data,
+            module_content=file_bytes,
+            module_filename=module_filename,
+        )
+        return {
+            "message": f"Tool '{result['name']}' created successfully.",
+            "name": result["name"],
+            "uuid": result["uuid"],
+            "module_name": result["module_name"],
+            "parameters": params_properties,
+            "description": description,
+            "action": "created",
+        }

--- a/src/skillberry_store/services/tools_service.py
+++ b/src/skillberry_store/services/tools_service.py
@@ -3,11 +3,20 @@
 from __future__ import annotations
 
 import logging
+import time
+import traceback
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set
 
+from prometheus_client import Counter, Histogram
+
 from skillberry_store.modules.object_handler import ObjectHandler
 from skillberry_store.modules.file_executor import detect_tool_dependencies
+from skillberry_store.plugins.events import (
+    emit_content_added,
+    emit_content_deleted,
+    emit_content_updated,
+)
 from skillberry_store.services.exceptions import ObjectAlreadyExistsError
 from skillberry_store.utils.utils import generate_or_validate_uuid
 from skillberry_store.tools.configure import is_auto_detect_dependencies_enabled
@@ -17,6 +26,50 @@ if TYPE_CHECKING:
     from skillberry_store.modules.lifecycle import LifecycleState
 
 logger = logging.getLogger(__name__)
+
+# observability - metrics
+prom_prefix = "sts_service_tools_"
+create_tool_counter = Counter(
+    f"{prom_prefix}create_tool_counter", "Count number of tool create operations"
+)
+list_tools_counter = Counter(
+    f"{prom_prefix}list_tools_counter", "Count number of tool list operations"
+)
+get_tool_counter = Counter(
+    f"{prom_prefix}get_tool_counter", "Count number of tool get operations"
+)
+get_tool_module_counter = Counter(
+    f"{prom_prefix}get_tool_module_counter",
+    "Count number of tool module get operations",
+)
+delete_tool_counter = Counter(
+    f"{prom_prefix}delete_tool_counter", "Count number of tool delete operations"
+)
+update_tool_counter = Counter(
+    f"{prom_prefix}update_tool_counter", "Count number of tool update operations"
+)
+execute_tool_counter = Counter(
+    f"{prom_prefix}execute_tool_counter",
+    "Count number of tool execute operations",
+    ["name"],
+)
+execute_successfully_tool_counter = Counter(
+    f"{prom_prefix}execute_successfully_tool_counter",
+    "Count number of tool executed successfully operations",
+    ["name"],
+)
+execute_successfully_tool_latency = Histogram(
+    f"{prom_prefix}execute_successfully_tool_latency",
+    "Histogram of execute tool successfully latencies",
+    ["name"],
+)
+search_tools_counter = Counter(
+    f"{prom_prefix}search_tools_counter", "Count number of tool search operations"
+)
+add_tool_from_python_counter = Counter(
+    f"{prom_prefix}add_tool_from_python_counter",
+    "Count number of tool add from Python operations",
+)
 
 
 class ToolsService:
@@ -120,37 +173,48 @@ class ToolsService:
         tool_dict = self.get(uuid_or_name)
         tool_uuid = tool_dict["uuid"]
         tool_name = tool_dict.get("name", uuid_or_name)
-        if tool_dict.get("packaging_format") == "mcp":
-            module_content = mcp_content_from_manifest(tool_dict)
-        else:
-            module_content = self.get_module(uuid_or_name)
-        dep_uuids = self.find_dependencies(
-            tool_dict.get("dependencies", []), tool_uuid
-        )
-        dep_dicts = self.handler.read_dicts(list(dep_uuids))
-        dep_files = [
-            self.handler.read_file(m["uuid"], m["module_name"], raw_content=True)
-            for m in dep_dicts
-        ]
-        file_executor = FileExecutor(
-            name=tool_name,
-            file_content=module_content,
-            file_manifest=tool_dict,
-            dependent_file_contents=dep_files,
-            dependent_tools_as_dict=dep_dicts,
-        )
-        result = await file_executor.execute_file(
-            parameters=parameters or {}, env_id=env_id
-        )
-        if isinstance(result, dict) and "error" in result:
-            error_message = result.get("error", "Unknown Error")
-            if "not found" in error_message.lower():
-                raise KeyError(error_message)
-            raise RuntimeError(error_message)
-        logger.info(
-            f"Tool '{tool_name}' (UUID: {tool_uuid}) executed successfully"
-        )
-        return result
+        execute_tool_counter.labels(name=tool_uuid).inc()
+        try:
+            if tool_dict.get("packaging_format") == "mcp":
+                module_content = mcp_content_from_manifest(tool_dict)
+            else:
+                module_content = self.get_module(uuid_or_name)
+            dep_uuids = self.find_dependencies(
+                tool_dict.get("dependencies", []), tool_uuid
+            )
+            dep_dicts = self.handler.read_dicts(list(dep_uuids))
+            dep_files = [
+                self.handler.read_file(m["uuid"], m["module_name"], raw_content=True)
+                for m in dep_dicts
+            ]
+            file_executor = FileExecutor(
+                name=tool_name,
+                file_content=module_content,
+                file_manifest=tool_dict,
+                dependent_file_contents=dep_files,
+                dependent_tools_as_dict=dep_dicts,
+            )
+            start_time = time.time()
+            result = await file_executor.execute_file(
+                parameters=parameters or {}, env_id=env_id
+            )
+            duration = time.time() - start_time
+            if isinstance(result, dict) and "error" in result:
+                error_message = result.get("error", "Unknown Error")
+                if "not found" in error_message.lower():
+                    raise KeyError(error_message)
+                raise RuntimeError(error_message)
+            execute_successfully_tool_counter.labels(name=tool_uuid).inc()
+            execute_successfully_tool_latency.labels(name=tool_uuid).observe(duration)
+            logger.info(
+                f"Tool '{tool_name}' (UUID: {tool_uuid}) executed successfully"
+            )
+            return result
+        except (KeyError, RuntimeError):
+            raise
+        except Exception as e:
+            logger.error(f"Error executing tool '{uuid_or_name}': {e}")
+            raise
 
     def create(
         self,
@@ -185,48 +249,56 @@ class ToolsService:
         Raises:
             ObjectAlreadyExistsError: If tool with the same UUID already exists.
         """
-        data["uuid"] = generate_or_validate_uuid(data.get("uuid"))
-        if self.handler.object_exists(data["uuid"]):
-            raise ObjectAlreadyExistsError(
-                f"Tool with UUID '{data['uuid']}' already exists"
-            )
-        now = datetime.now(timezone.utc).isoformat()
-        data.setdefault("created_at", now)
-        data["modified_at"] = now
-        if data.get("name"):
-            data["parent"] = self.handler.get_cache_parent_for_head(
-                data["uuid"], data["name"]
-            )
-        self.handler.write_file(data["uuid"], module_filename, module_content)
-        data["module_name"] = module_filename
-        if not data.get("dependencies") and is_auto_detect_dependencies_enabled():
-            try:
-                content_str = (
-                    module_content.decode("utf-8")
-                    if isinstance(module_content, bytes)
-                    else module_content
+        create_tool_counter.inc()
+        try:
+            data["uuid"] = generate_or_validate_uuid(data.get("uuid"))
+            if self.handler.object_exists(data["uuid"]):
+                raise ObjectAlreadyExistsError(
+                    f"Tool with UUID '{data['uuid']}' already exists"
                 )
-                available = self.handler.get_existing_names()
-                if extra_name_to_uuid:
-                    available = available | set(extra_name_to_uuid.keys())
-                detected_names = detect_tool_dependencies(
-                    content_str, data["name"], available
+            now = datetime.now(timezone.utc).isoformat()
+            data.setdefault("created_at", now)
+            data["modified_at"] = now
+            if data.get("name"):
+                data["parent"] = self.handler.get_cache_parent_for_head(
+                    data["uuid"], data["name"]
                 )
-                if detected_names:
-                    data["dependencies"] = [
-                        extra_name_to_uuid[n]
-                        if extra_name_to_uuid and n in extra_name_to_uuid
-                        else self.handler.name_to_uuid(n)
-                        for n in detected_names
-                    ]
-            except Exception as e:
-                logger.warning(f"Failed to auto-detect dependencies: {e}")
-        self.handler.write_dict(data["uuid"], data)
-        self.handler.update_cache(data["uuid"], new_name=data["name"])
-        if self.descriptions and data.get("description"):
-            self.descriptions.write_description(data["uuid"], data["description"])
-        logger.info(f"Tool '{data.get('name')}' created with UUID {data['uuid']}")
-        return data
+            self.handler.write_file(data["uuid"], module_filename, module_content)
+            data["module_name"] = module_filename
+            if not data.get("dependencies") and is_auto_detect_dependencies_enabled():
+                try:
+                    content_str = (
+                        module_content.decode("utf-8")
+                        if isinstance(module_content, bytes)
+                        else module_content
+                    )
+                    available = self.handler.get_existing_names()
+                    if extra_name_to_uuid:
+                        available = available | set(extra_name_to_uuid.keys())
+                    detected_names = detect_tool_dependencies(
+                        content_str, data["name"], available
+                    )
+                    if detected_names:
+                        data["dependencies"] = [
+                            extra_name_to_uuid[n]
+                            if extra_name_to_uuid and n in extra_name_to_uuid
+                            else self.handler.name_to_uuid(n)
+                            for n in detected_names
+                        ]
+                except Exception as e:
+                    logger.warning(f"Failed to auto-detect dependencies: {e}")
+            self.handler.write_dict(data["uuid"], data)
+            self.handler.update_cache(data["uuid"], new_name=data["name"])
+            if self.descriptions and data.get("description"):
+                self.descriptions.write_description(data["uuid"], data["description"])
+            emit_content_added("tool", data["uuid"])
+            logger.info(f"Tool '{data.get('name')}' created with UUID {data['uuid']}")
+            return data
+        except ObjectAlreadyExistsError:
+            raise
+        except Exception as e:
+            logger.error(f"Error creating tool '{data.get('name')}': {e}")
+            raise
 
     def _safe_read(self, uuid: str, label: str) -> Dict[str, Any]:
         """Safely read a tool dictionary with error handling.
@@ -250,18 +322,25 @@ class ToolsService:
 
     def get(self, uuid_or_name: str) -> Dict[str, Any]:
         """Get tool metadata by UUID or name.
-        
+
         Args:
             uuid_or_name: Tool UUID or name.
-            
+
         Returns:
             Dict[str, Any]: Tool metadata dictionary.
-            
+
         Raises:
             KeyError: If tool not found.
         """
-        uuid = self._resolve_uuid(uuid_or_name)
-        return self._safe_read(uuid, uuid_or_name)
+        get_tool_counter.inc()
+        try:
+            uuid = self._resolve_uuid(uuid_or_name)
+            return self._safe_read(uuid, uuid_or_name)
+        except KeyError:
+            raise
+        except Exception as e:
+            logger.error(f"Error retrieving tool '{uuid_or_name}': {e}")
+            raise
 
     def get_module(self, uuid_or_name: str) -> str:
         """Get the module file content for a tool.
@@ -282,17 +361,26 @@ class ToolsService:
         """
         from skillberry_store.fast_api.server_utils import mcp_content_from_manifest
 
-        uuid = self._resolve_uuid(uuid_or_name)
-        tool = self.handler.read_dict(uuid)
-        if tool.get("packaging_format") == "mcp":
-            return mcp_content_from_manifest(tool)
-        module_name = tool.get("module_name")
-        if not module_name:
-            raise KeyError(f"Tool '{uuid_or_name}' has no module file")
-        content = self.handler.read_file(uuid, module_name, raw_content=True)
-        if not isinstance(content, str):
-            raise RuntimeError(f"Invalid module content type for tool '{uuid_or_name}'")
-        return content
+        get_tool_module_counter.inc()
+        try:
+            uuid = self._resolve_uuid(uuid_or_name)
+            tool = self.handler.read_dict(uuid)
+            if tool.get("packaging_format") == "mcp":
+                return mcp_content_from_manifest(tool)
+            module_name = tool.get("module_name")
+            if not module_name:
+                raise KeyError(f"Tool '{uuid_or_name}' has no module file")
+            content = self.handler.read_file(uuid, module_name, raw_content=True)
+            if not isinstance(content, str):
+                raise RuntimeError(
+                    f"Invalid module content type for tool '{uuid_or_name}'"
+                )
+            return content
+        except (KeyError, RuntimeError):
+            raise
+        except Exception as e:
+            logger.error(f"Error retrieving module for '{uuid_or_name}': {e}")
+            raise
 
     def list_all(self, filters: Optional[Dict] = None) -> List[Dict[str, Any]]:
         """List all tools with optional filtering.
@@ -303,11 +391,18 @@ class ToolsService:
         Returns:
             List[Dict[str, Any]]: List of tool metadata dictionaries, sorted by modified_at descending.
         """
-        items = self.handler.list_all_dicts()
-        if filters:
-            items = [i for i in items if all(i.get(k) == v for k, v in filters.items())]
-        items.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
-        return items
+        list_tools_counter.inc()
+        try:
+            items = self.handler.list_all_dicts()
+            if filters:
+                items = [
+                    i for i in items if all(i.get(k) == v for k, v in filters.items())
+                ]
+            items.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
+            return items
+        except Exception as e:
+            logger.error(f"Error listing tools: {e}\n{traceback.format_exc()}")
+            raise
 
     def search(
         self,
@@ -346,89 +441,106 @@ class ToolsService:
         from skillberry_store.modules.lifecycle import LifecycleState
         from skillberry_store.fast_api.search_filters import apply_search_filters
 
-        if lifecycle_state is None:
-            lifecycle_state = LifecycleState.ANY
-        if not self.descriptions:
-            raise RuntimeError(
-                "Tool search is not available - descriptions not initialized"
-            )
+        search_tools_counter.inc()
+        try:
+            if lifecycle_state is None:
+                lifecycle_state = LifecycleState.ANY
+            if not self.descriptions:
+                raise RuntimeError(
+                    "Tool search is not available - descriptions not initialized"
+                )
 
-        matched_entities = self.descriptions.search_description(
-            search_term=search_term, k=max_number_of_results
-        )
-        filtered_matched = [
-            m
-            for m in matched_entities
-            if float(m["similarity_score"]) <= similarity_threshold
-        ]
-        candidates: List[Dict[str, Any]] = []
-        for matched in filtered_matched:
-            tool_name = matched.get("filename") or matched.get("name")
-            if not tool_name:
-                continue
-            try:
-                tool_dict = self.get(tool_name)
-                tool_dict["similarity_score"] = matched.get("similarity_score", 0.0)
-                candidates.append(tool_dict)
-            except Exception as e:
-                logger.warning(f"Could not load tool {tool_name}: {e}")
-        filtered_tools = apply_search_filters(
-            candidates,
-            manifest_filter=manifest_filter,
-            lifecycle_state=lifecycle_state,
-        )
-        filtered_tools.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
-        return [
-            {
-                "filename": t.get("name", ""),
-                "similarity_score": t.get("similarity_score", 0.0),
-            }
-            for t in filtered_tools
-            if t.get("name")
-        ]
+            matched_entities = self.descriptions.search_description(
+                search_term=search_term, k=max_number_of_results
+            )
+            filtered_matched = [
+                m
+                for m in matched_entities
+                if float(m["similarity_score"]) <= similarity_threshold
+            ]
+            candidates: List[Dict[str, Any]] = []
+            for matched in filtered_matched:
+                tool_name = matched.get("filename") or matched.get("name")
+                if not tool_name:
+                    continue
+                try:
+                    tool_dict = self.get(tool_name)
+                    tool_dict["similarity_score"] = matched.get(
+                        "similarity_score", 0.0
+                    )
+                    candidates.append(tool_dict)
+                except Exception as e:
+                    logger.warning(f"Could not load tool {tool_name}: {e}")
+            filtered_tools = apply_search_filters(
+                candidates,
+                manifest_filter=manifest_filter,
+                lifecycle_state=lifecycle_state,
+            )
+            filtered_tools.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
+            return [
+                {
+                    "filename": t.get("name", ""),
+                    "similarity_score": t.get("similarity_score", 0.0),
+                }
+                for t in filtered_tools
+                if t.get("name")
+            ]
+        except RuntimeError:
+            raise
+        except Exception as e:
+            logger.error(f"Error searching tools: {e}")
+            raise
 
     def update(self, uuid_or_name: str, data: Dict[str, Any]) -> Dict[str, Any]:
         """Update an existing tool's metadata.
-        
+
         Merges new data with existing tool data, updates timestamps, caches,
         and description indexes as needed.
-        
+
         Args:
             uuid_or_name: Tool UUID or name to update.
             data: Dictionary of fields to update.
-            
+
         Returns:
             Dict[str, Any]: The updated tool metadata.
-            
+
         Raises:
             KeyError: If tool not found.
         """
-        uuid = self._resolve_uuid(uuid_or_name)
-        existing = self.handler.read_dict(uuid)
-        old_name = existing.get("name")
-        old_parent = existing.get("parent")
-        new_name = data.get("name") or old_name
-        if new_name:
-            data["parent"] = self.handler.get_cache_parent_for_head(uuid, new_name)
-        merged = {**existing, **data}
-        merged["uuid"] = existing.get("uuid", uuid)
-        merged["created_at"] = existing.get("created_at")
-        merged["modified_at"] = datetime.now(timezone.utc).isoformat()
-        self.handler.write_dict(uuid, merged)
-        if new_name:
-            self.handler.update_cache(
-                uuid, new_name=new_name, old_name=old_name, old_parent=old_parent
-            )
-        if self.descriptions and data.get("description"):
-            old_desc = existing.get("description")
-            if old_desc != data["description"]:
-                try:
-                    self.descriptions.delete_description(uuid)
-                except Exception:
-                    pass
-                self.descriptions.write_description(uuid, data["description"])
-        logger.info(f"Tool '{uuid_or_name}' updated")
-        return merged
+        update_tool_counter.inc()
+        try:
+            uuid = self._resolve_uuid(uuid_or_name)
+            existing = self.handler.read_dict(uuid)
+            old_name = existing.get("name")
+            old_parent = existing.get("parent")
+            new_name = data.get("name") or old_name
+            if new_name:
+                data["parent"] = self.handler.get_cache_parent_for_head(uuid, new_name)
+            merged = {**existing, **data}
+            merged["uuid"] = existing.get("uuid", uuid)
+            merged["created_at"] = existing.get("created_at")
+            merged["modified_at"] = datetime.now(timezone.utc).isoformat()
+            self.handler.write_dict(uuid, merged)
+            if new_name:
+                self.handler.update_cache(
+                    uuid, new_name=new_name, old_name=old_name, old_parent=old_parent
+                )
+            if self.descriptions and data.get("description"):
+                old_desc = existing.get("description")
+                if old_desc != data["description"]:
+                    try:
+                        self.descriptions.delete_description(uuid)
+                    except Exception:
+                        pass
+                    self.descriptions.write_description(uuid, data["description"])
+            emit_content_updated("tool", uuid)
+            logger.info(f"Tool '{uuid_or_name}' updated")
+            return merged
+        except KeyError:
+            raise
+        except Exception as e:
+            logger.error(f"Error updating tool '{uuid_or_name}': {e}")
+            raise
 
     def delete(self, uuid_or_name: str) -> Dict[str, Any]:
         """Delete a tool and its associated files.
@@ -444,24 +556,34 @@ class ToolsService:
         Raises:
             KeyError: If tool not found.
         """
-        uuid = self._resolve_uuid(uuid_or_name)
+        delete_tool_counter.inc()
         try:
-            d = self.handler.read_dict(uuid)
-            name, parent = d.get("name"), d.get("parent")
-        except Exception:
-            name, parent = None, None
-        if uuid and name:
-            self.handler.update_cache(
-                uuid, new_name=None, old_name=name, old_parent=parent
-            )
-        self.handler.delete_object(uuid)
-        if self.descriptions:
+            uuid = self._resolve_uuid(uuid_or_name)
             try:
-                self.descriptions.delete_description(uuid)
-            except Exception as e:
-                logger.warning(f"Could not delete tool description for {uuid}: {e}")
-        logger.info(f"Tool '{uuid_or_name}' deleted")
-        return {"uuid": uuid}
+                d = self.handler.read_dict(uuid)
+                name, parent = d.get("name"), d.get("parent")
+            except Exception:
+                name, parent = None, None
+            if uuid and name:
+                self.handler.update_cache(
+                    uuid, new_name=None, old_name=name, old_parent=parent
+                )
+            self.handler.delete_object(uuid)
+            if self.descriptions:
+                try:
+                    self.descriptions.delete_description(uuid)
+                except Exception as e:
+                    logger.warning(
+                        f"Could not delete tool description for {uuid}: {e}"
+                    )
+            emit_content_deleted("tool", uuid)
+            logger.info(f"Tool '{uuid_or_name}' deleted")
+            return {"uuid": uuid}
+        except KeyError:
+            raise
+        except Exception as e:
+            logger.error(f"Error deleting tool '{uuid_or_name}': {e}")
+            raise
 
     def add_from_python(
         self,
@@ -502,6 +624,7 @@ class ToolsService:
         """
         from skillberry_store.utils.python_utils import extract_docstring
 
+        add_tool_from_python_counter.inc()
         try:
             func_name, docstring_obj = extract_docstring(file_bytes, selected_func)
         except Exception as e:

--- a/src/skillberry_store/services/tools_service.py
+++ b/src/skillberry_store/services/tools_service.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set
 
 from skillberry_store.modules.object_handler import ObjectHandler
 from skillberry_store.modules.file_executor import detect_tool_dependencies
+from skillberry_store.services.exceptions import ObjectAlreadyExistsError
 from skillberry_store.utils.utils import generate_or_validate_uuid
 from skillberry_store.tools.configure import is_auto_detect_dependencies_enabled
 
@@ -182,11 +183,13 @@ class ToolsService:
             Dict[str, Any]: The created tool data with UUID and timestamps.
 
         Raises:
-            ValueError: If tool with the same UUID already exists.
+            ObjectAlreadyExistsError: If tool with the same UUID already exists.
         """
         data["uuid"] = generate_or_validate_uuid(data.get("uuid"))
         if self.handler.object_exists(data["uuid"]):
-            raise ValueError(f"Tool with UUID '{data['uuid']}' already exists")
+            raise ObjectAlreadyExistsError(
+                f"Tool with UUID '{data['uuid']}' already exists"
+            )
         now = datetime.now(timezone.utc).isoformat()
         data.setdefault("created_at", now)
         data["modified_at"] = now
@@ -262,19 +265,27 @@ class ToolsService:
 
     def get_module(self, uuid_or_name: str) -> str:
         """Get the module file content for a tool.
-        
+
+        For code-packaged tools, returns the module's source file content.
+        For MCP-packaged tools, returns a stub generated from the cached
+        manifest (no MCP round-trip required).
+
         Args:
             uuid_or_name: Tool UUID or name.
-            
+
         Returns:
-            str: Module file content as string.
-            
+            str: Module content (source code for code tools, MCP stub for MCP tools).
+
         Raises:
-            KeyError: If tool not found or has no module file.
+            KeyError: If tool not found, or if a code tool has no module file.
             RuntimeError: If module content type is invalid.
         """
+        from skillberry_store.fast_api.server_utils import mcp_content_from_manifest
+
         uuid = self._resolve_uuid(uuid_or_name)
         tool = self.handler.read_dict(uuid)
+        if tool.get("packaging_format") == "mcp":
+            return mcp_content_from_manifest(tool)
         module_name = tool.get("module_name")
         if not module_name:
             raise KeyError(f"Tool '{uuid_or_name}' has no module file")
@@ -419,14 +430,17 @@ class ToolsService:
         logger.info(f"Tool '{uuid_or_name}' updated")
         return merged
 
-    def delete(self, uuid_or_name: str) -> None:
+    def delete(self, uuid_or_name: str) -> Dict[str, Any]:
         """Delete a tool and its associated files.
-        
+
         Removes the tool metadata, module files, cache entries, and description indexes.
-        
+
         Args:
             uuid_or_name: Tool UUID or name to delete.
-            
+
+        Returns:
+            Dict[str, Any]: ``{"uuid": <deleted-tool-uuid>}``.
+
         Raises:
             KeyError: If tool not found.
         """
@@ -447,6 +461,7 @@ class ToolsService:
             except Exception as e:
                 logger.warning(f"Could not delete tool description for {uuid}: {e}")
         logger.info(f"Tool '{uuid_or_name}' deleted")
+        return {"uuid": uuid}
 
     def add_from_python(
         self,

--- a/src/skillberry_store/services/vmcp_service.py
+++ b/src/skillberry_store/services/vmcp_service.py
@@ -6,6 +6,8 @@ import logging
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
+from prometheus_client import Counter
+
 from skillberry_store.modules.object_handler import ObjectHandler
 from skillberry_store.utils.utils import generate_or_validate_uuid
 
@@ -15,6 +17,30 @@ if TYPE_CHECKING:
     from skillberry_store.modules.vmcp_server_manager import VirtualMcpServerManager
 
 logger = logging.getLogger(__name__)
+
+# observability - metrics
+prom_prefix = "sts_service_vmcp_"
+create_vmcp_counter = Counter(
+    f"{prom_prefix}create_vmcp_counter", "Count number of vmcp create operations"
+)
+list_vmcp_counter = Counter(
+    f"{prom_prefix}list_vmcp_counter", "Count number of vmcp list operations"
+)
+get_vmcp_counter = Counter(
+    f"{prom_prefix}get_vmcp_counter", "Count number of vmcp get operations"
+)
+delete_vmcp_counter = Counter(
+    f"{prom_prefix}delete_vmcp_counter", "Count number of vmcp delete operations"
+)
+update_vmcp_counter = Counter(
+    f"{prom_prefix}update_vmcp_counter", "Count number of vmcp update operations"
+)
+start_vmcp_counter = Counter(
+    f"{prom_prefix}start_vmcp_counter", "Count number of vmcp start operations"
+)
+search_vmcp_counter = Counter(
+    f"{prom_prefix}search_vmcp_counter", "Count number of vmcp search operations"
+)
 
 
 class VmcpService:
@@ -125,46 +151,57 @@ class VmcpService:
             PortConflictError,
         )
 
-        data["uuid"] = generate_or_validate_uuid(data.get("uuid"))
-        if self.handler.object_exists(data["uuid"]):
-            raise ObjectAlreadyExistsError(
-                f"VMCP server with UUID '{data['uuid']}' already exists"
-            )
-        now = datetime.now(timezone.utc).isoformat()
-        data.setdefault("created_at", now)
-        data["modified_at"] = now
-        if data.get("name"):
-            data["parent"] = self.handler.get_cache_parent_for_head(
-                data["uuid"], data["name"]
-            )
-        tool_uuids, snippet_uuids = self._resolve_skill_uuids(data.get("skill_uuid"))
+        create_vmcp_counter.inc()
         try:
-            server = self.server_manager.add_server(
-                name=data.get("name") or "",
-                uuid=data["uuid"],
-                description=data.get("description") or "",
-                port=data.get("port"),
-                tools=tool_uuids,
-                snippets=snippet_uuids,
-                env_id=env_id,
+            data["uuid"] = generate_or_validate_uuid(data.get("uuid"))
+            if self.handler.object_exists(data["uuid"]):
+                raise ObjectAlreadyExistsError(
+                    f"VMCP server with UUID '{data['uuid']}' already exists"
+                )
+            now = datetime.now(timezone.utc).isoformat()
+            data.setdefault("created_at", now)
+            data["modified_at"] = now
+            if data.get("name"):
+                data["parent"] = self.handler.get_cache_parent_for_head(
+                    data["uuid"], data["name"]
+                )
+            tool_uuids, snippet_uuids = self._resolve_skill_uuids(
+                data.get("skill_uuid")
             )
-        except ValueError as e:
-            msg = str(e).lower()
-            if "port" in msg and (
-                "not available" in msg
-                or "in use" in msg
-                or "already in use" in msg
-            ):
-                raise PortConflictError(str(e))
+            try:
+                server = self.server_manager.add_server(
+                    name=data.get("name") or "",
+                    uuid=data["uuid"],
+                    description=data.get("description") or "",
+                    port=data.get("port"),
+                    tools=tool_uuids,
+                    snippets=snippet_uuids,
+                    env_id=env_id,
+                )
+            except ValueError as e:
+                msg = str(e).lower()
+                if "port" in msg and (
+                    "not available" in msg
+                    or "in use" in msg
+                    or "already in use" in msg
+                ):
+                    raise PortConflictError(str(e))
+                raise
+            data["port"] = server.port
+            self.handler.write_dict(data["uuid"], data)
+            if data.get("name"):
+                self.handler.update_cache(data["uuid"], new_name=data["name"])
+            if self.descriptions and data.get("description"):
+                self.descriptions.write_description(data["uuid"], data["description"])
+            logger.info(
+                f"VMCP server '{data.get('name')}' created on port {server.port}"
+            )
+            return data
+        except ValueError:
             raise
-        data["port"] = server.port
-        self.handler.write_dict(data["uuid"], data)
-        if data.get("name"):
-            self.handler.update_cache(data["uuid"], new_name=data["name"])
-        if self.descriptions and data.get("description"):
-            self.descriptions.write_description(data["uuid"], data["description"])
-        logger.info(f"VMCP server '{data.get('name')}' created on port {server.port}")
-        return data
+        except Exception as e:
+            logger.error(f"Error creating vmcp server '{data.get('name')}': {e}")
+            raise
 
     def _safe_read(self, uuid: str, label: str) -> Dict[str, Any]:
         """Safely read a VMCP server dictionary with error handling.
@@ -188,28 +225,35 @@ class VmcpService:
 
     def get(self, uuid_or_name: str) -> Dict[str, Any]:
         """Get VMCP server metadata by UUID or name with runtime status.
-        
+
         Args:
             uuid_or_name: VMCP server UUID or name.
-            
+
         Returns:
             Dict[str, Any]: VMCP server metadata with 'running' and 'runtime' fields.
-            
+
         Raises:
             KeyError: If VMCP server not found.
         """
-        uuid = self._resolve_uuid(uuid_or_name)
-        d = self._safe_read(uuid, uuid_or_name)
+        get_vmcp_counter.inc()
         try:
-            runtime_details = self.server_manager.get_server_details(
-                d.get("name", ""), d.get("uuid", "")
-            )
-            d["runtime"] = runtime_details
-            d["running"] = True
-        except Exception:
-            d["running"] = False
-            d["runtime"] = None
-        return d
+            uuid = self._resolve_uuid(uuid_or_name)
+            d = self._safe_read(uuid, uuid_or_name)
+            try:
+                runtime_details = self.server_manager.get_server_details(
+                    d.get("name", ""), d.get("uuid", "")
+                )
+                d["runtime"] = runtime_details
+                d["running"] = True
+            except Exception:
+                d["running"] = False
+                d["runtime"] = None
+            return d
+        except KeyError:
+            raise
+        except Exception as e:
+            logger.error(f"Error retrieving vmcp server '{uuid_or_name}': {e}")
+            raise
 
     def list_all(self, skill_uuid: Optional[str] = None) -> Dict[str, Any]:
         """List all VMCP servers with runtime status.
@@ -222,46 +266,53 @@ class VmcpService:
             Dict[str, Any]: Dictionary with 'virtual_mcp_servers' key containing server info
                            indexed by UUID, including runtime status.
         """
-        items = self.handler.list_all_dicts()
-        if skill_uuid:
-            items = [i for i in items if i.get("skill_uuid") == skill_uuid]
-        servers = []
-        for item in items:
-            try:
-                runtime = None
+        list_vmcp_counter.inc()
+        try:
+            items = self.handler.list_all_dicts()
+            if skill_uuid:
+                items = [i for i in items if i.get("skill_uuid") == skill_uuid]
+            servers = []
+            for item in items:
                 try:
-                    runtime = self.server_manager.get_server(
-                        item.get("name", ""), item.get("uuid", "")
+                    runtime = None
+                    try:
+                        runtime = self.server_manager.get_server(
+                            item.get("name", ""), item.get("uuid", "")
+                        )
+                    except Exception:
+                        pass
+                    info = {
+                        "uuid": item.get("uuid"),
+                        "name": item.get("name"),
+                        "description": item.get("description"),
+                        "version": item.get("version"),
+                        "state": item.get("state"),
+                        "tags": item.get("tags", []),
+                        "port": item.get("port"),
+                        "skill_uuid": item.get("skill_uuid"),
+                        "modified_at": item.get("modified_at", ""),
+                        "running": runtime is not None,
+                        "runtime": (
+                            {
+                                "name": runtime.name,
+                                "description": runtime.description,
+                                "port": runtime.port,
+                                "tools": runtime.tool_uuids,
+                            }
+                            if runtime
+                            else None
+                        ),
+                    }
+                    servers.append(info)
+                except Exception as e:
+                    logger.warning(
+                        f"Error loading vmcp server '{item.get('name')}': {e}"
                     )
-                except Exception:
-                    pass
-                info = {
-                    "uuid": item.get("uuid"),
-                    "name": item.get("name"),
-                    "description": item.get("description"),
-                    "version": item.get("version"),
-                    "state": item.get("state"),
-                    "tags": item.get("tags", []),
-                    "port": item.get("port"),
-                    "skill_uuid": item.get("skill_uuid"),
-                    "modified_at": item.get("modified_at", ""),
-                    "running": runtime is not None,
-                    "runtime": (
-                        {
-                            "name": runtime.name,
-                            "description": runtime.description,
-                            "port": runtime.port,
-                            "tools": runtime.tool_uuids,
-                        }
-                        if runtime
-                        else None
-                    ),
-                }
-                servers.append(info)
-            except Exception as e:
-                logger.warning(f"Error loading vmcp server '{item.get('name')}': {e}")
-        servers.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
-        return {"virtual_mcp_servers": {s["uuid"]: s for s in servers}}
+            servers.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
+            return {"virtual_mcp_servers": {s["uuid"]: s for s in servers}}
+        except Exception as e:
+            logger.error(f"Error listing vmcp servers: {e}")
+            raise
 
     def search(
         self,
@@ -299,104 +350,121 @@ class VmcpService:
         from skillberry_store.modules.lifecycle import LifecycleState
         from skillberry_store.fast_api.search_filters import apply_search_filters
 
-        if lifecycle_state is None:
-            lifecycle_state = LifecycleState.ANY
-        if not self.descriptions:
-            raise RuntimeError("VMCP server search is not available")
+        search_vmcp_counter.inc()
+        try:
+            if lifecycle_state is None:
+                lifecycle_state = LifecycleState.ANY
+            if not self.descriptions:
+                raise RuntimeError("VMCP server search is not available")
 
-        matched_entities = self.descriptions.search_description(
-            search_term=search_term, k=max_number_of_results
-        )
-        filtered = [
-            m
-            for m in matched_entities
-            if float(m.get("similarity_score", 0)) <= similarity_threshold
-        ]
-        candidates: List[Dict[str, Any]] = []
-        for m in filtered:
-            vmcp_uuid = m.get("filename") or m.get("name")
-            if not vmcp_uuid:
-                continue
-            try:
-                d = self.handler.read_dict(vmcp_uuid)
-                d["similarity_score"] = m.get("similarity_score", 0.0)
-                candidates.append(d)
-            except Exception as exc:
-                logger.warning(f"Could not load vmcp '{vmcp_uuid}': {exc}")
-        result_items = apply_search_filters(
-            candidates,
-            manifest_filter=manifest_filter,
-            lifecycle_state=lifecycle_state,
-        )
-        result_items.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
-        return [
-            {
-                "filename": s.get("name", ""),
-                "similarity_score": s.get("similarity_score", 0.0),
-            }
-            for s in result_items
-            if s.get("name")
-        ]
+            matched_entities = self.descriptions.search_description(
+                search_term=search_term, k=max_number_of_results
+            )
+            filtered = [
+                m
+                for m in matched_entities
+                if float(m.get("similarity_score", 0)) <= similarity_threshold
+            ]
+            candidates: List[Dict[str, Any]] = []
+            for m in filtered:
+                vmcp_uuid = m.get("filename") or m.get("name")
+                if not vmcp_uuid:
+                    continue
+                try:
+                    d = self.handler.read_dict(vmcp_uuid)
+                    d["similarity_score"] = m.get("similarity_score", 0.0)
+                    candidates.append(d)
+                except Exception as exc:
+                    logger.warning(f"Could not load vmcp '{vmcp_uuid}': {exc}")
+            result_items = apply_search_filters(
+                candidates,
+                manifest_filter=manifest_filter,
+                lifecycle_state=lifecycle_state,
+            )
+            result_items.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
+            return [
+                {
+                    "filename": s.get("name", ""),
+                    "similarity_score": s.get("similarity_score", 0.0),
+                }
+                for s in result_items
+                if s.get("name")
+            ]
+        except RuntimeError:
+            raise
+        except Exception as e:
+            logger.error(f"Error searching vmcp servers: {e}")
+            raise
 
     def update(
         self, uuid_or_name: str, data: Dict[str, Any], env_id: str = ""
     ) -> Dict[str, Any]:
         """Update an existing VMCP server's metadata and restart it.
-        
+
         Stops the old runtime server, updates metadata, starts a new runtime server
         with updated configuration, and updates caches and indexes.
-        
+
         Args:
             uuid_or_name: VMCP server UUID or name to update.
             data: Dictionary of fields to update.
             env_id: Optional environment ID for server isolation.
-            
+
         Returns:
             Dict[str, Any]: The updated VMCP server metadata with new port.
-            
+
         Raises:
             KeyError: If VMCP server not found.
         """
-        uuid = self._resolve_uuid(uuid_or_name)
-        existing = self.handler.read_dict(uuid)
-        old_name = existing.get("name")
-        old_parent = existing.get("parent")
-        server_uuid = existing.get("uuid")
-        data["modified_at"] = datetime.now(timezone.utc).isoformat()
-        if not data.get("uuid"):
-            data["uuid"] = server_uuid
-        new_name = data.get("name")
-        if new_name:
-            data["parent"] = self.handler.get_cache_parent_for_head(
-                data["uuid"] or "", new_name
-            )
+        update_vmcp_counter.inc()
         try:
-            self.server_manager.remove_server(old_name or "", server_uuid or "")
-        except Exception as e:
-            logger.warning(f"Could not stop old runtime server: {e}")
-        tool_uuids, snippet_uuids = self._resolve_skill_uuids(data.get("skill_uuid"))
-        server = self.server_manager.add_server(
-            name=new_name or "",
-            uuid=data["uuid"] or "",
-            description=data.get("description") or "",
-            port=data.get("port"),
-            tools=tool_uuids,
-            snippets=snippet_uuids,
-            env_id=env_id,
-        )
-        data["port"] = server.port
-        self.handler.write_dict(data["uuid"] or "", data)
-        if new_name and old_name:
-            self.handler.update_cache(
-                data["uuid"] or "",
-                new_name=new_name,
-                old_name=old_name,
-                old_parent=old_parent,
+            uuid = self._resolve_uuid(uuid_or_name)
+            existing = self.handler.read_dict(uuid)
+            old_name = existing.get("name")
+            old_parent = existing.get("parent")
+            server_uuid = existing.get("uuid")
+            data["modified_at"] = datetime.now(timezone.utc).isoformat()
+            if not data.get("uuid"):
+                data["uuid"] = server_uuid
+            new_name = data.get("name")
+            if new_name:
+                data["parent"] = self.handler.get_cache_parent_for_head(
+                    data["uuid"] or "", new_name
+                )
+            try:
+                self.server_manager.remove_server(old_name or "", server_uuid or "")
+            except Exception as e:
+                logger.warning(f"Could not stop old runtime server: {e}")
+            tool_uuids, snippet_uuids = self._resolve_skill_uuids(
+                data.get("skill_uuid")
             )
-        if self.descriptions and data.get("description") and data.get("uuid"):
-            self.descriptions.write_description(data["uuid"], data["description"])
-        logger.info(f"VMCP server '{new_name}' updated on port {server.port}")
-        return data
+            server = self.server_manager.add_server(
+                name=new_name or "",
+                uuid=data["uuid"] or "",
+                description=data.get("description") or "",
+                port=data.get("port"),
+                tools=tool_uuids,
+                snippets=snippet_uuids,
+                env_id=env_id,
+            )
+            data["port"] = server.port
+            self.handler.write_dict(data["uuid"] or "", data)
+            if new_name and old_name:
+                self.handler.update_cache(
+                    data["uuid"] or "",
+                    new_name=new_name,
+                    old_name=old_name,
+                    old_parent=old_parent,
+                )
+            uuid_value = data.get("uuid")
+            if self.descriptions and data.get("description") and uuid_value:
+                self.descriptions.write_description(uuid_value, data["description"])
+            logger.info(f"VMCP server '{new_name}' updated on port {server.port}")
+            return data
+        except KeyError:
+            raise
+        except Exception as e:
+            logger.error(f"Error updating vmcp server '{uuid_or_name}': {e}")
+            raise
 
     def start(
         self,
@@ -423,58 +491,74 @@ class VmcpService:
         Raises:
             KeyError: If the VMCP server is not found.
         """
-        vmcp_uuid = self._resolve_uuid(uuid_or_name)
-        vmcp_data = self.handler.read_dict(vmcp_uuid)
-        server_name = vmcp_data.get("name", "")
-        server_uuid = vmcp_data.get("uuid", "")
+        start_vmcp_counter.inc()
         try:
-            existing = self.server_manager.get_server(server_name, server_uuid)
-            if existing:
-                return existing, True
-        except Exception:
-            pass
-        tool_uuids, snippet_uuids = self._resolve_skill_uuids(
-            vmcp_data.get("skill_uuid")
-        )
-        server = self.server_manager.add_server(
-            name=server_name,
-            uuid=server_uuid,
-            description=vmcp_data.get("description", ""),
-            port=vmcp_data.get("port"),
-            tools=tool_uuids,
-            snippets=snippet_uuids,
-            env_id=env_id,
-        )
-        logger.info(f"VMCP server '{server_name}' started on port {server.port}")
-        return server, False
+            vmcp_uuid = self._resolve_uuid(uuid_or_name)
+            vmcp_data = self.handler.read_dict(vmcp_uuid)
+            server_name = vmcp_data.get("name", "")
+            server_uuid = vmcp_data.get("uuid", "")
+            try:
+                existing = self.server_manager.get_server(server_name, server_uuid)
+                if existing:
+                    return existing, True
+            except Exception:
+                pass
+            tool_uuids, snippet_uuids = self._resolve_skill_uuids(
+                vmcp_data.get("skill_uuid")
+            )
+            server = self.server_manager.add_server(
+                name=server_name,
+                uuid=server_uuid,
+                description=vmcp_data.get("description", ""),
+                port=vmcp_data.get("port"),
+                tools=tool_uuids,
+                snippets=snippet_uuids,
+                env_id=env_id,
+            )
+            logger.info(f"VMCP server '{server_name}' started on port {server.port}")
+            return server, False
+        except (KeyError, ValueError):
+            raise
+        except Exception as e:
+            logger.error(f"Error starting vmcp server '{uuid_or_name}': {e}")
+            raise
 
     def delete(self, uuid_or_name: str) -> None:
         """Delete a VMCP server and stop its runtime process.
-        
+
         Stops the runtime server, removes metadata, cache entries, and description indexes.
-        
+
         Args:
             uuid_or_name: VMCP server UUID or name to delete.
-            
+
         Raises:
             KeyError: If VMCP server not found.
         """
-        uuid = self._resolve_uuid(uuid_or_name)
-        d = self.handler.read_dict(uuid)
-        name = d.get("name")
-        parent = d.get("parent")
+        delete_vmcp_counter.inc()
         try:
-            self.server_manager.remove_server(name or "", uuid or "")
-        except Exception as e:
-            logger.warning(f"Could not stop runtime server: {e}")
-        if name and uuid:
-            self.handler.update_cache(
-                uuid, new_name=None, old_name=name, old_parent=parent
-            )
-        self.handler.delete_object(uuid)
-        if self.descriptions:
+            uuid = self._resolve_uuid(uuid_or_name)
+            d = self.handler.read_dict(uuid)
+            name = d.get("name")
+            parent = d.get("parent")
             try:
-                self.descriptions.delete_description(uuid)
+                self.server_manager.remove_server(name or "", uuid or "")
             except Exception as e:
-                logger.warning(f"Could not delete vmcp description for {uuid}: {e}")
-        logger.info(f"VMCP server '{uuid_or_name}' deleted")
+                logger.warning(f"Could not stop runtime server: {e}")
+            if name and uuid:
+                self.handler.update_cache(
+                    uuid, new_name=None, old_name=name, old_parent=parent
+                )
+            self.handler.delete_object(uuid)
+            if self.descriptions:
+                try:
+                    self.descriptions.delete_description(uuid)
+                except Exception as e:
+                    logger.warning(
+                        f"Could not delete vmcp description for {uuid}: {e}"
+                    )
+            logger.info(f"VMCP server '{uuid_or_name}' deleted")
+        except KeyError:
+            raise
+        except Exception as e:
+            logger.error(f"Error deleting vmcp server '{uuid_or_name}': {e}")
+            raise

--- a/src/skillberry_store/services/vmcp_service.py
+++ b/src/skillberry_store/services/vmcp_service.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from skillberry_store.modules.object_handler import ObjectHandler
 from skillberry_store.utils.utils import generate_or_validate_uuid
 
 if TYPE_CHECKING:
     from skillberry_store.modules.description import Description
+    from skillberry_store.modules.lifecycle import LifecycleState
     from skillberry_store.modules.vmcp_server_manager import VirtualMcpServerManager
 
 logger = logging.getLogger(__name__)
@@ -18,35 +19,34 @@ logger = logging.getLogger(__name__)
 
 class VmcpService:
     """Service layer for virtual MCP server CRUD operations.
-    
+
     Provides business logic for managing virtual MCP servers, which expose
-    skills as MCP-compatible servers on specified ports.
-    
+    skills as MCP-compatible servers on specified ports. Skill-related lookups
+    (e.g. resolving the underlying skill's tools and snippets in
+    :meth:`_resolve_skill_uuids`) are routed through
+    :func:`skillberry_store.services.registry.get_service`.
+
     Attributes:
         handler: ObjectHandler for VMCP server persistence operations.
         server_manager: VirtualMcpServerManager for runtime server management.
-        skills_handler: ObjectHandler for resolving skill references.
         descriptions: Optional Description instance for semantic search indexing.
     """
-    
+
     def __init__(
         self,
         handler: ObjectHandler,
         server_manager: VirtualMcpServerManager,
-        skills_handler: ObjectHandler,
         descriptions: Optional[Description] = None,
     ):
         """Initialize the VmcpService.
-        
+
         Args:
             handler: ObjectHandler instance for VMCP server operations.
             server_manager: VirtualMcpServerManager for managing runtime servers.
-            skills_handler: ObjectHandler instance for skill operations.
             descriptions: Optional Description instance for managing VMCP descriptions.
         """
         self.handler = handler
         self.server_manager = server_manager
-        self.skills_handler = skills_handler
         self.descriptions = descriptions
 
     def _resolve_uuid(self, uuid_or_name: str) -> str:
@@ -70,19 +70,30 @@ class VmcpService:
 
     def _resolve_skill_uuids(self, skill_uuid: Optional[str]):
         """Resolve a skill UUID to its tool and snippet UUIDs.
-        
+
+        Routes the lookup through the sibling :class:`SkillsService` singleton
+        (obtained from
+        :func:`skillberry_store.services.registry.get_service`) rather than
+        the skill handler directly.
+
         Args:
             skill_uuid: Optional skill UUID to resolve.
-            
+
         Returns:
-            Tuple[List[str], List[str]]: Tool UUIDs and snippet UUIDs from the skill.
+            Tuple[List[str], List[str]]: Tool UUIDs and snippet UUIDs from the
+                skill. Returns ``([], [])`` when ``skill_uuid`` is falsy or the
+                skill cannot be loaded (errors are logged and swallowed to
+                preserve the original best-effort contract used by
+                ``create`` / ``update`` / ``start``).
         """
+        from skillberry_store.services.registry import get_service
+
         tool_uuids: List[str] = []
         snippet_uuids: List[str] = []
         if not skill_uuid:
             return tool_uuids, snippet_uuids
         try:
-            skill = self.skills_handler.read_dict(skill_uuid)
+            skill = get_service("skill").get(skill_uuid)
             tool_uuids = skill.get("tool_uuids", [])
             snippet_uuids = skill.get("snippet_uuids", [])
         except Exception as e:
@@ -181,7 +192,7 @@ class VmcpService:
 
     def list_all(self) -> Dict[str, Any]:
         """List all VMCP servers with runtime status.
-        
+
         Returns:
             Dict[str, Any]: Dictionary with 'virtual_mcp_servers' key containing server info
                            indexed by UUID, including runtime status.
@@ -224,6 +235,81 @@ class VmcpService:
                 logger.warning(f"Error loading vmcp server '{item.get('name')}': {e}")
         servers.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
         return {"virtual_mcp_servers": {s["uuid"]: s for s in servers}}
+
+    def search(
+        self,
+        search_term: str,
+        max_number_of_results: int = 5,
+        similarity_threshold: float = 1.0,
+        manifest_filter: str = ".",
+        lifecycle_state: Optional["LifecycleState"] = None,
+    ) -> List[Dict[str, Any]]:
+        """Search VMCP servers by semantic similarity to a search term.
+
+        Performs a vector-similarity search over VMCP server descriptions, then
+        filters by similarity threshold, manifest properties, and lifecycle state,
+        and returns matched names with similarity scores sorted by ``modified_at``
+        (most recent first).
+
+        Args:
+            search_term: Free-text query to match against VMCP descriptions.
+            max_number_of_results: Upper bound on candidates returned by the
+                vector index before threshold filtering.
+            similarity_threshold: Maximum allowed similarity score (lower is
+                more similar).
+            manifest_filter: Manifest property filter expression
+                (e.g. ``"tags:python"``, ``"state:approved"``).
+            lifecycle_state: Lifecycle state filter. Defaults to
+                ``LifecycleState.ANY`` when ``None`` is passed.
+
+        Returns:
+            List[Dict[str, Any]]: Matches, each ``{"filename": <name>, "similarity_score": <float>}``.
+
+        Raises:
+            RuntimeError: If the service was constructed without a
+                ``Description`` instance (search index unavailable).
+        """
+        from skillberry_store.modules.lifecycle import LifecycleState
+        from skillberry_store.fast_api.search_filters import apply_search_filters
+
+        if lifecycle_state is None:
+            lifecycle_state = LifecycleState.ANY
+        if not self.descriptions:
+            raise RuntimeError("VMCP server search is not available")
+
+        matched_entities = self.descriptions.search_description(
+            search_term=search_term, k=max_number_of_results
+        )
+        filtered = [
+            m
+            for m in matched_entities
+            if float(m.get("similarity_score", 0)) <= similarity_threshold
+        ]
+        candidates: List[Dict[str, Any]] = []
+        for m in filtered:
+            vmcp_uuid = m.get("filename") or m.get("name")
+            if not vmcp_uuid:
+                continue
+            try:
+                d = self.handler.read_dict(vmcp_uuid)
+                d["similarity_score"] = m.get("similarity_score", 0.0)
+                candidates.append(d)
+            except Exception as exc:
+                logger.warning(f"Could not load vmcp '{vmcp_uuid}': {exc}")
+        result_items = apply_search_filters(
+            candidates,
+            manifest_filter=manifest_filter,
+            lifecycle_state=lifecycle_state,
+        )
+        result_items.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
+        return [
+            {
+                "filename": s.get("name", ""),
+                "similarity_score": s.get("similarity_score", 0.0),
+            }
+            for s in result_items
+            if s.get("name")
+        ]
 
     def update(
         self, uuid_or_name: str, data: Dict[str, Any], env_id: str = ""
@@ -284,6 +370,56 @@ class VmcpService:
             self.descriptions.write_description(data["uuid"], data["description"])
         logger.info(f"VMCP server '{new_name}' updated on port {server.port}")
         return data
+
+    def start(
+        self,
+        uuid_or_name: str,
+        env_id: str = "",
+    ) -> Tuple[Any, bool]:
+        """Start (or report already-running) a VMCP server runtime.
+
+        Resolves the VMCP server, checks whether its runtime is already up; if
+        so, returns the existing runtime with ``already_running=True``. Otherwise
+        resolves the associated skill's tools and snippets and adds the server
+        via the runtime manager.
+
+        Args:
+            uuid_or_name: VMCP server UUID or name to start.
+            env_id: Optional environment ID for runtime isolation.
+
+        Returns:
+            Tuple[Any, bool]: Pair of the runtime server object (whose ``.port``
+                and ``.name`` callers may read) and a boolean that is ``True``
+                when the server was already running and ``False`` when it was
+                started by this call.
+
+        Raises:
+            KeyError: If the VMCP server is not found.
+        """
+        vmcp_uuid = self._resolve_uuid(uuid_or_name)
+        vmcp_data = self.handler.read_dict(vmcp_uuid)
+        server_name = vmcp_data.get("name", "")
+        server_uuid = vmcp_data.get("uuid", "")
+        try:
+            existing = self.server_manager.get_server(server_name, server_uuid)
+            if existing:
+                return existing, True
+        except Exception:
+            pass
+        tool_uuids, snippet_uuids = self._resolve_skill_uuids(
+            vmcp_data.get("skill_uuid")
+        )
+        server = self.server_manager.add_server(
+            name=server_name,
+            uuid=server_uuid,
+            description=vmcp_data.get("description", ""),
+            port=vmcp_data.get("port"),
+            tools=tool_uuids,
+            snippets=snippet_uuids,
+            env_id=env_id,
+        )
+        logger.info(f"VMCP server '{server_name}' started on port {server.port}")
+        return server, False
 
     def delete(self, uuid_or_name: str) -> None:
         """Delete a VMCP server and stop its runtime process.

--- a/src/skillberry_store/services/vmcp_service.py
+++ b/src/skillberry_store/services/vmcp_service.py
@@ -102,23 +102,34 @@ class VmcpService:
 
     def create(self, data: Dict[str, Any], env_id: str = "") -> Dict[str, Any]:
         """Create a new virtual MCP server and start it.
-        
+
         Creates a VMCP server entry, starts the runtime server process, and updates
         caches and indexes.
-        
+
         Args:
             data: VMCP server metadata dictionary (name, skill_uuid, port, etc.).
             env_id: Optional environment ID for server isolation.
-            
+
         Returns:
             Dict[str, Any]: The created VMCP server data with UUID, timestamps, and assigned port.
-            
+
         Raises:
-            ValueError: If VMCP server with the same UUID already exists.
+            ObjectAlreadyExistsError: If VMCP server with the same UUID already
+                exists.
+            PortConflictError: If the runtime manager rejects the port as
+                unavailable / already in use.
+            ValueError: For other server-creation failures.
         """
+        from skillberry_store.services.exceptions import (
+            ObjectAlreadyExistsError,
+            PortConflictError,
+        )
+
         data["uuid"] = generate_or_validate_uuid(data.get("uuid"))
         if self.handler.object_exists(data["uuid"]):
-            raise ValueError(f"VMCP server with UUID '{data['uuid']}' already exists")
+            raise ObjectAlreadyExistsError(
+                f"VMCP server with UUID '{data['uuid']}' already exists"
+            )
         now = datetime.now(timezone.utc).isoformat()
         data.setdefault("created_at", now)
         data["modified_at"] = now
@@ -127,15 +138,25 @@ class VmcpService:
                 data["uuid"], data["name"]
             )
         tool_uuids, snippet_uuids = self._resolve_skill_uuids(data.get("skill_uuid"))
-        server = self.server_manager.add_server(
-            name=data.get("name") or "",
-            uuid=data["uuid"],
-            description=data.get("description") or "",
-            port=data.get("port"),
-            tools=tool_uuids,
-            snippets=snippet_uuids,
-            env_id=env_id,
-        )
+        try:
+            server = self.server_manager.add_server(
+                name=data.get("name") or "",
+                uuid=data["uuid"],
+                description=data.get("description") or "",
+                port=data.get("port"),
+                tools=tool_uuids,
+                snippets=snippet_uuids,
+                env_id=env_id,
+            )
+        except ValueError as e:
+            msg = str(e).lower()
+            if "port" in msg and (
+                "not available" in msg
+                or "in use" in msg
+                or "already in use" in msg
+            ):
+                raise PortConflictError(str(e))
+            raise
         data["port"] = server.port
         self.handler.write_dict(data["uuid"], data)
         if data.get("name"):
@@ -190,14 +211,20 @@ class VmcpService:
             d["runtime"] = None
         return d
 
-    def list_all(self) -> Dict[str, Any]:
+    def list_all(self, skill_uuid: Optional[str] = None) -> Dict[str, Any]:
         """List all VMCP servers with runtime status.
+
+        Args:
+            skill_uuid: When provided, restrict the result to servers whose
+                ``skill_uuid`` matches this value.
 
         Returns:
             Dict[str, Any]: Dictionary with 'virtual_mcp_servers' key containing server info
                            indexed by UUID, including runtime status.
         """
         items = self.handler.list_all_dicts()
+        if skill_uuid:
+            items = [i for i in items if i.get("skill_uuid") == skill_uuid]
         servers = []
         for item in items:
             try:

--- a/src/skillberry_store/services/vnfs_service.py
+++ b/src/skillberry_store/services/vnfs_service.py
@@ -7,6 +7,8 @@ from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
+from prometheus_client import Counter
+
 from skillberry_store.modules.object_handler import ObjectHandler
 from skillberry_store.utils.utils import generate_or_validate_uuid
 
@@ -16,6 +18,16 @@ if TYPE_CHECKING:
     from skillberry_store.modules.vnfs_server_manager import VirtualNfsServerManager
 
 logger = logging.getLogger(__name__)
+
+# observability - metrics
+prom_prefix = "sts_service_vnfs_"
+create_vnfs_counter = Counter(f"{prom_prefix}create_counter", "vNFS create operations")
+list_vnfs_counter = Counter(f"{prom_prefix}list_counter", "vNFS list operations")
+get_vnfs_counter = Counter(f"{prom_prefix}get_counter", "vNFS get operations")
+delete_vnfs_counter = Counter(f"{prom_prefix}delete_counter", "vNFS delete operations")
+update_vnfs_counter = Counter(f"{prom_prefix}update_counter", "vNFS update operations")
+start_vnfs_counter = Counter(f"{prom_prefix}start_counter", "vNFS start operations")
+search_vnfs_counter = Counter(f"{prom_prefix}search_counter", "vNFS search operations")
 
 
 def _to_ns(data: Dict[str, Any]) -> SimpleNamespace:
@@ -108,37 +120,46 @@ class VnfsService:
             PortConflictError,
         )
 
-        data["uuid"] = generate_or_validate_uuid(data.get("uuid"))
-        if self.handler.object_exists(data["uuid"]):
-            raise ObjectAlreadyExistsError(
-                f"vNFS server with UUID '{data['uuid']}' already exists"
-            )
-        now = datetime.now(timezone.utc).isoformat()
-        data.setdefault("created_at", now)
-        data["modified_at"] = now
-        if data.get("name"):
-            data["parent"] = self.handler.get_cache_parent_for_head(
-                data["uuid"], data["name"]
-            )
+        create_vnfs_counter.inc()
         try:
-            server = self.server_manager.add_server(_to_ns(data))
-        except ValueError as e:
-            msg = str(e).lower()
-            if "port" in msg and (
-                "not available" in msg
-                or "in use" in msg
-                or "already in use" in msg
-            ):
-                raise PortConflictError(str(e))
+            data["uuid"] = generate_or_validate_uuid(data.get("uuid"))
+            if self.handler.object_exists(data["uuid"]):
+                raise ObjectAlreadyExistsError(
+                    f"vNFS server with UUID '{data['uuid']}' already exists"
+                )
+            now = datetime.now(timezone.utc).isoformat()
+            data.setdefault("created_at", now)
+            data["modified_at"] = now
+            if data.get("name"):
+                data["parent"] = self.handler.get_cache_parent_for_head(
+                    data["uuid"], data["name"]
+                )
+            try:
+                server = self.server_manager.add_server(_to_ns(data))
+            except ValueError as e:
+                msg = str(e).lower()
+                if "port" in msg and (
+                    "not available" in msg
+                    or "in use" in msg
+                    or "already in use" in msg
+                ):
+                    raise PortConflictError(str(e))
+                raise
+            data["port"] = server.port
+            self.handler.write_dict(data["uuid"], data)
+            if data.get("name"):
+                self.handler.update_cache(data["uuid"], new_name=data["name"])
+            if self.descriptions and data.get("description"):
+                self.descriptions.write_description(data["uuid"], data["description"])
+            logger.info(
+                f"vNFS server '{data.get('name')}' created on port {server.port}"
+            )
+            return data
+        except ValueError:
             raise
-        data["port"] = server.port
-        self.handler.write_dict(data["uuid"], data)
-        if data.get("name"):
-            self.handler.update_cache(data["uuid"], new_name=data["name"])
-        if self.descriptions and data.get("description"):
-            self.descriptions.write_description(data["uuid"], data["description"])
-        logger.info(f"vNFS server '{data.get('name')}' created on port {server.port}")
-        return data
+        except Exception as exc:
+            logger.error(f"Error creating vnfs server '{data.get('name')}': {exc}")
+            raise
 
     def _safe_read(self, uuid: str, label: str) -> Dict[str, Any]:
         """Safely read a vNFS server dictionary with error handling.
@@ -162,28 +183,35 @@ class VnfsService:
 
     def get(self, uuid_or_name: str) -> Dict[str, Any]:
         """Get vNFS server metadata by UUID or name with runtime status.
-        
+
         Args:
             uuid_or_name: vNFS server UUID or name.
-            
+
         Returns:
             Dict[str, Any]: vNFS server metadata with 'running' and 'export_path' fields.
-            
+
         Raises:
             KeyError: If vNFS server not found.
         """
-        uuid = self._resolve_uuid(uuid_or_name)
-        d = self._safe_read(uuid, uuid_or_name)
+        get_vnfs_counter.inc()
         try:
-            runtime = self.server_manager.get_server(
-                d.get("name", ""), d.get("uuid", "")
-            )
-            d["running"] = runtime is not None and runtime.running
-            d["export_path"] = str(runtime.export_path) if runtime else None
-        except Exception:
-            d["running"] = False
-            d["export_path"] = None
-        return d
+            uuid = self._resolve_uuid(uuid_or_name)
+            d = self._safe_read(uuid, uuid_or_name)
+            try:
+                runtime = self.server_manager.get_server(
+                    d.get("name", ""), d.get("uuid", "")
+                )
+                d["running"] = runtime is not None and runtime.running
+                d["export_path"] = str(runtime.export_path) if runtime else None
+            except Exception:
+                d["running"] = False
+                d["export_path"] = None
+            return d
+        except KeyError:
+            raise
+        except Exception as exc:
+            logger.error(f"Error retrieving vnfs server '{uuid_or_name}': {exc}")
+            raise
 
     def list_all(self, skill_uuid: Optional[str] = None) -> Dict[str, Any]:
         """List all vNFS servers with runtime status.
@@ -196,38 +224,45 @@ class VnfsService:
             Dict[str, Any]: Dictionary with 'virtual_nfs_servers' key containing server info
                            indexed by UUID, including runtime status and export paths.
         """
-        items = self.handler.list_all_dicts()
-        if skill_uuid:
-            items = [i for i in items if i.get("skill_uuid") == skill_uuid]
-        servers = []
-        for item in items:
-            try:
-                runtime = None
+        list_vnfs_counter.inc()
+        try:
+            items = self.handler.list_all_dicts()
+            if skill_uuid:
+                items = [i for i in items if i.get("skill_uuid") == skill_uuid]
+            servers = []
+            for item in items:
                 try:
-                    runtime = self.server_manager.get_server(
-                        item.get("name", ""), item.get("uuid", "")
+                    runtime = None
+                    try:
+                        runtime = self.server_manager.get_server(
+                            item.get("name", ""), item.get("uuid", "")
+                        )
+                    except Exception:
+                        pass
+                    info = {
+                        "uuid": item.get("uuid"),
+                        "name": item.get("name"),
+                        "description": item.get("description"),
+                        "version": item.get("version"),
+                        "state": item.get("state"),
+                        "tags": item.get("tags", []),
+                        "port": item.get("port"),
+                        "skill_uuid": item.get("skill_uuid"),
+                        "protocol": item.get("protocol", "webdav"),
+                        "modified_at": item.get("modified_at", ""),
+                        "running": runtime is not None and runtime.running,
+                        "export_path": str(runtime.export_path) if runtime else None,
+                    }
+                    servers.append(info)
+                except Exception as e:
+                    logger.warning(
+                        f"Error loading vnfs server '{item.get('name')}': {e}"
                     )
-                except Exception:
-                    pass
-                info = {
-                    "uuid": item.get("uuid"),
-                    "name": item.get("name"),
-                    "description": item.get("description"),
-                    "version": item.get("version"),
-                    "state": item.get("state"),
-                    "tags": item.get("tags", []),
-                    "port": item.get("port"),
-                    "skill_uuid": item.get("skill_uuid"),
-                    "protocol": item.get("protocol", "webdav"),
-                    "modified_at": item.get("modified_at", ""),
-                    "running": runtime is not None and runtime.running,
-                    "export_path": str(runtime.export_path) if runtime else None,
-                }
-                servers.append(info)
-            except Exception as e:
-                logger.warning(f"Error loading vnfs server '{item.get('name')}': {e}")
-        servers.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
-        return {"virtual_nfs_servers": {s["uuid"]: s for s in servers}}
+            servers.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
+            return {"virtual_nfs_servers": {s["uuid"]: s for s in servers}}
+        except Exception as exc:
+            logger.error(f"Error listing vnfs servers: {exc}")
+            raise
 
     def search(
         self,
@@ -265,90 +300,107 @@ class VnfsService:
         from skillberry_store.modules.lifecycle import LifecycleState
         from skillberry_store.fast_api.search_filters import apply_search_filters
 
-        if lifecycle_state is None:
-            lifecycle_state = LifecycleState.ANY
-        if not self.descriptions:
-            raise RuntimeError("vNFS server search is not available")
+        search_vnfs_counter.inc()
+        try:
+            if lifecycle_state is None:
+                lifecycle_state = LifecycleState.ANY
+            if not self.descriptions:
+                raise RuntimeError("vNFS server search is not available")
 
-        matched = self.descriptions.search_description(
-            search_term=search_term, k=max_number_of_results
-        )
-        filtered = [
-            m for m in matched if float(m["similarity_score"]) <= similarity_threshold
-        ]
-        candidates: List[Dict[str, Any]] = []
-        for m in filtered:
-            vnfs_uuid = m.get("filename") or m.get("name")
-            if not vnfs_uuid:
-                continue
-            try:
-                d = self.handler.read_dict(vnfs_uuid)
-                d["similarity_score"] = m.get("similarity_score", 0.0)
-                candidates.append(d)
-            except Exception as exc:
-                logger.warning(f"Could not load vnfs '{vnfs_uuid}': {exc}")
-        result_items = apply_search_filters(
-            candidates,
-            manifest_filter=manifest_filter,
-            lifecycle_state=lifecycle_state,
-        )
-        result_items.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
-        return [
-            {
-                "filename": s.get("name", ""),
-                "similarity_score": s.get("similarity_score", 0.0),
-            }
-            for s in result_items
-            if s.get("name")
-        ]
+            matched = self.descriptions.search_description(
+                search_term=search_term, k=max_number_of_results
+            )
+            filtered = [
+                m
+                for m in matched
+                if float(m["similarity_score"]) <= similarity_threshold
+            ]
+            candidates: List[Dict[str, Any]] = []
+            for m in filtered:
+                vnfs_uuid = m.get("filename") or m.get("name")
+                if not vnfs_uuid:
+                    continue
+                try:
+                    d = self.handler.read_dict(vnfs_uuid)
+                    d["similarity_score"] = m.get("similarity_score", 0.0)
+                    candidates.append(d)
+                except Exception as exc:
+                    logger.warning(f"Could not load vnfs '{vnfs_uuid}': {exc}")
+            result_items = apply_search_filters(
+                candidates,
+                manifest_filter=manifest_filter,
+                lifecycle_state=lifecycle_state,
+            )
+            result_items.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
+            return [
+                {
+                    "filename": s.get("name", ""),
+                    "similarity_score": s.get("similarity_score", 0.0),
+                }
+                for s in result_items
+                if s.get("name")
+            ]
+        except RuntimeError:
+            raise
+        except Exception as exc:
+            logger.error(f"Error searching vnfs servers: {exc}")
+            raise
 
     def update(self, uuid_or_name: str, data: Dict[str, Any]) -> Dict[str, Any]:
         """Update an existing vNFS server's metadata and restart it.
-        
+
         Stops the old runtime server, updates metadata, starts a new runtime server
         with updated configuration, and updates caches and indexes.
-        
+
         Args:
             uuid_or_name: vNFS server UUID or name to update.
             data: Dictionary of fields to update.
-            
+
         Returns:
             Dict[str, Any]: The updated vNFS server metadata with new port.
-            
+
         Raises:
             KeyError: If vNFS server not found.
         """
-        uuid = self._resolve_uuid(uuid_or_name)
-        existing = self.handler.read_dict(uuid)
-        old_name = existing.get("name")
-        old_parent = existing.get("parent")
-        server_uuid = existing.get("uuid")
-        data["modified_at"] = datetime.now(timezone.utc).isoformat()
-        if not data.get("uuid"):
-            data["uuid"] = server_uuid
-        new_name = data.get("name")
-        if new_name:
-            data["parent"] = self.handler.get_cache_parent_for_head(
-                data["uuid"] or "", new_name
-            )
+        update_vnfs_counter.inc()
         try:
-            self.server_manager.remove_server(old_name or "", server_uuid or "")
-        except Exception as e:
-            logger.warning(f"Could not stop old runtime server: {e}")
-        server = self.server_manager.add_server(_to_ns(data))
-        data["port"] = server.port
-        self.handler.write_dict(data["uuid"] or "", data)
-        if new_name and old_name:
-            self.handler.update_cache(
-                data["uuid"] or "",
-                new_name=new_name,
-                old_name=old_name,
-                old_parent=old_parent,
-            )
-        if self.descriptions and data.get("description") and data.get("uuid"):
-            self.descriptions.write_description(data["uuid"], data["description"])
-        logger.info(f"vNFS server '{new_name}' updated on port {server.port}")
-        return data
+            uuid = self._resolve_uuid(uuid_or_name)
+            existing = self.handler.read_dict(uuid)
+            old_name = existing.get("name")
+            old_parent = existing.get("parent")
+            server_uuid = existing.get("uuid")
+            data["modified_at"] = datetime.now(timezone.utc).isoformat()
+            if not data.get("uuid"):
+                data["uuid"] = server_uuid
+            new_name = data.get("name")
+            if new_name:
+                data["parent"] = self.handler.get_cache_parent_for_head(
+                    data["uuid"] or "", new_name
+                )
+            try:
+                self.server_manager.remove_server(old_name or "", server_uuid or "")
+            except Exception as e:
+                logger.warning(f"Could not stop old runtime server: {e}")
+            server = self.server_manager.add_server(_to_ns(data))
+            data["port"] = server.port
+            self.handler.write_dict(data["uuid"] or "", data)
+            if new_name and old_name:
+                self.handler.update_cache(
+                    data["uuid"] or "",
+                    new_name=new_name,
+                    old_name=old_name,
+                    old_parent=old_parent,
+                )
+            uuid_value = data.get("uuid")
+            if self.descriptions and data.get("description") and uuid_value:
+                self.descriptions.write_description(uuid_value, data["description"])
+            logger.info(f"vNFS server '{new_name}' updated on port {server.port}")
+            return data
+        except KeyError:
+            raise
+        except Exception as exc:
+            logger.error(f"Error updating vnfs server '{uuid_or_name}': {exc}")
+            raise
 
     def start(self, uuid_or_name: str) -> Tuple[Any, bool]:
         """Start (or report already-running) a vNFS server runtime.
@@ -370,47 +422,63 @@ class VnfsService:
         Raises:
             KeyError: If the vNFS server is not found.
         """
-        vnfs_uuid = self._resolve_uuid(uuid_or_name)
-        vnfs_data = self.handler.read_dict(vnfs_uuid)
-        server_name = vnfs_data.get("name", "")
-        server_uuid = vnfs_data.get("uuid", "")
+        start_vnfs_counter.inc()
         try:
-            existing = self.server_manager.get_server(server_name, server_uuid)
-            if existing and existing.running:
-                return existing, True
-        except Exception:
-            pass
-        server = self.server_manager.add_server(_to_ns(vnfs_data))
-        logger.info(f"vNFS server '{server_name}' started on port {server.port}")
-        return server, False
+            vnfs_uuid = self._resolve_uuid(uuid_or_name)
+            vnfs_data = self.handler.read_dict(vnfs_uuid)
+            server_name = vnfs_data.get("name", "")
+            server_uuid = vnfs_data.get("uuid", "")
+            try:
+                existing = self.server_manager.get_server(server_name, server_uuid)
+                if existing and existing.running:
+                    return existing, True
+            except Exception:
+                pass
+            server = self.server_manager.add_server(_to_ns(vnfs_data))
+            logger.info(f"vNFS server '{server_name}' started on port {server.port}")
+            return server, False
+        except (KeyError, ValueError):
+            raise
+        except Exception as exc:
+            logger.error(f"Error starting vnfs server '{uuid_or_name}': {exc}")
+            raise
 
     def delete(self, uuid_or_name: str) -> None:
         """Delete a vNFS server and stop its runtime process.
-        
+
         Stops the runtime server, removes metadata, cache entries, and description indexes.
-        
+
         Args:
             uuid_or_name: vNFS server UUID or name to delete.
-            
+
         Raises:
             KeyError: If vNFS server not found.
         """
-        uuid = self._resolve_uuid(uuid_or_name)
-        d = self.handler.read_dict(uuid)
-        name = d.get("name")
-        parent = d.get("parent")
+        delete_vnfs_counter.inc()
         try:
-            self.server_manager.remove_server(name or "", uuid or "")
-        except Exception as e:
-            logger.warning(f"Could not stop runtime server: {e}")
-        if name and uuid:
-            self.handler.update_cache(
-                uuid, new_name=None, old_name=name, old_parent=parent
-            )
-        self.handler.delete_object(uuid)
-        if self.descriptions:
+            uuid = self._resolve_uuid(uuid_or_name)
+            d = self.handler.read_dict(uuid)
+            name = d.get("name")
+            parent = d.get("parent")
             try:
-                self.descriptions.delete_description(uuid)
+                self.server_manager.remove_server(name or "", uuid or "")
             except Exception as e:
-                logger.warning(f"Could not delete vnfs description for {uuid}: {e}")
-        logger.info(f"vNFS server '{uuid_or_name}' deleted")
+                logger.warning(f"Could not stop runtime server: {e}")
+            if name and uuid:
+                self.handler.update_cache(
+                    uuid, new_name=None, old_name=name, old_parent=parent
+                )
+            self.handler.delete_object(uuid)
+            if self.descriptions:
+                try:
+                    self.descriptions.delete_description(uuid)
+                except Exception as e:
+                    logger.warning(
+                        f"Could not delete vnfs description for {uuid}: {e}"
+                    )
+            logger.info(f"vNFS server '{uuid_or_name}' deleted")
+        except KeyError:
+            raise
+        except Exception as exc:
+            logger.error(f"Error deleting vnfs server '{uuid_or_name}': {exc}")
+            raise

--- a/src/skillberry_store/services/vnfs_service.py
+++ b/src/skillberry_store/services/vnfs_service.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 import logging
 from datetime import datetime, timezone
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from skillberry_store.modules.object_handler import ObjectHandler
 from skillberry_store.utils.utils import generate_or_validate_uuid
 
 if TYPE_CHECKING:
     from skillberry_store.modules.description import Description
+    from skillberry_store.modules.lifecycle import LifecycleState
     from skillberry_store.modules.vnfs_server_manager import VirtualNfsServerManager
 
 logger = logging.getLogger(__name__)
@@ -202,6 +203,79 @@ class VnfsService:
         servers.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
         return {"virtual_nfs_servers": {s["uuid"]: s for s in servers}}
 
+    def search(
+        self,
+        search_term: str,
+        max_number_of_results: int = 5,
+        similarity_threshold: float = 1.0,
+        manifest_filter: str = ".",
+        lifecycle_state: Optional["LifecycleState"] = None,
+    ) -> List[Dict[str, Any]]:
+        """Search vNFS servers by semantic similarity to a search term.
+
+        Performs a vector-similarity search over vNFS server descriptions, then
+        filters by similarity threshold, manifest properties, and lifecycle state,
+        and returns matched names with similarity scores sorted by ``modified_at``
+        (most recent first).
+
+        Args:
+            search_term: Free-text query to match against vNFS descriptions.
+            max_number_of_results: Upper bound on candidates returned by the
+                vector index before threshold filtering.
+            similarity_threshold: Maximum allowed similarity score (lower is
+                more similar).
+            manifest_filter: Manifest property filter expression
+                (e.g. ``"tags:python"``, ``"state:approved"``).
+            lifecycle_state: Lifecycle state filter. Defaults to
+                ``LifecycleState.ANY`` when ``None`` is passed.
+
+        Returns:
+            List[Dict[str, Any]]: Matches, each ``{"filename": <name>, "similarity_score": <float>}``.
+
+        Raises:
+            RuntimeError: If the service was constructed without a
+                ``Description`` instance (search index unavailable).
+        """
+        from skillberry_store.modules.lifecycle import LifecycleState
+        from skillberry_store.fast_api.search_filters import apply_search_filters
+
+        if lifecycle_state is None:
+            lifecycle_state = LifecycleState.ANY
+        if not self.descriptions:
+            raise RuntimeError("vNFS server search is not available")
+
+        matched = self.descriptions.search_description(
+            search_term=search_term, k=max_number_of_results
+        )
+        filtered = [
+            m for m in matched if float(m["similarity_score"]) <= similarity_threshold
+        ]
+        candidates: List[Dict[str, Any]] = []
+        for m in filtered:
+            vnfs_uuid = m.get("filename") or m.get("name")
+            if not vnfs_uuid:
+                continue
+            try:
+                d = self.handler.read_dict(vnfs_uuid)
+                d["similarity_score"] = m.get("similarity_score", 0.0)
+                candidates.append(d)
+            except Exception as exc:
+                logger.warning(f"Could not load vnfs '{vnfs_uuid}': {exc}")
+        result_items = apply_search_filters(
+            candidates,
+            manifest_filter=manifest_filter,
+            lifecycle_state=lifecycle_state,
+        )
+        result_items.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
+        return [
+            {
+                "filename": s.get("name", ""),
+                "similarity_score": s.get("similarity_score", 0.0),
+            }
+            for s in result_items
+            if s.get("name")
+        ]
+
     def update(self, uuid_or_name: str, data: Dict[str, Any]) -> Dict[str, Any]:
         """Update an existing vNFS server's metadata and restart it.
         
@@ -249,6 +323,40 @@ class VnfsService:
             self.descriptions.write_description(data["uuid"], data["description"])
         logger.info(f"vNFS server '{new_name}' updated on port {server.port}")
         return data
+
+    def start(self, uuid_or_name: str) -> Tuple[Any, bool]:
+        """Start (or report already-running) a vNFS server runtime.
+
+        Resolves the vNFS server, checks whether its runtime is already up and
+        running; if so, returns the existing runtime with
+        ``already_running=True``. Otherwise adds the server via the runtime
+        manager.
+
+        Args:
+            uuid_or_name: vNFS server UUID or name to start.
+
+        Returns:
+            Tuple[Any, bool]: Pair of the runtime server object (whose ``.port``
+                callers may read) and a boolean that is ``True`` when the server
+                was already running and ``False`` when it was started by this
+                call.
+
+        Raises:
+            KeyError: If the vNFS server is not found.
+        """
+        vnfs_uuid = self._resolve_uuid(uuid_or_name)
+        vnfs_data = self.handler.read_dict(vnfs_uuid)
+        server_name = vnfs_data.get("name", "")
+        server_uuid = vnfs_data.get("uuid", "")
+        try:
+            existing = self.server_manager.get_server(server_name, server_uuid)
+            if existing and existing.running:
+                return existing, True
+        except Exception:
+            pass
+        server = self.server_manager.add_server(_to_ns(vnfs_data))
+        logger.info(f"vNFS server '{server_name}' started on port {server.port}")
+        return server, False
 
     def delete(self, uuid_or_name: str) -> None:
         """Delete a vNFS server and stop its runtime process.

--- a/src/skillberry_store/services/vnfs_service.py
+++ b/src/skillberry_store/services/vnfs_service.py
@@ -87,22 +87,32 @@ class VnfsService:
 
     def create(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """Create a new virtual NFS server and start it.
-        
+
         Creates a vNFS server entry, starts the runtime server process, and updates
         caches and indexes.
-        
+
         Args:
             data: vNFS server metadata dictionary (name, skill_uuid, port, protocol, etc.).
-            
+
         Returns:
             Dict[str, Any]: The created vNFS server data with UUID, timestamps, and assigned port.
-            
+
         Raises:
-            ValueError: If vNFS server with the same UUID already exists.
+            ObjectAlreadyExistsError: If vNFS server with the same UUID already exists.
+            PortConflictError: If the runtime manager rejects the port as
+                unavailable / already in use.
+            ValueError: For other server-creation failures.
         """
+        from skillberry_store.services.exceptions import (
+            ObjectAlreadyExistsError,
+            PortConflictError,
+        )
+
         data["uuid"] = generate_or_validate_uuid(data.get("uuid"))
         if self.handler.object_exists(data["uuid"]):
-            raise ValueError(f"vNFS server with UUID '{data['uuid']}' already exists")
+            raise ObjectAlreadyExistsError(
+                f"vNFS server with UUID '{data['uuid']}' already exists"
+            )
         now = datetime.now(timezone.utc).isoformat()
         data.setdefault("created_at", now)
         data["modified_at"] = now
@@ -110,7 +120,17 @@ class VnfsService:
             data["parent"] = self.handler.get_cache_parent_for_head(
                 data["uuid"], data["name"]
             )
-        server = self.server_manager.add_server(_to_ns(data))
+        try:
+            server = self.server_manager.add_server(_to_ns(data))
+        except ValueError as e:
+            msg = str(e).lower()
+            if "port" in msg and (
+                "not available" in msg
+                or "in use" in msg
+                or "already in use" in msg
+            ):
+                raise PortConflictError(str(e))
+            raise
         data["port"] = server.port
         self.handler.write_dict(data["uuid"], data)
         if data.get("name"):
@@ -165,14 +185,20 @@ class VnfsService:
             d["export_path"] = None
         return d
 
-    def list_all(self) -> Dict[str, Any]:
+    def list_all(self, skill_uuid: Optional[str] = None) -> Dict[str, Any]:
         """List all vNFS servers with runtime status.
-        
+
+        Args:
+            skill_uuid: When provided, restrict the result to servers whose
+                ``skill_uuid`` matches this value.
+
         Returns:
             Dict[str, Any]: Dictionary with 'virtual_nfs_servers' key containing server info
                            indexed by UUID, including runtime status and export paths.
         """
         items = self.handler.list_all_dicts()
+        if skill_uuid:
+            items = [i for i in items if i.get("skill_uuid") == skill_uuid]
         servers = []
         for item in items:
             try:

--- a/src/skillberry_store/tests/e2e/test_tools_api.py
+++ b/src/skillberry_store/tests/e2e/test_tools_api.py
@@ -333,7 +333,7 @@ async def test_add_tool_from_python_endpoint_update(run_sbs):
         )
         updated = update_response.json()
         assert updated.get("name") == "add_via_tools_add_update"
-        assert updated.get("message") == "Tool 'add_via_tools_add_update' created successfully."
+        assert updated.get("message") == "Tool 'add_via_tools_add_update' updated successfully."
         assert updated.get("module_name") == "add_via_tools_add_update.py"
         assert updated.get("uuid") is not None
         assert updated.get("uuid") == first_uuid    # When updating with add from python, UUID should be the same

--- a/src/skillberry_store/tests/services/test_skills_service.py
+++ b/src/skillberry_store/tests/services/test_skills_service.py
@@ -21,23 +21,26 @@ def _handler(exists=False):
 
 
 def test_create_generates_uuid():
-    svc = SkillsService(_handler(), tools_handler=MagicMock(), snippets_handler=MagicMock())
+    svc = SkillsService(_handler())
     result = svc.create({"name": "sk1"})
     assert "uuid" in result
 
 
 def test_create_raises_on_duplicate():
-    svc = SkillsService(_handler(exists=True), tools_handler=MagicMock(), snippets_handler=MagicMock())
+    svc = SkillsService(_handler(exists=True))
     with pytest.raises(ValueError, match="already exists"):
         svc.create({"name": "sk1"})
 
 
-def test_populate_objects_adds_tools_and_snippets():
-    tools_h = MagicMock()
-    tools_h.read_dicts.return_value = [{"uuid": "t1", "name": "tool1"}]
-    snippets_h = MagicMock()
-    snippets_h.read_dicts.return_value = []
-    svc = SkillsService(_handler(), tools_handler=tools_h, snippets_handler=snippets_h)
+def test_populate_objects_adds_tools_and_snippets(monkeypatch):
+    import skillberry_store.services.registry as registry
+    tools_svc = MagicMock()
+    tools_svc.get.return_value = {"uuid": "t1", "name": "tool1"}
+    monkeypatch.setattr(registry, "_initialized", True)
+    monkeypatch.setattr(
+        registry, "_services", {"tool": tools_svc, "snippet": MagicMock()}
+    )
+    svc = SkillsService(_handler())
     skill = {"name": "sk1", "tool_uuids": ["t1"], "snippet_uuids": []}
     result = svc.populate_objects(skill)
     assert result["tools"] == [{"uuid": "t1", "name": "tool1"}]
@@ -45,25 +48,18 @@ def test_populate_objects_adds_tools_and_snippets():
 
 
 def test_list_all_returns_sorted_and_populated():
-    th, sh = MagicMock(), MagicMock()
-    th.read_dicts.return_value = []
-    sh.read_dicts.return_value = []
-    svc = SkillsService(_handler(), tools_handler=th, snippets_handler=sh)
+    svc = SkillsService(_handler())
     result = svc.list_all()
     assert len(result) == 1
 
 
 def test_list_all_tolerates_skill_with_missing_tool():
-    th = MagicMock()
-    th.read_dicts.side_effect = RuntimeError("Skill 'get_time' references missing tools: 404: Tool not found")
-    sh = MagicMock()
-    sh.read_dicts.return_value = []
     h = _handler()
     h.list_all_dicts.return_value = [
         {"name": "get_time", "modified_at": "2024-02-01", "tool_uuids": ["missing-uuid"], "snippet_uuids": []},
         {"name": "other", "modified_at": "2024-01-01", "tool_uuids": [], "snippet_uuids": []},
     ]
-    svc = SkillsService(h, tools_handler=th, snippets_handler=sh)
+    svc = SkillsService(h)
     result = svc.list_all()
     assert len(result) == 2
     broken = next(r for r in result if r["name"] == "get_time")
@@ -73,7 +69,7 @@ def test_list_all_tolerates_skill_with_missing_tool():
 
 def test_delete_updates_cache_then_deletes():
     h = _handler()
-    svc = SkillsService(h, tools_handler=MagicMock(), snippets_handler=MagicMock())
+    svc = SkillsService(h)
     svc.delete("sk1")
     calls = [str(c) for c in h.mock_calls]
     assert any("update_cache" in c for c in calls)

--- a/src/skillberry_store/tests/services/test_vmcp_service.py
+++ b/src/skillberry_store/tests/services/test_vmcp_service.py
@@ -32,21 +32,20 @@ def _manager():
 
 
 def test_create_returns_dict_with_port():
-    skills_h = MagicMock()
-    svc = VmcpService(_handler(), _manager(), skills_handler=skills_h)
+    svc = VmcpService(_handler(), _manager())
     result = svc.create({"name": "vm1", "uuid": None}, env_id="")
     assert "uuid" in result
     assert result["port"] == 8100
 
 
 def test_create_raises_on_duplicate():
-    svc = VmcpService(_handler(exists=True), _manager(), skills_handler=MagicMock())
+    svc = VmcpService(_handler(exists=True), _manager())
     with pytest.raises(ValueError, match="already exists"):
         svc.create({"name": "vm1", "uuid": None}, env_id="")
 
 
 def test_list_includes_running_status():
-    svc = VmcpService(_handler(), _manager(), skills_handler=MagicMock())
+    svc = VmcpService(_handler(), _manager())
     result = svc.list_all()
     assert "virtual_mcp_servers" in result
 
@@ -54,7 +53,7 @@ def test_list_includes_running_status():
 def test_delete_stops_runtime_and_removes_persistent():
     h = _handler()
     mgr = _manager()
-    svc = VmcpService(h, mgr, skills_handler=MagicMock())
+    svc = VmcpService(h, mgr)
     svc.delete("vm1")
     mgr.remove_server.assert_called_once()
     h.delete_object.assert_called_once()

--- a/src/skillberry_store/tests/test_cascade_delete.py
+++ b/src/skillberry_store/tests/test_cascade_delete.py
@@ -1,31 +1,52 @@
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
+
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+
 from skillberry_store.fast_api.skills_api import register_skills_api
+from skillberry_store.services.skills_service import SkillsService
 
 
-def _make_client(skill, all_skills, mock_tools_svc, mock_snippets_svc):
-    """Register a test app with fully mocked services."""
+def _make_client(skill, all_skills):
+    """Wire a real SkillsService backed by a mocked ObjectHandler.
+
+    Cascade-delete logic now lives in SkillsService.delete; the only thing the
+    test layer needs to fake is the persistence handler. Sibling-service
+    lookups (``get_service("tool"|"snippet")``) are patched per request via
+    ``_patched_registry``.
+    """
     app = FastAPI()
-    svc = MagicMock()
-    svc.get.return_value = skill
-    svc.delete.return_value = None
-    svc.handler.list_all_dicts.return_value = all_skills
-    svc.tools_handler = MagicMock()
-    svc.snippets_handler = MagicMock()
-    with patch("skillberry_store.fast_api.skills_api.ToolsService", return_value=mock_tools_svc), \
-         patch("skillberry_store.fast_api.skills_api.SnippetsService", return_value=mock_snippets_svc):
-        register_skills_api(app, service=svc)
-    return TestClient(app), svc
+    handler = MagicMock()
+    handler.resolve_to_uuid_or_error.return_value = skill["uuid"]
+    handler.read_dict.return_value = skill
+    handler.list_all_dicts.return_value = all_skills
+    svc = SkillsService(handler, descriptions=None)
+    register_skills_api(app, service=svc)
+    return TestClient(app), handler
+
+
+@contextmanager
+def _patched_registry(mock_tools_svc, mock_snippets_svc):
+    """Route SkillsService.delete's ``get_service`` lookups to the mocks."""
+    def _fake_get_service(service_type: str):
+        return {"tool": mock_tools_svc, "snippet": mock_snippets_svc}[service_type]
+
+    with patch(
+        "skillberry_store.services.registry.get_service",
+        side_effect=_fake_get_service,
+    ):
+        yield
 
 
 def test_cascade_delete_exclusive_tool_is_deleted():
     skill = {"uuid": "sk1", "name": "myskill", "tool_uuids": ["t1"], "snippet_uuids": []}
     other = {"uuid": "sk2", "tool_uuids": [], "snippet_uuids": []}
     mock_tools, mock_snippets = MagicMock(), MagicMock()
-    client, _ = _make_client(skill, [skill, other], mock_tools, mock_snippets)
+    client, _ = _make_client(skill, [skill, other])
 
-    resp = client.delete("/skills/sk1?delete_tools=true")
+    with _patched_registry(mock_tools, mock_snippets):
+        resp = client.delete("/skills/sk1?delete_tools=true")
 
     assert resp.status_code == 200
     mock_tools.delete.assert_called_once_with("t1")
@@ -36,9 +57,10 @@ def test_cascade_delete_shared_tool_is_skipped():
     skill = {"uuid": "sk1", "name": "myskill", "tool_uuids": ["t1"], "snippet_uuids": []}
     other = {"uuid": "sk2", "tool_uuids": ["t1"], "snippet_uuids": []}
     mock_tools, mock_snippets = MagicMock(), MagicMock()
-    client, _ = _make_client(skill, [skill, other], mock_tools, mock_snippets)
+    client, _ = _make_client(skill, [skill, other])
 
-    resp = client.delete("/skills/sk1?delete_tools=true")
+    with _patched_registry(mock_tools, mock_snippets):
+        resp = client.delete("/skills/sk1?delete_tools=true")
 
     assert resp.status_code == 200
     mock_tools.delete.assert_not_called()
@@ -48,9 +70,10 @@ def test_cascade_delete_exclusive_snippet_is_deleted():
     skill = {"uuid": "sk1", "name": "myskill", "tool_uuids": [], "snippet_uuids": ["sn1"]}
     other = {"uuid": "sk2", "tool_uuids": [], "snippet_uuids": []}
     mock_tools, mock_snippets = MagicMock(), MagicMock()
-    client, _ = _make_client(skill, [skill, other], mock_tools, mock_snippets)
+    client, _ = _make_client(skill, [skill, other])
 
-    resp = client.delete("/skills/sk1?delete_snippets=true")
+    with _patched_registry(mock_tools, mock_snippets):
+        resp = client.delete("/skills/sk1?delete_snippets=true")
 
     assert resp.status_code == 200
     mock_snippets.delete.assert_called_once_with("sn1")
@@ -60,9 +83,10 @@ def test_cascade_delete_exclusive_snippet_is_deleted():
 def test_no_flags_skips_cascade():
     skill = {"uuid": "sk1", "name": "myskill", "tool_uuids": ["t1"], "snippet_uuids": ["sn1"]}
     mock_tools, mock_snippets = MagicMock(), MagicMock()
-    client, _ = _make_client(skill, [skill], mock_tools, mock_snippets)
+    client, _ = _make_client(skill, [skill])
 
-    resp = client.delete("/skills/sk1")
+    with _patched_registry(mock_tools, mock_snippets):
+        resp = client.delete("/skills/sk1")
 
     assert resp.status_code == 200
     mock_tools.delete.assert_not_called()
@@ -73,9 +97,10 @@ def test_response_includes_deleted_lists():
     skill = {"uuid": "sk1", "name": "myskill", "tool_uuids": ["t1"], "snippet_uuids": ["sn1"]}
     other = {"uuid": "sk2", "tool_uuids": [], "snippet_uuids": []}
     mock_tools, mock_snippets = MagicMock(), MagicMock()
-    client, _ = _make_client(skill, [skill, other], mock_tools, mock_snippets)
+    client, _ = _make_client(skill, [skill, other])
 
-    resp = client.delete("/skills/sk1?delete_tools=true&delete_snippets=true")
+    with _patched_registry(mock_tools, mock_snippets):
+        resp = client.delete("/skills/sk1?delete_tools=true&delete_snippets=true")
 
     assert resp.status_code == 200
     data = resp.json()
@@ -87,9 +112,10 @@ def test_cascade_tool_failure_does_not_abort_skill_delete():
     skill = {"uuid": "sk1", "name": "myskill", "tool_uuids": ["t1"], "snippet_uuids": []}
     mock_tools, mock_snippets = MagicMock(), MagicMock()
     mock_tools.delete.side_effect = Exception("storage error")
-    client, svc = _make_client(skill, [skill], mock_tools, mock_snippets)
+    client, handler = _make_client(skill, [skill])
 
-    resp = client.delete("/skills/sk1?delete_tools=true")
+    with _patched_registry(mock_tools, mock_snippets):
+        resp = client.delete("/skills/sk1?delete_tools=true")
 
     assert resp.status_code == 200
-    svc.delete.assert_called_once()  # skill still deleted
+    handler.delete_object.assert_called_once_with("sk1")  # skill still deleted

--- a/src/skillberry_store/tests/test_vmcp_api_filter.py
+++ b/src/skillberry_store/tests/test_vmcp_api_filter.py
@@ -6,10 +6,15 @@ from skillberry_store.fast_api.vmcp_api import register_vmcp_api
 def _app(servers):
     app = FastAPI()
     svc = MagicMock()
-    svc.list_all.return_value = {
-        "virtual_mcp_servers": {s["uuid"]: s for s in servers}
-    }
-    register_vmcp_api(app, sts_url="http://test", service=svc)
+
+    def _list_all(skill_uuid=None):
+        matches = servers if skill_uuid is None else [
+            s for s in servers if s.get("skill_uuid") == skill_uuid
+        ]
+        return {"virtual_mcp_servers": {s["uuid"]: s for s in matches}}
+
+    svc.list_all.side_effect = _list_all
+    register_vmcp_api(app, service=svc)
     return TestClient(app)
 
 SERVERS = [

--- a/src/skillberry_store/tests/test_vnfs_api_filter.py
+++ b/src/skillberry_store/tests/test_vnfs_api_filter.py
@@ -7,8 +7,15 @@ from skillberry_store.fast_api.vnfs_api import register_vnfs_api
 def _app(servers):
     app = FastAPI()
     svc = MagicMock()
-    svc.list_all.return_value = {"virtual_nfs_servers": {s["uuid"]: s for s in servers}}
-    register_vnfs_api(app, sts_url="http://test", service=svc)
+
+    def _list_all(skill_uuid=None):
+        matches = servers if skill_uuid is None else [
+            s for s in servers if s.get("skill_uuid") == skill_uuid
+        ]
+        return {"virtual_nfs_servers": {s["uuid"]: s for s in matches}}
+
+    svc.list_all.side_effect = _list_all
+    register_vnfs_api(app, service=svc)
     return TestClient(app)
 
 


### PR DESCRIPTION
It's a bit hefty PR, but the concept is simple: clean separation of API and logic layers in all object services (object = skill, tool, snippet etc) to prepare for future enhancments such as concurrency and multi-tenancy.
- **Refactor - separating API and logic layers**
- **2nd round of moving code from API to logic - items that Claude missed**
- **Moved observability to logic layer**
- **Fixed failing tests**
