### PR TITLE
feat(ask-runspace): add 'dream' preset for trajectory-driven skill optimization

### DIFF
--- a/plugins/skillberry-plugin-ask-runspace/src/skillberry_plugin_ask_runspace/presets.py
+++ b/plugins/skillberry-plugin-ask-runspace/src/skillberry_plugin_ask_runspace/presets.py
@@ -20,6 +20,19 @@ PRESETS: List[Dict[str, Union[str, List[str], Dict[str, str]]]] = [
      # Optimization benefits from the multi-agent team workflow, so turn on the
      # experimental agent-teams flag for this preset (merged into the agent env).
      "env": {"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"}},
+    {"id": "dream", "label": "Dream — improve an agent's skills from its trajectories",
+     "prompt": ("Run a skill 'dreaming' pass. You are given an agent's recent execution "
+                "trajectories (inlined in this request, or fetched via an attached "
+                "trajectories MCP). Study where the agent struggled, repeated work, or hit "
+                "errors, and identify which of its skills were involved. Then improve those "
+                "skills IN PLACE via the skillberry-store MCP: update each skill under its "
+                "existing name so the store chains the previous version as its parent "
+                "(version history is preserved) — do not create *_optimized duplicates. "
+                "Record a short rationale per change, and make NO change to a skill when the "
+                "trajectories don't justify one."),
+     "skills": [],
+     # Dreaming reviews multiple trajectories and skills; the agent-teams workflow helps.
+     "env": {"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"}},
     {"id": "skill", "label": "Create a skill that…",
      "prompt": "Create a new skill that <describe it>, following the Anthropic skill format (a SKILL.md plus supporting files).",
      "skills": ["https://github.com/anthropics/skills/tree/main/skills/skill-creator"],

--- a/plugins/skillberry-plugin-ask-runspace/src/skillberry_plugin_ask_runspace/presets.py
+++ b/plugins/skillberry-plugin-ask-runspace/src/skillberry_plugin_ask_runspace/presets.py
@@ -24,12 +24,17 @@ PRESETS: List[Dict[str, Union[str, List[str], Dict[str, str]]]] = [
      "prompt": ("Run a skill 'dreaming' pass. You are given an agent's recent execution "
                 "trajectories (inlined in this request, or fetched via an attached "
                 "trajectories MCP). Study where the agent struggled, repeated work, or hit "
-                "errors, and identify which of its skills were involved. Then improve those "
-                "skills IN PLACE via the skillberry-store MCP: update each skill under its "
-                "existing name so the store chains the previous version as its parent "
-                "(version history is preserved) — do not create *_optimized duplicates. "
-                "Record a short rationale per change, and make NO change to a skill when the "
-                "trajectories don't justify one."),
+                "errors, and identify which of its skills were involved. Then improve them "
+                "via the skillberry-store MCP.\n"
+                "Store objects are IMMUTABLE and versioned like git: revising a skill under "
+                "its EXISTING NAME produces a NEW VERSION with a new UUID whose parent is the "
+                "previous version — the latest is resolved by name, and a specific version by "
+                "UUID (stability, traceability, lineage). Keep the same name so it stays the "
+                "same logical skill; do NOT invent a new name (e.g. no *_optimized).\n"
+                "Do whatever the trajectories call for: revise an involved skill (new version, "
+                "same name), and/or add supporting snippets or a genuinely new skill if that "
+                "is the right fix. Record a short rationale per change, and make NO change "
+                "when the trajectories don't justify one."),
      "skills": [],
      # Dreaming reviews multiple trajectories and skills; the agent-teams workflow helps.
      "env": {"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"}},

--- a/plugins/skillberry-plugin-ask-runspace/src/skillberry_plugin_ask_runspace/presets.py
+++ b/plugins/skillberry-plugin-ask-runspace/src/skillberry_plugin_ask_runspace/presets.py
@@ -21,20 +21,16 @@ PRESETS: List[Dict[str, Union[str, List[str], Dict[str, str]]]] = [
      # experimental agent-teams flag for this preset (merged into the agent env).
      "env": {"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"}},
     {"id": "dream", "label": "Dream — improve an agent's skills from its trajectories",
-     "prompt": ("Run a skill 'dreaming' pass. You are given an agent's recent execution "
-                "trajectories (inlined in this request, or fetched via an attached "
-                "trajectories MCP). Study where the agent struggled, repeated work, or hit "
-                "errors, and identify which of its skills were involved. Then improve them "
-                "via the skillberry-store MCP.\n"
-                "Store objects are IMMUTABLE and versioned like git: revising a skill under "
-                "its EXISTING NAME produces a NEW VERSION with a new UUID whose parent is the "
-                "previous version — the latest is resolved by name, and a specific version by "
-                "UUID (stability, traceability, lineage). Keep the same name so it stays the "
-                "same logical skill; do NOT invent a new name (e.g. no *_optimized).\n"
-                "Do whatever the trajectories call for: revise an involved skill (new version, "
-                "same name), and/or add supporting snippets or a genuinely new skill if that "
-                "is the right fix. Record a short rationale per change, and make NO change "
-                "when the trajectories don't justify one."),
+     "prompt": ("Run a skill 'dreaming' pass on the agent trajectories in this request. Find "
+                "where the agent struggled, repeated work, or errored, and which skills were "
+                "involved, then improve them via the skillberry-store MCP.\n"
+                "Behave AS IF the store never allows in-place updates: a skill name always "
+                "resolves to its latest version (like git). So to change a skill, always "
+                "create a NEW skill (new UUID) with the SAME name — never edit in place, never "
+                "rename (no *_optimized).\n"
+                "Do what the trajectories call for: new version of an involved skill, and/or a "
+                "supporting snippet or genuinely new skill. Note a short rationale per change; "
+                "make none if nothing warrants it."),
      "skills": [],
      # Dreaming reviews multiple trajectories and skills; the agent-teams workflow helps.
      "env": {"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"}},

