### PR TITLE
fix: use Imgur-hosted GIF so README demo auto-plays on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This service implements a smart skills repository for agentic workflows. Manage, execute, and organize your skills, tools and snippets with powerful search and lifecycle management.
 
-![Skillberry Store demo](docs/images/skillberry-demo.gif)
+![Skillberry Store demo](https://i.imgur.com/ribHQNH.gif)
 
 ▶ [Watch full highlights video](https://github.com/user-attachments/assets/eab2f9f1-1196-4858-b4ca-72d6c664d9f3)
 


### PR DESCRIPTION
## Problem

GitHub converts all GIF files hosted under `github.com` or `user-attachments` into `<video>` elements. These do not auto-play in Chrome due to browser autoplay policies, requiring a manual click.

## Fix

Replace the GitHub-hosted GIF URL with the same GIF uploaded to Imgur CDN:
```
https://i.imgur.com/ribHQNH.gif
```
GitHub renders external image URLs as true `<img>` tags, which auto-play and loop immediately on page load.

Closes #260

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>