### PR TITLE
chore: bump runspace-agent[claude] to 0.4.2

### DIFF
--- a/plugins/skillberry-plugin-anthropic-skill-generator/pyproject.toml
+++ b/plugins/skillberry-plugin-anthropic-skill-generator/pyproject.toml
@@ -9,7 +9,7 @@ description = "Skillberry Store plugin for generating Anthropic skills from desc
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "runspace-agent[claude]==0.4.1",
+    "runspace-agent[claude]==0.4.2",
 ]
 
 [project.entry-points."skillberry_store.plugins"]

--- a/plugins/skillberry-plugin-ask-runspace/pyproject.toml
+++ b/plugins/skillberry-plugin-ask-runspace/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "fastapi>=0.115.12",
     "httpx>=0.28.1",
     "pydantic>=2.11.1",
-    "runspace-agent[claude]==0.4.1",
+    "runspace-agent[claude]==0.4.2",
 ]
 
 [project.entry-points."skillberry_store.plugins"]

--- a/plugins/skillberry-plugin-skill-optimizer/pyproject.toml
+++ b/plugins/skillberry-plugin-skill-optimizer/pyproject.toml
@@ -9,7 +9,7 @@ description = "Optimize existing Skillberry skills using RunSpace-powered Claude
 requires-python = ">=3.10"
 dependencies = [
     "skillberry-store",
-    "runspace-agent[claude]==0.4.1",
+    "runspace-agent[claude]==0.4.2",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## What
Bump `runspace-agent[claude]` from `0.4.1` → `0.4.2` in all three plugins that depend on it:
- `plugins/skillberry-plugin-ask-runspace`
- `plugins/skillberry-plugin-anthropic-skill-generator`
- `plugins/skillberry-plugin-skill-optimizer`

## Why
runspace-agent 0.4.2 builds its container image `FROM` a published multi-arch base image (`ghcr.io/skillberry-ai/runspace-agent-base`) rather than installing Python + Node.js + the Claude Code CLI on every build. Result: `runspace-srv` image builds are fast and no longer hit apt/npm registry rate limits. No public API changes in runspace-agent.

## Note
This branch is cut from `main`, which does not yet include the CI mirror fix in #267. Its CI `pull-docker-image` step may still hit the ECR `toomanyrequests` flake until #267 merges — that's unrelated to this dependency bump.