--- a/plugins/skillberry-plugin-ask-runspace/tests/test_ask_runspace_plugin.py
+++ b/plugins/skillberry-plugin-ask-runspace/tests/test_ask_runspace_plugin.py
@@ -20,12 +20,21 @@ def test_preset_skills_prefilled():
 
 def test_optimize_preset_enables_agent_teams():
     # Every preset carries an env block so the x-prefill always seeds agent_env;
-    # only the optimize preset turns on the experimental agent-teams flag.
+    # the optimize and dream presets turn on the experimental agent-teams flag.
     by_id = {p["id"]: p for p in PRESETS}
     for p in PRESETS:
         assert isinstance(p["env"], dict)
     assert by_id["optimize"]["env"] == {"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"}
     assert by_id["custom"]["env"] == {}
+
+
+def test_dream_preset_optimizes_skills_in_place():
+    by_id = {p["id"]: p for p in PRESETS}
+    assert "dream" in by_id
+    dream = by_id["dream"]
+    assert "IN PLACE" in dream["prompt"]
+    assert "_optimized" in dream["prompt"]  # instructs against *_optimized duplicates
+    assert dream["env"] == {"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"}
 
 
 def test_generic_custom_preset_is_empty():

--- a/plugins/skillberry-plugin-ask-runspace/tests/test_ask_runspace_plugin.py
+++ b/plugins/skillberry-plugin-ask-runspace/tests/test_ask_runspace_plugin.py
@@ -28,12 +28,15 @@ def test_optimize_preset_enables_agent_teams():
     assert by_id["custom"]["env"] == {}
 
 
-def test_dream_preset_optimizes_skills_in_place():
+def test_dream_preset_versions_skills_immutably():
     by_id = {p["id"]: p for p in PRESETS}
     assert "dream" in by_id
     dream = by_id["dream"]
-    assert "IN PLACE" in dream["prompt"]
-    assert "_optimized" in dream["prompt"]  # instructs against *_optimized duplicates
+    # Immutable, git-like versioning: new version under the same name, no invented names.
+    assert "IMMUTABLE" in dream["prompt"]
+    assert "NEW VERSION" in dream["prompt"]
+    assert "same name" in dream["prompt"]
+    assert "_optimized" in dream["prompt"]  # explicitly forbids inventing a new name
     assert dream["env"] == {"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"}
 
 

--- a/plugins/skillberry-plugin-ask-runspace/tests/test_ask_runspace_plugin.py
+++ b/plugins/skillberry-plugin-ask-runspace/tests/test_ask_runspace_plugin.py
@@ -32,11 +32,14 @@ def test_dream_preset_versions_skills_immutably():
     by_id = {p["id"]: p for p in PRESETS}
     assert "dream" in by_id
     dream = by_id["dream"]
-    # Immutable, git-like versioning: new version under the same name, no invented names.
-    assert "IMMUTABLE" in dream["prompt"]
-    assert "NEW VERSION" in dream["prompt"]
-    assert "same name" in dream["prompt"]
-    assert "_optimized" in dream["prompt"]  # explicitly forbids inventing a new name
+    # Git-like versioning framing: never in-place, name resolves to latest, new
+    # UUID under the same name, no invented names.
+    prompt = dream["prompt"]
+    assert "in-place" in prompt
+    assert "latest version" in prompt
+    assert "new UUID" in prompt
+    assert "SAME name" in prompt
+    assert "_optimized" in prompt  # explicitly forbids inventing a new name
     assert dream["env"] == {"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"}
 
 


### PR DESCRIPTION
# feat(ask-runspace): add a "dream" preset for trajectory-driven skill optimization

Closes #281

## What
Adds a first-class `dream` preset to `ask-runspace`, alongside `optimize`. Given
an agent's recent execution trajectories (inlined, or via an attached trajectories
MCP), the RunSpace agent identifies the skills involved and improves them **in
place** via the store control MCP — updating each under its existing name so the
store chains the previous version as `parent` (version history preserved; no
`*_optimized` duplicates). Enables the experimental agent-teams workflow, like
`optimize`.

This is what Kagenti's skill **"dreaming"** flow calls into (see the kagenti
`feat/skill-dreaming` PR).

## Notes
No behavioral change to the plugin — the request text is still the whole prompt
and the store control MCP is already pre-wired. This adds a starter template and
a test. Comment on the existing agent-teams test updated to reflect that both
`optimize` and `dream` enable the flag.

## Tests
`plugins/skillberry-plugin-ask-runspace/tests/test_ask_runspace_plugin.py` — added
`test_dream_preset_optimizes_skills_in_place`; full file passes (28 tests).

Assisted-By: Claude Code

## Demo (full UI walkthrough, live)

📹 **Full working demo on a real cluster:** https://drive.google.com/file/d/1x5LTkZ-_pxrb0ulSKDwWchnOJF4Ccxu9/view

Real Kagenti UI end-to-end: converse with the weather agent → click the **💤 Dream** button on the agent page → Kagenti reads the agent's new spans from **Phoenix** and sends them to a **RunSpace** session (Claude Code on the in-cluster store, via IBM LiteLLM) → the `weather-reporting` skill is **rewritten in place** (thin → transport fallback, session reuse, graceful errors, JSON interpretation, 'not a forecast' caveat + attached snippets) → **auto-sync** to `team1`. No human edits.


