### PR TITLE
fix: add permissions blocks to all Bob workflow callers

### DIFF
--- a/.github/workflows/fix-issues-with-bob.yml
+++ b/.github/workflows/fix-issues-with-bob.yml
@@ -13,5 +13,13 @@ jobs:
   call-fix-issues:
     uses: skillberry-ai/skillberry-common/.github/workflows/fix-issues-with-bob.yml@main
     secrets: inherit
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: write
+      deployments: write
+      statuses: write
+      actions: write
+      checks: read
 
 # Made with Bob

--- a/.github/workflows/fix-pr-reviews-with-bob.yml
+++ b/.github/workflows/fix-pr-reviews-with-bob.yml
@@ -16,5 +16,13 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     uses: skillberry-ai/skillberry-common/.github/workflows/fix-pr-reviews-with-bob.yml@main
     secrets: inherit
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: write
+      deployments: write
+      statuses: write
+      actions: write
+      checks: read
 
 # Made with Bob

--- a/.github/workflows/label-new-issues.yml
+++ b/.github/workflows/label-new-issues.yml
@@ -19,5 +19,8 @@ jobs:
   call-label-issues:
     uses: skillberry-ai/skillberry-common/.github/workflows/label-new-issues.yml@main
     secrets: inherit
+    permissions:
+      issues: write
+      contents: read
 
 # Made with Bob

--- a/.github/workflows/label-new-prs.yml
+++ b/.github/workflows/label-new-prs.yml
@@ -21,5 +21,9 @@ jobs:
   call-label-prs:
     uses: skillberry-ai/skillberry-common/.github/workflows/label-new-prs.yml@main
     secrets: inherit
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: read
 
 # Made with Bob

--- a/.github/workflows/test-pr-with-bob.yml
+++ b/.github/workflows/test-pr-with-bob.yml
@@ -11,13 +11,6 @@ on:
     workflows: ["Test PR with Bob - Trigger"]
     types: [completed]
 
-permissions:
-  actions: read
-  checks: read
-  contents: read
-  issues: write
-  pull-requests: write
-
 concurrency:
   group: test-pr-with-bob-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
@@ -26,5 +19,11 @@ jobs:
   call-test-pr:
     uses: skillberry-ai/skillberry-common/.github/workflows/test-pr-with-bob.yml@main
     secrets: inherit
+    permissions:
+      actions: read
+      checks: read
+      contents: read
+      issues: write
+      pull-requests: write
 
 # Made with Bob


### PR DESCRIPTION
## Problem

All 5 Bob automation caller workflows were missing `permissions:` blocks, causing GitHub to reject them with:

> The nested job is requesting '...', but is only allowed '...: none'

GitHub's `workflow_call` permission model requires the **caller** to explicitly grant any permissions the reusable workflow's jobs need.

## Changes

Added `permissions:` at the job level for all 5 callers:

| Workflow | Permissions granted |
|---|---|
| `label-new-issues` | `issues: write`, `contents: read` |
| `label-new-prs` | `issues: write`, `pull-requests: write`, `contents: read` |
| `fix-issues-with-bob` | `issues/pull-requests/contents/deployments/statuses/actions: write`, `checks: read` |
| `fix-pr-reviews-with-bob` | `issues/pull-requests/contents/deployments/statuses/actions: write`, `checks: read` |
| `test-pr-with-bob` | `actions/checks/contents: read`, `issues/pull-requests: write` |

Also moved `test-pr-with-bob` permissions from workflow level → job level (required for `workflow_call` callers).

Made with Bob