### PR TITLE
fix: python:3.11 via GHCR mirror + bump runspace-agent to 0.4.2

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,7 +23,11 @@ jobs:
           source .venv/bin/activate
           pip install --upgrade pip
     - name: pull-docker-image
-      run: docker pull public.ecr.aws/docker/library/python:3.11
+      # Mirror of python:3.11 hosted on the org GHCR. AWS ECR Public throttles
+      # anonymous pulls per source IP; GitHub's shared runner IPs blow through
+      # that limit and fail this step with "toomanyrequests". GHCR public pulls
+      # are not subject to that anonymous limit. See issue #249.
+      run: docker pull ghcr.io/skillberry-ai/python:3.11
     - name: run-make
       run: |
           source .venv/bin/activate

--- a/plugins/skillberry-plugin-anthropic-skill-generator/pyproject.toml
+++ b/plugins/skillberry-plugin-anthropic-skill-generator/pyproject.toml
@@ -9,7 +9,7 @@ description = "Skillberry Store plugin for generating Anthropic skills from desc
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "runspace-agent[claude]==0.4.1",
+    "runspace-agent[claude]==0.4.2",
 ]
 
 [project.entry-points."skillberry_store.plugins"]

--- a/plugins/skillberry-plugin-ask-runspace/pyproject.toml
+++ b/plugins/skillberry-plugin-ask-runspace/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "fastapi>=0.115.12",
     "httpx>=0.28.1",
     "pydantic>=2.11.1",
-    "runspace-agent[claude]==0.4.1",
+    "runspace-agent[claude]==0.4.2",
 ]
 
 [project.entry-points."skillberry_store.plugins"]

--- a/plugins/skillberry-plugin-skill-optimizer/pyproject.toml
+++ b/plugins/skillberry-plugin-skill-optimizer/pyproject.toml
@@ -9,7 +9,7 @@ description = "Optimize existing Skillberry skills using RunSpace-powered Claude
 requires-python = ">=3.10"
 dependencies = [
     "skillberry-store",
-    "runspace-agent[claude]==0.4.1",
+    "runspace-agent[claude]==0.4.2",
 ]
 
 [project.optional-dependencies]

--- a/src/skillberry_store/modules/file_executor.py
+++ b/src/skillberry_store/modules/file_executor.py
@@ -583,7 +583,7 @@ class FileExecutor:
 
             # Create and run a container to execute the Python file
             container = self.client.containers.run(
-                "public.ecr.aws/docker/library/python:3.11",  # Python 3.11 image from AWS (no rate limits)
+                "ghcr.io/skillberry-ai/python:3.11",  # org GHCR mirror of python:3.11 (avoids ECR Public anonymous rate limits — see issue #249)
                 command=f"/bin/bash -c '{command}'",
                 volumes={temp_file_path: {"bind": f"/tmp/function.py", "mode": "ro"}},
                 remove=True,


### PR DESCRIPTION
## Problem
The `pull_request` CI job intermittently fails at the `pull-docker-image` step with:

```
docker pull public.ecr.aws/docker/library/python:3.11
Error response from daemon: toomanyrequests: Rate exceeded
```

AWS ECR Public throttles **anonymous** pulls per source IP; GitHub Actions shared runner IPs regularly exceed that limit. The same image is pulled at runtime by the `file_executor` sandbox.

## Changes
1. **Fix the rate limit** — pull `python:3.11` from the org GHCR mirror `ghcr.io/skillberry-ai/python:3.11` (public, multi-arch) in both places:
   - `.github/workflows/pull_request.yml` (CI pre-pull)
   - `src/skillberry_store/modules/file_executor.py` (runtime sandbox)

   GHCR public pulls aren't subject to the ECR anonymous per-IP limit, and CI authenticates with the built-in `GITHUB_TOKEN`.

2. **Bump `runspace-agent[claude]` 0.4.1 → 0.4.2** across the three dependent plugins (ask-runspace, anthropic-skill-generator, skill-optimizer). 0.4.2 builds its container image `FROM` a published multi-arch GHCR base instead of installing Python/Node/the Claude Code CLI on every build.

Closes #249