### PR TITLE
Preset As Label

### DIFF
--- a/docs/gui-performance-strategies.md
+++ b/docs/gui-performance-strategies.md
@@ -1,0 +1,399 @@
+# Strategies for Scaling the Skillberry-Store GUI to Large Object Counts
+
+Author: analysis snapshot, 2026-07-01
+Scope: `src/skillberry_store/ui` (React + PatternFly + TanStack Query + Vite) and
+its collaborating FastAPI list endpoints under `src/skillberry_store/fast_api`.
+
+---
+
+## 1. What is actually slow — root causes
+
+The symptoms (long page load, "kill this tab?" from the browser, worst on the
+Snippets page) are the product of **four independent bottlenecks that compound**:
+
+### 1.1 Server returns the full object on every list call
+
+- [`GET /snippets/`](../src/skillberry_store/fast_api/snippets_api.py#L82) →
+  [`SnippetsService.list_all`](../src/skillberry_store/services/snippets_service.py#L200) →
+  `handler.list_all_dicts()` returns **every field of every snippet, including
+  `content`** — which is the entire snippet body (may be kilobytes to hundreds of
+  kilobytes per row). With 5K+ snippets this can easily exceed 50–200 MB of
+  JSON on the wire.
+- [`GET /skills/`](../src/skillberry_store/fast_api/skills_api.py#L85) →
+  [`SkillsService.list_all`](../src/skillberry_store/services/skills_service.py#L290)
+  runs [`populate_objects`](../src/skillberry_store/services/skills_service.py#L146)
+  **for every skill**, which resolves every `tool_uuid` and `snippet_uuid`
+  reference into a **full inlined object** (including snippet `content` again).
+  For 972 skills that reference ~2K tools and thousands of snippets, this
+  materializes a huge cross-product payload — the same snippet body may appear
+  inlined in many skills.
+- [`GET /tools/`](../src/skillberry_store/fast_api/tools_api.py) also returns the
+  full tool manifest (params/returns/dependencies) for every row.
+
+### 1.2 Client fetches ALL rows on every page mount
+
+Every list page uses `useQuery({queryKey: ['<type>'], queryFn: <api>.list })`
+with no `limit`/`offset` and a 30-second `staleTime`
+(`ui/src/main.tsx:18`). The Skills page additionally pulls **all tools and all
+snippets in parallel** so the "Create Skill" modal has data ready
+([SkillsPage.tsx:103-112](../src/skillberry_store/ui/src/pages/SkillsPage.tsx#L103-L112)) —
+even when the user only wants to browse skills.
+
+### 1.3 Every row is rendered synchronously (no virtualization)
+
+The PatternFly `Table` in [`SnippetsPage.tsx`](../src/skillberry_store/ui/src/pages/SnippetsPage.tsx#L457-L542)
+and [`SkillListView.tsx`](../src/skillberry_store/ui/src/components/SkillListView.tsx#L27-L110)
+maps directly over the filtered array. React reconciles ~5K rows × 6–7 cells
+each = ~30K–40K DOM nodes on Snippets alone. Filtering, sorting, and typing
+into the search box each rerun `useMemo` over the full array and rebuild the
+whole table.
+
+### 1.4 Background poll fully invalidates the massive queries
+
+[`useChangesMonitor`](../src/skillberry_store/ui/src/hooks/useChangesMonitor.ts)
+polls `/api/changes` every 5 s and, on any change bump, invalidates
+`skills`/`tools`/`snippets` queries — triggering the whole 1.1 + 1.2 loop again.
+During an import (which is when the store is most likely to have many items),
+this fires continuously.
+
+**Cost model of the current design** (order-of-magnitude, for 972 skills / 5K
+snippets / 300 tools):
+
+| Cost                       | Snippets page | Skills page                                     |
+| -------------------------- | ------------- | ----------------------------------------------- |
+| Backend serialization work | 5K JSON dumps | 972 × avg(fanout ≈ 8) ≈ 7–8K nested dumps       |
+| Wire payload               | 50–200 MB     | 20–100 MB (often larger due to inlined content) |
+| Browser parse + memo       | 5K objects    | 972 objects + inlined tools+snippets            |
+| DOM nodes rendered         | ~35K          | ~7K (list view) / ~5K (card view)               |
+
+Any single one of these is enough to cause the browser to warn.
+
+---
+
+## 2. Strategies
+
+Six strategies below, from smallest change to largest. They are **not mutually
+exclusive** — several combine well (Section 4).
+
+### Strategy A — Server-side "list field selection" (slim payload)
+
+**Idea:** the list endpoints keep their signatures but drop fields that the
+list view never displays. New optional query param `?fields=list` (or a
+dedicated `/snippets/summary`, `/skills/summary`, `/tools/summary`) returns
+only what the table columns actually use.
+
+For snippets, the list view uses only:
+`uuid, name, description, state, content_type, version, tags, modified_at`
+— **not** `content` or `extra`.
+
+For skills, the list view uses:
+`uuid, name, description, state, tags, version, tools.length, snippets.length,
+modified_at`. We don't need to inline tool/snippet **objects**; a count
+(`tool_count`, `snippet_count`) is enough for cards and rows. Detail page
+still calls `GET /skills/{id}` and gets the fully populated view.
+
+For tools, the list view uses:
+`uuid, name, description, state, tags, module_name, version, modified_at` —
+**not** `params`, `returns`, `dependencies`.
+
+**Server work:**
+
+- Add a field-selection helper in `object_handler.list_all_dicts` (or in the
+  three services) that pops heavy fields when `fields=list`.
+- In `SkillsService.list_all`, skip `populate_objects()` and instead compute
+  counts from `tool_uuids`/`snippet_uuids` lengths.
+
+**Client work:**
+
+- Change `snippetsApi.list`, `skillsApi.list`, `toolsApi.list` to hit the slim
+  variant. Add a `SnippetSummary`/`SkillSummary` TS type. Detail-page fetches
+  are unchanged.
+
+**Expected impact:** wire payload for Snippets falls from ~100 MB to ~2 MB
+(a 50–100× reduction — most of the bytes are `content`). Skills payload
+similarly. JSON parse and React memo pass drop proportionally. The 5K-row
+render itself is still slow (see B).
+
+| Aspect                | Value                                                                                                          |
+| --------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Files changed         | ~5 backend (services + one shared helper), 3 client (`api.ts`, `types/index.ts`, references in the list pages) |
+| Breaking API changes  | None if additive (`?fields=list`); mildly breaking if you change the default shape                             |
+| Backend CPU / memory  | ↓↓ (no populate_objects, no `content` serialization)                                                           |
+| Wire / browser memory | ↓↓↓                                                                                                            |
+| DOM render cost       | Unchanged                                                                                                      |
+| Risk                  | Low — additive, per-endpoint                                                                                   |
+| Effort                | 0.5–1 day                                                                                                      |
+
+---
+
+### Strategy B — Client-side row virtualization
+
+**Idea:** render only the ~30 rows currently in the viewport. Add
+`@tanstack/react-virtual` (a peer of the already-used TanStack Query) or
+`react-window`. This is a pure client change.
+
+**Where to apply:**
+
+- `SnippetsPage.tsx` — wrap the `<Tbody>` render in a virtualizer.
+- `SkillListView.tsx` — same.
+- `SkillCardView.tsx` — grid virtualization is slightly trickier but supported
+  by both libraries; card row height is uniform.
+- `ToolsPage.tsx` — same as snippets.
+
+PatternFly's `Table` supports virtualization via its `VirtualizedTable`
+component or via a custom `Tbody`. `@tanstack/react-virtual` is the smaller,
+more flexible choice.
+
+**Expected impact:** DOM node count for a page becomes O(viewport), independent
+of dataset size. Sort/filter still re-runs across the whole in-memory array —
+but the array is small compared to the DOM, so this cost is minor if we also
+`useMemo`+`useDeferredValue` the search term. Does **not** help network cost or
+memory footprint of the underlying data.
+
+| Aspect                | Value                                                                     |
+| --------------------- | ------------------------------------------------------------------------- |
+| Files changed         | 4 UI files, plus 1 dep addition                                           |
+| Breaking API changes  | None                                                                      |
+| Backend CPU / memory  | Unchanged                                                                 |
+| Wire / browser memory | Unchanged                                                                 |
+| DOM render cost       | ↓↓↓                                                                       |
+| Risk                  | Low; testable in isolation                                                |
+| Effort                | 0.5 day for list views; 1 day if you also want card-grid virtualization   |
+| Caveat                | Standalone this alone will _not_ fix Snippets — the payload is still huge |
+
+---
+
+### Strategy C — Server-side pagination + server-side search/sort/filter
+
+**Idea:** the list endpoints stop returning the whole world. Instead,
+`GET /snippets/?limit=50&offset=0&search=foo&tags=python&sort=modified_at:desc`
+returns `{ items: [...], total: 4972, next_offset: 50 }`. The client keeps a
+page in state and fetches page-at-a-time.
+
+**Server work:**
+
+- Extend list endpoints with `limit`, `offset` (or `cursor`), `sort`, and a
+  simple substring `search` (over name/description), plus `tags`/`namespace`
+  filters. The `DictCache` layer already has everything in memory, so filtering
+  is O(N) but N is bounded — fast for 5K items.
+- Move the sort/filter code currently in `filteredSnippets` `useMemo` blocks
+  server-side. Semantic-search already exists on the server; that path stays as
+  is.
+
+**Client work:**
+
+- Replace `useQuery` with `useInfiniteQuery` (from TanStack Query) or a
+  paginated `useQuery` keyed by `(search, tags, page)`.
+- Debounce the search input (200–300 ms) before firing the query. Filters/sort
+  update the query key rather than a `useMemo`.
+- Combine with virtualization (B) if you want a single scrolling list; combine
+  with a classic pager if you want fixed page-size UX.
+
+**Expected impact:** first paint returns 50 items = O(KB) instead of MB.
+Backend CPU is bounded per page. Combined with B, memory is bounded too.
+
+| Aspect                | Value                                                                                                                                            |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Files changed         | 3–4 backend (3 endpoints + service filter helper), 4–6 client (`api.ts`, `types`, 3 list pages, possibly a shared `useListQuery` hook)           |
+| Breaking API changes  | The list endpoints change shape (`items+total` rather than a bare array). The CLI and any external consumer are affected — mitigate via `?legacy=1` or a version flag |
+| Backend CPU / memory  | ↓↓ per request (bounded page size)                                                                                                               |
+| Wire / browser memory | ↓↓↓                                                                                                                                              |
+| DOM render cost       | ↓↓ (small page); ↓↓↓ combined with virtualization                                                                                                |
+| Risk                  | Medium — touches API contract, CLI, and every list page                                                                                          |
+| Effort                | 1.5–3 days                                                                                                                                       |
+| Nice property         | Client-side tag/namespace enumeration (`allTags` `useMemo`) also has to move server-side or become a `/facets` endpoint — a nice cleanup         |
+
+---
+
+### Strategy D — Streaming list (NDJSON or SSE) with progressive render
+
+**Idea:** the server keeps a "return everything" contract but streams objects
+one line at a time (NDJSON) or as SSE events. The client processes each chunk
+as it arrives and appends to the table.
+
+**Server work:**
+
+- Add a streaming endpoint: `GET /snippets/stream` returning
+  `application/x-ndjson`. Use a FastAPI `StreamingResponse` that pulls from
+  `handler.iter_dicts()` (already exists — see `object_handler.py:1028`) and
+  writes `json.dumps(item) + "\n"` per row. No buffering.
+- Or reuse SSE — same idea, more overhead per event.
+
+**Client work:**
+
+- Use `fetch` + `ReadableStream` + a line-splitting reader. Push rows into
+  React state in batches (e.g., every 100 rows or every 50 ms via
+  `requestAnimationFrame`) to avoid render thrash.
+- Cancel the stream on unmount.
+
+**Expected impact:** first row visible almost immediately; the browser is
+never blocked on a giant JSON parse. The **total** amount of data transferred
+is still huge unless you also apply field selection (A) — so this is a UX-only win
+if used alone.
+
+| Aspect                | Value                                                                                                                     |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Files changed         | 3 backend endpoints + 1 helper; 1 client streaming helper + 3 list pages                                                  |
+| Breaking API changes  | Additive (new endpoint)                                                                                                   |
+| Backend CPU / memory  | ↓ (server no longer buffers a giant string); still serializes all rows                                                    |
+| Wire / browser memory | Unchanged unless combined with A                                                                                          |
+| DOM render cost       | Unchanged unless combined with B                                                                                          |
+| Risk                  | Medium — streaming edge cases (backpressure, timeouts, mid-stream error); TanStack Query doesn't cache streams as neatly  |
+| Effort                | 1–2 days plus test hardening                                                                                              |
+| Best for              | Very large, always-growing datasets when you _want_ the client to hold all items (e.g. for global client-side search)     |
+
+---
+
+### Strategy E — Search-first UX ("no upfront list")
+
+**Idea:** the default view is empty (or a small "recent" slice, ~20 items)
+plus a prominent search box. Users only load results when they type or apply a
+filter. This flips the assumption that the user needs to see all items at once
+— for 5000 snippets, no human scrolls through them.
+
+**Server work:**
+
+- Add a lightweight `GET /snippets/recent?limit=20` (or reuse `limit`/`offset`
+  from Strategy C).
+- Search endpoint is already there (`/search/snippets`) and is what powers
+  "semantic" mode today — extend it to accept a plain-text mode server-side.
+
+**Client work:**
+
+- Reshape the list page: on mount, show "Type to search — 4972 snippets in
+  store" with the recent 20. Full list is opt-in behind a "Show all" button
+  that in turn kicks a paginated fetch.
+- Reuse the existing `SearchBox` component; make "text" mode issue a
+  server-side query instead of filtering an in-memory array.
+
+**Expected impact:** first paint is instant. This is arguably the best UX for
+5K+ items because scrolling through them is not a real workflow anyway. Cost
+lives with the search endpoint, which is already indexed.
+
+| Aspect                | Value                                                                                                                             |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| Files changed         | 3 list pages (heavier), 1 backend if extending search; combines naturally with A/C                                                |
+| Breaking API changes  | None if additive                                                                                                                  |
+| Backend CPU / memory  | ↓↓↓                                                                                                                               |
+| Wire / browser memory | ↓↓↓                                                                                                                               |
+| DOM render cost       | ↓↓↓                                                                                                                               |
+| Risk                  | Product/UX risk: "I want to see everything" workflows (export-all, bulk-tag) need explicit affordances                            |
+| Effort                | 1–1.5 days                                                                                                                        |
+| Caveat                | Bulk operations (export/delete "all matching") need a new "operate on entire result set, not just visible page" API, e.g. `/snippets/bulk-delete?filter=...`  |
+
+---
+
+### Strategy F — Client-side micro-optimizations
+
+**Idea:** keep the API as is, but reduce the CPU cost of the current React
+tree. This is the smallest possible change and buys the least.
+
+Concrete moves:
+
+- Wrap `filteredSnippets` search term with `useDeferredValue` so typing stays
+  responsive.
+- Memoize row components (`React.memo(SnippetRow)`).
+- Precompute `allTags` / `allNamespaces` once, indexed on the server via a
+  `/facets` endpoint (nice to have anyway).
+- Bump `staleTime` for the big lists to `5 * 60 * 1000` and tighten the
+  `useChangesMonitor` invalidation to only invalidate the type that actually
+  changed (already possible if `/api/changes` returns per-type counts — check
+  before assuming).
+- Turn off `useChangesMonitor` polling while a page is fetching (avoid
+  invalidation thrash during imports).
+
+**Expected impact:** typing feels faster, background refetches are less
+disruptive, but a 5000-row initial render still stalls the main thread.
+
+| Aspect                | Value                                                        |
+| --------------------- | ------------------------------------------------------------ |
+| Files changed         | 3–5 UI files                                                 |
+| Breaking API changes  | None                                                         |
+| Backend CPU / memory  | Unchanged                                                    |
+| Wire / browser memory | Unchanged                                                    |
+| DOM render cost       | ↓ (marginal)                                                 |
+| Risk                  | Very low                                                     |
+| Effort                | 0.5 day                                                      |
+| Note                  | Best treated as _polish_ once one of A/B/C/E is in place     |
+
+---
+
+## 3. Side-by-side comparison
+
+Legend: ↓ small win, ↓↓ big win, ↓↓↓ dominant win, — no change.
+
+| Strategy                    | Wire payload | Backend CPU | Browser CPU / mem | DOM render | Breaking API? | Effort  | Composes with     |
+| --------------------------- | ------------ | ----------- | ----------------- | ---------- | ------------- | ------- | ----------------- |
+| A. Slim list field selection| ↓↓↓          | ↓↓          | ↓↓                | —          | Additive      | 0.5–1 d | B, C, D, E, F     |
+| B. Row virtualization       | —            | —           | ↓↓                | ↓↓↓        | No            | 0.5–1 d | A, C, D, E, F     |
+| C. Server pagination+search | ↓↓↓          | ↓↓          | ↓↓↓               | ↓↓         | Yes (major)   | 1.5–3 d | A, B, E, F        |
+| D. NDJSON/SSE streaming     | —            | ↓           | Time-to-first-row ↓↓↓ | —      | Additive      | 1–2 d   | A, B              |
+| E. Search-first UX          | ↓↓↓          | ↓↓↓         | ↓↓↓               | ↓↓↓        | Additive      | 1–1.5 d | A, C, F           |
+| F. Client micro-fixes       | —            | —           | ↓                 | ↓          | No            | 0.5 d   | Any               |
+
+### Notes on breakage
+
+- The service, CLI, and MCP layer all consume the same FastAPI endpoints. The
+  CLI's `list-*` commands assume a bare array (see `openapi_extra={"x-cli-name":
+  "list-*"}` decorators). Any strategy that changes the response envelope
+  (C) needs to be gated behind either a new endpoint (`/snippets/page`) or a
+  `?legacy=1` fallback, or the CLI has to be updated in lockstep.
+- Strategies A, D, E can all be strictly additive (new fields / new endpoints)
+  with zero blast radius outside the browser.
+
+---
+
+## 4. Recommended combination
+
+For 5K+ objects, no single strategy is optimal on its own:
+
+- **A alone** cuts payload by ~50× but still renders 5K DOM rows.
+- **B alone** does not fix the Snippets 100 MB fetch — the browser stalls
+  before the first row.
+- **C alone** works, but requires an API contract change and a rewrite of the
+  in-page filtering/sorting/tag-enumeration logic.
+- **E alone** is the cheapest end-state UX win, but breaks the "show me
+  everything, let me multi-select and bulk-delete" flow unless bulk operations
+  get their own filter-based API.
+
+The **highest-value, lowest-risk staged plan** is:
+
+1. **A (slim field selection)** — 1 day. Ship first. This alone will make the
+   Snippets page usable at 5K items (small payload, fast parse). Pure additive,
+   no client contract change beyond types.
+2. **B (row virtualization)** — 1 day. Ship after A. Fixes the residual
+   render cost so scrolling is smooth even at 10K rows.
+3. **F (micro-fixes)** — half a day in parallel with B.
+4. **E (search-first UX)** — optional next step. Reframes the Snippets page
+   from "browse table" to "find and act". A separate discussion — it changes
+   product feel, not just performance.
+5. **C (server pagination)** — hold off until the store crosses ~50K items or
+   until we want to eliminate client-side sort/filter entirely. A + B is
+   sufficient at 5K–20K scale.
+
+**Not recommended right now:** D (streaming). It is the cleverest option but
+adds moving parts (backpressure, mid-stream error handling, cache invalidation
+semantics) for a benefit that A+B already delivers.
+
+---
+
+## 5. Concrete first PR (if you agree)
+
+- Add `?fields=list` (or a `/summary` sibling) to
+  [`GET /snippets/`](../src/skillberry_store/fast_api/snippets_api.py#L82),
+  [`GET /skills/`](../src/skillberry_store/fast_api/skills_api.py#L85),
+  [`GET /tools/`](../src/skillberry_store/fast_api/tools_api.py). Server
+  field selection = pop `content`, `params`, `returns`, `dependencies`, `extra`, and
+  skip `populate_objects` in `SkillsService.list_all` (send `tool_count` /
+  `snippet_count` instead).
+- Add a `SnippetSummary` / `SkillSummary` / `ToolSummary` type alias in
+  [`ui/src/types/index.ts`](../src/skillberry_store/ui/src/types/index.ts).
+- Point `snippetsApi.list`, `skillsApi.list`, `toolsApi.list` at the new mode
+  in [`ui/src/services/api.ts`](../src/skillberry_store/ui/src/services/api.ts).
+- Update `filteredSnippets` / `SkillCardView` / `SkillListView` to use the
+  slim type; detail pages stay on the full object type.
+- Add a `useChangesMonitor` guard so an in-flight query is not immediately
+  invalidated by a change tick.
+
+This is the smallest coherent change that will make the browser stop asking
+whether to kill the tab.

--- a/plugins/skillberry-plugin-provenance/tests/test_github_source.py
+++ b/plugins/skillberry-plugin-provenance/tests/test_github_source.py
@@ -162,21 +162,6 @@ def test_confidence_medium_for_copyleft_reputable():
 
 
 def test_assess_confidence_new_anonymous_repo_is_low():
-<<<<<<< HEAD
-    # Dates are computed relative to now() so the repo is always genuinely
-    # "new" (< 30 days, the medium-confidence threshold) whenever CI runs —
-    # hardcoded dates here would become "old" as wall-clock time advances.
-    now = datetime.now(timezone.utc)
-
-    def _iso(days_ago: int) -> str:
-        return (now - timedelta(days=days_ago)).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-    fresh = {
-        "stargazers_count": 0,
-        "owner": {"login": "newbie", "type": "User"},
-        "created_at": _iso(5),  # a few days old → below the 30-day threshold
-        "pushed_at": _iso(3),
-=======
     # Use relative timestamps so the "fresh repo" premise stays true as
     # real time advances — previously the hardcoded 2026-06-10 date drifted
     # past the >=30-day MEDIUM threshold.
@@ -185,7 +170,6 @@ def test_assess_confidence_new_anonymous_repo_is_low():
         "owner": {"login": "newbie", "type": "User"},
         "created_at": _iso_days_ago(5),
         "pushed_at": _iso_days_ago(2),
->>>>>>> 6c701b5 (test: repair two pre-existing test-ordering / time bugs)
     }
     bg = build_background(
         {"owner": "newbie", "repo": "z", "ref": "main", "path": ""},

--- a/plugins/skillberry-plugin-provenance/tests/test_github_source.py
+++ b/plugins/skillberry-plugin-provenance/tests/test_github_source.py
@@ -11,6 +11,13 @@ from skillberry_plugin_provenance.sources.base import (
     LICENSE_PERMISSIVE,
     license_category,
 )
+
+
+def _iso_days_ago(days: int) -> str:
+    """ISO-8601 UTC timestamp for ``now - days`` (matches GitHub's ``Z`` suffix)."""
+    return (datetime.now(timezone.utc) - timedelta(days=days)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
 from skillberry_plugin_provenance.sources.github_source import (
     GitHubSource,
     assess_confidence,
@@ -155,6 +162,7 @@ def test_confidence_medium_for_copyleft_reputable():
 
 
 def test_assess_confidence_new_anonymous_repo_is_low():
+<<<<<<< HEAD
     # Dates are computed relative to now() so the repo is always genuinely
     # "new" (< 30 days, the medium-confidence threshold) whenever CI runs —
     # hardcoded dates here would become "old" as wall-clock time advances.
@@ -168,6 +176,16 @@ def test_assess_confidence_new_anonymous_repo_is_low():
         "owner": {"login": "newbie", "type": "User"},
         "created_at": _iso(5),  # a few days old → below the 30-day threshold
         "pushed_at": _iso(3),
+=======
+    # Use relative timestamps so the "fresh repo" premise stays true as
+    # real time advances — previously the hardcoded 2026-06-10 date drifted
+    # past the >=30-day MEDIUM threshold.
+    fresh = {
+        "stargazers_count": 0,
+        "owner": {"login": "newbie", "type": "User"},
+        "created_at": _iso_days_ago(5),
+        "pushed_at": _iso_days_ago(2),
+>>>>>>> 6c701b5 (test: repair two pre-existing test-ordering / time bugs)
     }
     bg = build_background(
         {"owner": "newbie", "repo": "z", "ref": "main", "path": ""},

--- a/src/skillberry_store/fast_api/server.py
+++ b/src/skillberry_store/fast_api/server.py
@@ -48,7 +48,7 @@ class SBSettings(BaseSettings):
         "INFO", validation_alias="UVICORN_LOG_LEVEL"
     )
     observability: bool = Field(True, validation_alias="OBSERVABILITY")
-    sbs_vdb: str = Field("faiss", env="SBS_VDB")
+    sbs_vdb: str = Field("faiss", validation_alias="SBS_VDB")
 
     @property
     def display_host(self) -> str:

--- a/src/skillberry_store/fast_api/skills_api.py
+++ b/src/skillberry_store/fast_api/skills_api.py
@@ -95,7 +95,7 @@ def register_skills_api(
         fields: Optional[str] = Query(
             None,
             description=(
-                "Field projection. Omit for full objects with populated "
+                "Field selection. Omit for full objects with populated "
                 "'tools'/'snippets' arrays (default). Use 'list' for the "
                 "slim list-view preset (skips populate_objects; caller uses "
                 "tool_uuids/snippet_uuids arrays), 'full' for the full "
@@ -108,12 +108,12 @@ def register_skills_api(
         Retrieves metadata for all skills currently stored in the system.
 
         Args:
-            fields: Optional projection spec (see query-param description).
+            fields: Optional field-selection spec (see query-param description).
 
         Returns:
             list: List of dictionaries, each containing skill metadata
                 (name, uuid, description, tool_uuids, snippet_uuids,
-                etc. — subset when ``fields`` narrows the projection).
+                etc. — subset when ``fields`` narrows the field selection).
 
         Raises:
             HTTPException: 400 if ``fields`` is invalid, 500 if listing fails.
@@ -256,9 +256,9 @@ def register_skills_api(
         fields: Optional[str] = Query(
             None,
             description=(
-                "Optional projection over each matched skill. Omit for the "
-                "legacy '{filename, similarity_score}' shape. Use 'list' for "
-                "the slim list-view preset merged with 'similarity_score', "
+                "Optional field selection over each matched skill. Omit for "
+                "the legacy '{filename, similarity_score}' shape. Use 'list' "
+                "for the slim list-view preset merged with 'similarity_score', "
                 "'full' for the raw skill dict (tool_uuids/snippet_uuids not "
                 "populated into inlined objects), or a comma-separated "
                 "allowlist of field names."
@@ -275,12 +275,12 @@ def register_skills_api(
             similarity_threshold: Threshold to be used.
             manifest_filter: Manifest properties to filter (e.g., "tags:python", "state:approved").
             lifecycle_state: State to filter by (e.g., LifecycleState.APPROVED).
-            fields: Optional projection spec (see query-param description).
+            fields: Optional field-selection spec (see query-param description).
 
         Returns:
             list: Matches. Legacy ``{"filename", "similarity_score"}`` shape
-                when ``fields`` is omitted; otherwise projected skill dicts
-                with ``similarity_score`` merged in.
+                when ``fields`` is omitted; otherwise field-selected skill
+                dicts with ``similarity_score`` merged in.
         """
         try:
             return service.search(

--- a/src/skillberry_store/fast_api/skills_api.py
+++ b/src/skillberry_store/fast_api/skills_api.py
@@ -253,6 +253,17 @@ def register_skills_api(
         similarity_threshold: float = 1,
         manifest_filter: str = ".",
         lifecycle_state: LifecycleState = LifecycleState.ANY,
+        fields: Optional[str] = Query(
+            None,
+            description=(
+                "Optional projection over each matched skill. Omit for the "
+                "legacy '{filename, similarity_score}' shape. Use 'list' for "
+                "the slim list-view preset merged with 'similarity_score', "
+                "'full' for the raw skill dict (tool_uuids/snippet_uuids not "
+                "populated into inlined objects), or a comma-separated "
+                "allowlist of field names."
+            ),
+        ),
     ):
         """Return a list of skills that are similar to the given search term.
 
@@ -264,9 +275,12 @@ def register_skills_api(
             similarity_threshold: Threshold to be used.
             manifest_filter: Manifest properties to filter (e.g., "tags:python", "state:approved").
             lifecycle_state: State to filter by (e.g., LifecycleState.APPROVED).
+            fields: Optional projection spec (see query-param description).
 
         Returns:
-            list: A list of matched skill names and similarity scores.
+            list: Matches. Legacy ``{"filename", "similarity_score"}`` shape
+                when ``fields`` is omitted; otherwise projected skill dicts
+                with ``similarity_score`` merged in.
         """
         try:
             return service.search(
@@ -275,7 +289,10 @@ def register_skills_api(
                 similarity_threshold=similarity_threshold,
                 manifest_filter=manifest_filter,
                 lifecycle_state=lifecycle_state,
+                fields=fields,
             )
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
         except RuntimeError as e:
             raise HTTPException(status_code=503, detail=str(e))
         except Exception as e:

--- a/src/skillberry_store/fast_api/skills_api.py
+++ b/src/skillberry_store/fast_api/skills_api.py
@@ -93,15 +93,15 @@ def register_skills_api(
     )
     def list_skills(
         fields: Optional[str] = Query(
-            None,
+            "narrow",
             description=(
-                "Field selection. Omit or 'full' for the complete object "
-                "with the '_populate' mechanism running — 'tools' and "
-                "'snippets' are inlined from tool_uuids/snippet_uuids "
-                "(default). 'narrow' returns the minimal set required "
-                "by the UI listing page (no inlining; use "
-                "tool_uuids/snippet_uuids). 'wide' returns every "
-                "persisted manifest field (no inlining). Or supply a "
+                "Field selection. Omit or 'narrow' for the minimal set "
+                "required by the UI listing page — no inlining; use "
+                "tool_uuids/snippet_uuids (default). 'wide' returns "
+                "every persisted manifest field (no inlining). 'full' "
+                "returns the complete object with the '_populate' "
+                "mechanism running — 'tools' and 'snippets' are "
+                "inlined from tool_uuids/snippet_uuids. Or supply a "
                 "comma-separated allowlist of field names (include "
                 "'_populate' to trigger inlining)."
             ),
@@ -258,14 +258,14 @@ def register_skills_api(
         manifest_filter: str = ".",
         lifecycle_state: LifecycleState = LifecycleState.ANY,
         fields: Optional[str] = Query(
-            None,
+            "narrow",
             description=(
                 "Field selection over each match. Same grammar as the "
-                "list endpoint. Default (omit / 'full') triggers "
-                "'_populate' — 'tools' and 'snippets' are inlined. "
-                "'narrow' returns the UI listing set (no inlining). "
-                "'wide' returns every persisted manifest field (no "
-                "inlining). CSV allowlist also supported. Each match is "
+                "list endpoint. Default (omit / 'narrow') returns the "
+                "UI listing set (no inlining). 'wide' returns every "
+                "persisted manifest field (no inlining). 'full' "
+                "triggers '_populate' — 'tools' and 'snippets' are "
+                "inlined. CSV allowlist also supported. Each match is "
                 "a field-selected skill dict with 'similarity_score' "
                 "merged in."
             ),

--- a/src/skillberry_store/fast_api/skills_api.py
+++ b/src/skillberry_store/fast_api/skills_api.py
@@ -95,11 +95,15 @@ def register_skills_api(
         fields: Optional[str] = Query(
             None,
             description=(
-                "Field selection. Omit for full objects with populated "
-                "'tools'/'snippets' arrays (default). Use 'list' for the "
-                "slim list-view preset (skips populate_objects; caller uses "
-                "tool_uuids/snippet_uuids arrays), 'full' for the full "
-                "object, or a comma-separated allowlist of field names."
+                "Field selection. Omit or 'full' for the complete object "
+                "with the '_populate' mechanism running — 'tools' and "
+                "'snippets' are inlined from tool_uuids/snippet_uuids "
+                "(default). 'narrow' returns the minimal set required "
+                "by the UI listing page (no inlining; use "
+                "tool_uuids/snippet_uuids). 'wide' returns every "
+                "persisted manifest field (no inlining). Or supply a "
+                "comma-separated allowlist of field names (include "
+                "'_populate' to trigger inlining)."
             ),
         ),
     ):
@@ -256,12 +260,14 @@ def register_skills_api(
         fields: Optional[str] = Query(
             None,
             description=(
-                "Optional field selection over each matched skill. Omit for "
-                "the legacy '{filename, similarity_score}' shape. Use 'list' "
-                "for the slim list-view preset merged with 'similarity_score', "
-                "'full' for the raw skill dict (tool_uuids/snippet_uuids not "
-                "populated into inlined objects), or a comma-separated "
-                "allowlist of field names."
+                "Field selection over each match. Same grammar as the "
+                "list endpoint. Default (omit / 'full') triggers "
+                "'_populate' — 'tools' and 'snippets' are inlined. "
+                "'narrow' returns the UI listing set (no inlining). "
+                "'wide' returns every persisted manifest field (no "
+                "inlining). CSV allowlist also supported. Each match is "
+                "a field-selected skill dict with 'similarity_score' "
+                "merged in."
             ),
         ),
     ):
@@ -278,9 +284,8 @@ def register_skills_api(
             fields: Optional field-selection spec (see query-param description).
 
         Returns:
-            list: Matches. Legacy ``{"filename", "similarity_score"}`` shape
-                when ``fields`` is omitted; otherwise field-selected skill
-                dicts with ``similarity_score`` merged in.
+            list: Field-selected skill dicts with ``similarity_score``
+                merged in.
         """
         try:
             return service.search(

--- a/src/skillberry_store/fast_api/skills_api.py
+++ b/src/skillberry_store/fast_api/skills_api.py
@@ -91,22 +91,37 @@ def register_skills_api(
         tags=[tags],
         openapi_extra={"x-cli-name": "list-skills", "x-mcp-tool": True},
     )
-    def list_skills():
+    def list_skills(
+        fields: Optional[str] = Query(
+            None,
+            description=(
+                "Field projection. Omit for full objects with populated "
+                "'tools'/'snippets' arrays (default). Use 'list' for the "
+                "slim list-view preset (skips populate_objects; caller uses "
+                "tool_uuids/snippet_uuids arrays), 'full' for the full "
+                "object, or a comma-separated allowlist of field names."
+            ),
+        ),
+    ):
         """List all skills in the store.
 
         Retrieves metadata for all skills currently stored in the system.
 
         Args:
-            None.
+            fields: Optional projection spec (see query-param description).
 
         Returns:
-            list: List of dictionaries, each containing skill metadata (name, uuid, description, tool_uuids, snippet_uuids, etc.).
+            list: List of dictionaries, each containing skill metadata
+                (name, uuid, description, tool_uuids, snippet_uuids,
+                etc. — subset when ``fields`` narrows the projection).
 
         Raises:
-            HTTPException: 500 if listing fails.
+            HTTPException: 400 if ``fields`` is invalid, 500 if listing fails.
         """
         try:
-            return service.list_all()
+            return service.list_all(fields=fields)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
         except Exception as e:
             raise HTTPException(
                 status_code=500, detail=f"Error listing skills: {str(e)}"

--- a/src/skillberry_store/fast_api/snippets_api.py
+++ b/src/skillberry_store/fast_api/snippets_api.py
@@ -92,7 +92,7 @@ def register_snippets_api(
         fields: Optional[str] = Query(
             None,
             description=(
-                "Field projection. Omit for full objects (default). Use "
+                "Field selection. Omit for full objects (default). Use "
                 "'list' for the slim list-view preset (drops 'content'), "
                 "'full' for the full object, or a comma-separated allowlist "
                 "of field names."
@@ -104,12 +104,12 @@ def register_snippets_api(
         Retrieves metadata for all snippets currently stored in the system.
 
         Args:
-            fields: Optional projection spec (see query-param description).
+            fields: Optional field-selection spec (see query-param description).
 
         Returns:
             list: List of dictionaries, each containing snippet metadata
                 (name, uuid, description, content, etc. — subset when
-                ``fields`` narrows the projection).
+                ``fields`` narrows the field selection).
 
         Raises:
             HTTPException: 400 if ``fields`` is invalid, 500 if listing fails.
@@ -233,11 +233,11 @@ def register_snippets_api(
         fields: Optional[str] = Query(
             None,
             description=(
-                "Optional projection over each matched snippet. Omit for the "
-                "legacy '{filename, similarity_score}' shape. Use 'list' for "
-                "the slim list-view preset merged with 'similarity_score', "
-                "'full' for the full snippet, or a comma-separated allowlist "
-                "of field names."
+                "Optional field selection over each matched snippet. Omit "
+                "for the legacy '{filename, similarity_score}' shape. Use "
+                "'list' for the slim list-view preset merged with "
+                "'similarity_score', 'full' for the full snippet, or a "
+                "comma-separated allowlist of field names."
             ),
         ),
     ):
@@ -252,12 +252,12 @@ def register_snippets_api(
             similarity_threshold: Maximum similarity score threshold (default: 1, lower is more similar).
             manifest_filter: Manifest properties to filter (e.g., "tags:python", "state:approved").
             lifecycle_state: State to filter by (e.g., LifecycleState.APPROVED).
-            fields: Optional projection spec (see query-param description).
+            fields: Optional field-selection spec (see query-param description).
 
         Returns:
             list: Matches. Legacy ``{"filename", "similarity_score"}`` shape
-                when ``fields`` is omitted; otherwise projected snippet dicts
-                with ``similarity_score`` merged in.
+                when ``fields`` is omitted; otherwise field-selected snippet
+                dicts with ``similarity_score`` merged in.
 
         Raises:
             HTTPException: 400 if ``fields`` is invalid, 503 if search is not

--- a/src/skillberry_store/fast_api/snippets_api.py
+++ b/src/skillberry_store/fast_api/snippets_api.py
@@ -90,13 +90,14 @@ def register_snippets_api(
     )
     def list_snippets(
         fields: Optional[str] = Query(
-            None,
+            "narrow",
             description=(
-                "Field selection. Omit or 'full' for the complete object "
-                "(default). 'narrow' returns the minimal set required by "
-                "the UI listing page for this type. 'wide' returns every "
-                "persisted manifest field. Or supply a comma-separated "
-                "allowlist of field names."
+                "Field selection. Omit or 'narrow' for the minimal set "
+                "required by the UI listing page for this type "
+                "(default). 'wide' returns every persisted manifest "
+                "field. 'full' returns the complete object, including "
+                "flag fields that trigger bundling mechanisms. Or "
+                "supply a comma-separated allowlist of field names."
             ),
         ),
     ):
@@ -232,14 +233,14 @@ def register_snippets_api(
         manifest_filter: str = ".",
         lifecycle_state: LifecycleState = LifecycleState.ANY,
         fields: Optional[str] = Query(
-            None,
+            "narrow",
             description=(
                 "Field selection over each match. Same grammar as the "
-                "list endpoint (omit or 'full' for the complete object; "
-                "'narrow' for the UI listing set; 'wide' for every "
-                "persisted manifest field; CSV allowlist). Each match "
-                "is a field-selected snippet dict with 'similarity_score' "
-                "merged in."
+                "list endpoint (omit or 'narrow' for the UI listing "
+                "set — default; 'wide' for every persisted manifest "
+                "field; 'full' for the complete object; CSV allowlist). "
+                "Each match is a field-selected snippet dict with "
+                "'similarity_score' merged in."
             ),
         ),
     ):

--- a/src/skillberry_store/fast_api/snippets_api.py
+++ b/src/skillberry_store/fast_api/snippets_api.py
@@ -88,22 +88,36 @@ def register_snippets_api(
         tags=[tags],
         openapi_extra={"x-cli-name": "list-snippets", "x-mcp-tool": True},
     )
-    def list_snippets():
+    def list_snippets(
+        fields: Optional[str] = Query(
+            None,
+            description=(
+                "Field projection. Omit for full objects (default). Use "
+                "'list' for the slim list-view preset (drops 'content'), "
+                "'full' for the full object, or a comma-separated allowlist "
+                "of field names."
+            ),
+        ),
+    ):
         """List all snippets in the store.
 
         Retrieves metadata for all snippets currently stored in the system.
 
         Args:
-            None.
+            fields: Optional projection spec (see query-param description).
 
         Returns:
-            list: List of dictionaries, each containing snippet metadata (name, uuid, description, content, etc.).
+            list: List of dictionaries, each containing snippet metadata
+                (name, uuid, description, content, etc. — subset when
+                ``fields`` narrows the projection).
 
         Raises:
-            HTTPException: 500 if listing fails.
+            HTTPException: 400 if ``fields`` is invalid, 500 if listing fails.
         """
         try:
-            return service.list_all()
+            return service.list_all(fields=fields)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
         except Exception as e:
             raise HTTPException(
                 status_code=500, detail=f"Error listing snippets: {str(e)}"

--- a/src/skillberry_store/fast_api/snippets_api.py
+++ b/src/skillberry_store/fast_api/snippets_api.py
@@ -92,10 +92,11 @@ def register_snippets_api(
         fields: Optional[str] = Query(
             None,
             description=(
-                "Field selection. Omit for full objects (default). Use "
-                "'list' for the slim list-view preset (drops 'content'), "
-                "'full' for the full object, or a comma-separated allowlist "
-                "of field names."
+                "Field selection. Omit or 'full' for the complete object "
+                "(default). 'narrow' returns the minimal set required by "
+                "the UI listing page for this type. 'wide' returns every "
+                "persisted manifest field. Or supply a comma-separated "
+                "allowlist of field names."
             ),
         ),
     ):
@@ -233,11 +234,12 @@ def register_snippets_api(
         fields: Optional[str] = Query(
             None,
             description=(
-                "Optional field selection over each matched snippet. Omit "
-                "for the legacy '{filename, similarity_score}' shape. Use "
-                "'list' for the slim list-view preset merged with "
-                "'similarity_score', 'full' for the full snippet, or a "
-                "comma-separated allowlist of field names."
+                "Field selection over each match. Same grammar as the "
+                "list endpoint (omit or 'full' for the complete object; "
+                "'narrow' for the UI listing set; 'wide' for every "
+                "persisted manifest field; CSV allowlist). Each match "
+                "is a field-selected snippet dict with 'similarity_score' "
+                "merged in."
             ),
         ),
     ):
@@ -255,9 +257,8 @@ def register_snippets_api(
             fields: Optional field-selection spec (see query-param description).
 
         Returns:
-            list: Matches. Legacy ``{"filename", "similarity_score"}`` shape
-                when ``fields`` is omitted; otherwise field-selected snippet
-                dicts with ``similarity_score`` merged in.
+            list: Field-selected snippet dicts with ``similarity_score``
+                merged in.
 
         Raises:
             HTTPException: 400 if ``fields`` is invalid, 503 if search is not

--- a/src/skillberry_store/fast_api/snippets_api.py
+++ b/src/skillberry_store/fast_api/snippets_api.py
@@ -230,6 +230,16 @@ def register_snippets_api(
         similarity_threshold: float = 1,
         manifest_filter: str = ".",
         lifecycle_state: LifecycleState = LifecycleState.ANY,
+        fields: Optional[str] = Query(
+            None,
+            description=(
+                "Optional projection over each matched snippet. Omit for the "
+                "legacy '{filename, similarity_score}' shape. Use 'list' for "
+                "the slim list-view preset merged with 'similarity_score', "
+                "'full' for the full snippet, or a comma-separated allowlist "
+                "of field names."
+            ),
+        ),
     ):
         """Search for snippets using semantic similarity.
 
@@ -242,12 +252,16 @@ def register_snippets_api(
             similarity_threshold: Maximum similarity score threshold (default: 1, lower is more similar).
             manifest_filter: Manifest properties to filter (e.g., "tags:python", "state:approved").
             lifecycle_state: State to filter by (e.g., LifecycleState.APPROVED).
+            fields: Optional projection spec (see query-param description).
 
         Returns:
-            list: List of matched snippet names and similarity scores.
+            list: Matches. Legacy ``{"filename", "similarity_score"}`` shape
+                when ``fields`` is omitted; otherwise projected snippet dicts
+                with ``similarity_score`` merged in.
 
         Raises:
-            HTTPException: 503 if search is not available, 500 for other errors.
+            HTTPException: 400 if ``fields`` is invalid, 503 if search is not
+                available, 500 for other errors.
         """
         try:
             return service.search(
@@ -256,7 +270,10 @@ def register_snippets_api(
                 similarity_threshold=similarity_threshold,
                 manifest_filter=manifest_filter,
                 lifecycle_state=lifecycle_state,
+                fields=fields,
             )
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
         except RuntimeError as e:
             raise HTTPException(status_code=503, detail=str(e))
         except Exception as e:

--- a/src/skillberry_store/fast_api/tools_api.py
+++ b/src/skillberry_store/fast_api/tools_api.py
@@ -98,22 +98,36 @@ def register_tools_api(
         tags=[tags],
         openapi_extra={"x-cli-name": "list-tools", "x-mcp-tool": True},
     )
-    def list_tools() -> List[Dict[str, Any]]:
+    def list_tools(
+        fields: Optional[str] = Query(
+            None,
+            description=(
+                "Field projection. Omit for full objects (default). Use "
+                "'list' for the slim list-view preset (drops 'params', "
+                "'returns', 'dependencies', 'packaging_params'), 'full' "
+                "for the full object, or a comma-separated allowlist of "
+                "field names."
+            ),
+        ),
+    ) -> List[Dict[str, Any]]:
         """List all tools in the store.
 
         Retrieves metadata for all tools currently stored in the system.
 
         Args:
-            None.
+            fields: Optional projection spec (see query-param description).
 
         Returns:
-            list: List of dictionaries, each containing tool metadata (name, uuid, description, etc.).
+            list: List of dictionaries, each containing tool metadata
+                (subset when ``fields`` narrows the projection).
 
         Raises:
-            HTTPException: 500 if listing fails.
+            HTTPException: 400 if ``fields`` is invalid, 500 if listing fails.
         """
         try:
-            return service.list_all()
+            return service.list_all(fields=fields)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
         except Exception as e:
             raise HTTPException(
                 status_code=500,

--- a/src/skillberry_store/fast_api/tools_api.py
+++ b/src/skillberry_store/fast_api/tools_api.py
@@ -102,7 +102,7 @@ def register_tools_api(
         fields: Optional[str] = Query(
             None,
             description=(
-                "Field projection. Omit for full objects (default). Use "
+                "Field selection. Omit for full objects (default). Use "
                 "'list' for the slim list-view preset (drops 'params', "
                 "'returns', 'dependencies', 'packaging_params'), 'full' "
                 "for the full object, or a comma-separated allowlist of "
@@ -115,11 +115,11 @@ def register_tools_api(
         Retrieves metadata for all tools currently stored in the system.
 
         Args:
-            fields: Optional projection spec (see query-param description).
+            fields: Optional field-selection spec (see query-param description).
 
         Returns:
             list: List of dictionaries, each containing tool metadata
-                (subset when ``fields`` narrows the projection).
+                (subset when ``fields`` narrows the field selection).
 
         Raises:
             HTTPException: 400 if ``fields`` is invalid, 500 if listing fails.
@@ -323,9 +323,9 @@ def register_tools_api(
         fields: Optional[str] = Query(
             None,
             description=(
-                "Optional projection over each matched tool. Omit for the "
-                "legacy '{filename, similarity_score}' shape. Use 'list' for "
-                "the slim list-view preset merged with 'similarity_score', "
+                "Optional field selection over each matched tool. Omit for "
+                "the legacy '{filename, similarity_score}' shape. Use 'list' "
+                "for the slim list-view preset merged with 'similarity_score', "
                 "'full' for the full tool, or a comma-separated allowlist of "
                 "field names."
             ),
@@ -341,12 +341,12 @@ def register_tools_api(
             similarity_threshold: Threshold to be used.
             manifest_filter: Manifest properties to filter (e.g., "tags:python", "state:approved").
             lifecycle_state: State to filter by (e.g., LifecycleState.APPROVED).
-            fields: Optional projection spec (see query-param description).
+            fields: Optional field-selection spec (see query-param description).
 
         Returns:
             list: Matches. Legacy ``{"filename", "similarity_score"}`` shape
-                when ``fields`` is omitted; otherwise projected tool dicts
-                with ``similarity_score`` merged in.
+                when ``fields`` is omitted; otherwise field-selected tool
+                dicts with ``similarity_score`` merged in.
         """
         try:
             return service.search(

--- a/src/skillberry_store/fast_api/tools_api.py
+++ b/src/skillberry_store/fast_api/tools_api.py
@@ -102,11 +102,11 @@ def register_tools_api(
         fields: Optional[str] = Query(
             None,
             description=(
-                "Field selection. Omit for full objects (default). Use "
-                "'list' for the slim list-view preset (drops 'params', "
-                "'returns', 'dependencies', 'packaging_params'), 'full' "
-                "for the full object, or a comma-separated allowlist of "
-                "field names."
+                "Field selection. Omit or 'full' for the complete object "
+                "(default). 'narrow' returns the minimal set required by "
+                "the UI listing page for this type. 'wide' returns every "
+                "persisted manifest field. Or supply a comma-separated "
+                "allowlist of field names."
             ),
         ),
     ) -> List[Dict[str, Any]]:
@@ -323,11 +323,12 @@ def register_tools_api(
         fields: Optional[str] = Query(
             None,
             description=(
-                "Optional field selection over each matched tool. Omit for "
-                "the legacy '{filename, similarity_score}' shape. Use 'list' "
-                "for the slim list-view preset merged with 'similarity_score', "
-                "'full' for the full tool, or a comma-separated allowlist of "
-                "field names."
+                "Field selection over each match. Same grammar as the "
+                "list endpoint (omit or 'full' for the complete object; "
+                "'narrow' for the UI listing set; 'wide' for every "
+                "persisted manifest field; CSV allowlist). Each match "
+                "is a field-selected tool dict with 'similarity_score' "
+                "merged in."
             ),
         ),
     ) -> List:
@@ -344,9 +345,8 @@ def register_tools_api(
             fields: Optional field-selection spec (see query-param description).
 
         Returns:
-            list: Matches. Legacy ``{"filename", "similarity_score"}`` shape
-                when ``fields`` is omitted; otherwise field-selected tool
-                dicts with ``similarity_score`` merged in.
+            list: Field-selected tool dicts with ``similarity_score``
+                merged in.
         """
         try:
             return service.search(

--- a/src/skillberry_store/fast_api/tools_api.py
+++ b/src/skillberry_store/fast_api/tools_api.py
@@ -320,6 +320,16 @@ def register_tools_api(
         similarity_threshold: float = 1,
         manifest_filter: str = ".",
         lifecycle_state: LifecycleState = LifecycleState.ANY,
+        fields: Optional[str] = Query(
+            None,
+            description=(
+                "Optional projection over each matched tool. Omit for the "
+                "legacy '{filename, similarity_score}' shape. Use 'list' for "
+                "the slim list-view preset merged with 'similarity_score', "
+                "'full' for the full tool, or a comma-separated allowlist of "
+                "field names."
+            ),
+        ),
     ) -> List:
         """Return a list of tools that are similar to the given search term.
 
@@ -331,9 +341,12 @@ def register_tools_api(
             similarity_threshold: Threshold to be used.
             manifest_filter: Manifest properties to filter (e.g., "tags:python", "state:approved").
             lifecycle_state: State to filter by (e.g., LifecycleState.APPROVED).
+            fields: Optional projection spec (see query-param description).
 
         Returns:
-            list: A list of matched tool names and similarity scores.
+            list: Matches. Legacy ``{"filename", "similarity_score"}`` shape
+                when ``fields`` is omitted; otherwise projected tool dicts
+                with ``similarity_score`` merged in.
         """
         try:
             return service.search(
@@ -342,7 +355,10 @@ def register_tools_api(
                 similarity_threshold=similarity_threshold,
                 manifest_filter=manifest_filter,
                 lifecycle_state=lifecycle_state,
+                fields=fields,
             )
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
         except RuntimeError as e:
             raise HTTPException(status_code=503, detail=str(e))
         except Exception as e:

--- a/src/skillberry_store/fast_api/tools_api.py
+++ b/src/skillberry_store/fast_api/tools_api.py
@@ -100,13 +100,14 @@ def register_tools_api(
     )
     def list_tools(
         fields: Optional[str] = Query(
-            None,
+            "narrow",
             description=(
-                "Field selection. Omit or 'full' for the complete object "
-                "(default). 'narrow' returns the minimal set required by "
-                "the UI listing page for this type. 'wide' returns every "
-                "persisted manifest field. Or supply a comma-separated "
-                "allowlist of field names."
+                "Field selection. Omit or 'narrow' for the minimal set "
+                "required by the UI listing page for this type "
+                "(default). 'wide' returns every persisted manifest "
+                "field. 'full' returns the complete object, including "
+                "flag fields that trigger bundling mechanisms. Or "
+                "supply a comma-separated allowlist of field names."
             ),
         ),
     ) -> List[Dict[str, Any]]:
@@ -321,14 +322,14 @@ def register_tools_api(
         manifest_filter: str = ".",
         lifecycle_state: LifecycleState = LifecycleState.ANY,
         fields: Optional[str] = Query(
-            None,
+            "narrow",
             description=(
                 "Field selection over each match. Same grammar as the "
-                "list endpoint (omit or 'full' for the complete object; "
-                "'narrow' for the UI listing set; 'wide' for every "
-                "persisted manifest field; CSV allowlist). Each match "
-                "is a field-selected tool dict with 'similarity_score' "
-                "merged in."
+                "list endpoint (omit or 'narrow' for the UI listing "
+                "set — default; 'wide' for every persisted manifest "
+                "field; 'full' for the complete object; CSV allowlist). "
+                "Each match is a field-selected tool dict with "
+                "'similarity_score' merged in."
             ),
         ),
     ) -> List:

--- a/src/skillberry_store/fast_api/vmcp_api.py
+++ b/src/skillberry_store/fast_api/vmcp_api.py
@@ -110,7 +110,7 @@ def register_vmcp_api(
             skill_uuid: Optional skill UUID to filter servers by.
 
         Returns:
-            dict: Dictionary containing virtual_mcp_servers with server metadata.
+            list: List of server metadata dicts (each with runtime status).
 
         Raises:
             HTTPException: 500 if listing fails.

--- a/src/skillberry_store/fast_api/vmcp_api.py
+++ b/src/skillberry_store/fast_api/vmcp_api.py
@@ -101,22 +101,38 @@ def register_vmcp_api(
         tags=[tags],
         openapi_extra={"x-cli-name": "list-vmcp-servers", "x-mcp-tool": True},
     )
-    def list_vmcp_servers(skill_uuid: Optional[str] = None):
+    def list_vmcp_servers(
+        skill_uuid: Optional[str] = None,
+        fields: Optional[str] = Query(
+            None,
+            description=(
+                "Field selection. Omit for the full runtime-enriched server "
+                "object (default). Use 'list' for the slim list-view preset "
+                "(keeps runtime-status fields the list UI depends on), "
+                "'full' for the full object, or a comma-separated allowlist "
+                "of field names."
+            ),
+        ),
+    ):
         """List all virtual MCP servers in the store.
 
         Retrieves metadata for all virtual MCP servers, optionally filtered by skill UUID.
 
         Args:
             skill_uuid: Optional skill UUID to filter servers by.
+            fields: Optional field-selection spec (see query-param description).
 
         Returns:
             list: List of server metadata dicts (each with runtime status).
+                Fields are filtered when ``fields`` narrows the selection.
 
         Raises:
-            HTTPException: 500 if listing fails.
+            HTTPException: 400 if ``fields`` is invalid, 500 if listing fails.
         """
         try:
-            return service.list_all(skill_uuid=skill_uuid)
+            return service.list_all(skill_uuid=skill_uuid, fields=fields)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
         except Exception as e:
             raise HTTPException(
                 status_code=500, detail=f"Error listing vmcp servers: {str(e)}"
@@ -273,6 +289,16 @@ def register_vmcp_api(
         similarity_threshold: float = 1,
         manifest_filter: str = ".",
         lifecycle_state: LifecycleState = LifecycleState.ANY,
+        fields: Optional[str] = Query(
+            None,
+            description=(
+                "Optional field selection over each matched vMCP server. "
+                "Omit for the legacy '{filename, similarity_score}' shape. "
+                "Use 'list' for the slim list-view preset merged with "
+                "'similarity_score', 'full' for the raw vMCP dict, or a "
+                "comma-separated allowlist of field names."
+            ),
+        ),
     ):
         """Search for virtual MCP servers using semantic similarity.
 
@@ -285,12 +311,16 @@ def register_vmcp_api(
             similarity_threshold: Maximum similarity score threshold (default: 1, lower is more similar).
             manifest_filter: Manifest properties to filter (e.g., "tags:python", "state:approved").
             lifecycle_state: State to filter by (e.g., LifecycleState.APPROVED).
+            fields: Optional field-selection spec (see query-param description).
 
         Returns:
-            list: List of matched server names and similarity scores.
+            list: Matches. Legacy ``{"filename", "similarity_score"}`` shape
+                when ``fields`` is omitted; otherwise field-selected vMCP
+                dicts with ``similarity_score`` merged in.
 
         Raises:
-            HTTPException: 503 if search is not available, 500 for other errors.
+            HTTPException: 400 if ``fields`` is invalid, 503 if search is not
+                available, 500 for other errors.
         """
         try:
             return service.search(
@@ -299,7 +329,10 @@ def register_vmcp_api(
                 similarity_threshold=similarity_threshold,
                 manifest_filter=manifest_filter,
                 lifecycle_state=lifecycle_state,
+                fields=fields,
             )
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
         except RuntimeError as e:
             raise HTTPException(status_code=503, detail=str(e))
         except Exception as e:

--- a/src/skillberry_store/fast_api/vmcp_api.py
+++ b/src/skillberry_store/fast_api/vmcp_api.py
@@ -106,11 +106,15 @@ def register_vmcp_api(
         fields: Optional[str] = Query(
             None,
             description=(
-                "Field selection. Omit for the full runtime-enriched server "
-                "object (default). Use 'list' for the slim list-view preset "
-                "(keeps runtime-status fields the list UI depends on), "
-                "'full' for the full object, or a comma-separated allowlist "
-                "of field names."
+                "Field selection. Omit or 'full' for the complete object "
+                "with the '_enhance' mechanism running — 'running' and "
+                "'runtime' are computed and merged in (default). "
+                "'narrow' returns the minimal set required by the UI "
+                "listing page (still runs enhancement so 'running' is "
+                "available). 'wide' returns every persisted manifest "
+                "field only (enhancement skipped). Or supply a "
+                "comma-separated allowlist (include '_enhance' to "
+                "trigger enhancement)."
             ),
         ),
     ):
@@ -292,11 +296,14 @@ def register_vmcp_api(
         fields: Optional[str] = Query(
             None,
             description=(
-                "Optional field selection over each matched vMCP server. "
-                "Omit for the legacy '{filename, similarity_score}' shape. "
-                "Use 'list' for the slim list-view preset merged with "
-                "'similarity_score', 'full' for the raw vMCP dict, or a "
-                "comma-separated allowlist of field names."
+                "Field selection over each match. Same grammar as the "
+                "list endpoint. Default (omit / 'full') triggers "
+                "'_enhance' — 'running' and 'runtime' are merged in. "
+                "'narrow' returns the UI listing set (also runs "
+                "enhancement). 'wide' returns every persisted manifest "
+                "field (enhancement skipped). CSV allowlist also "
+                "supported. Each match is a field-selected vMCP dict "
+                "with 'similarity_score' merged in."
             ),
         ),
     ):
@@ -314,9 +321,8 @@ def register_vmcp_api(
             fields: Optional field-selection spec (see query-param description).
 
         Returns:
-            list: Matches. Legacy ``{"filename", "similarity_score"}`` shape
-                when ``fields`` is omitted; otherwise field-selected vMCP
-                dicts with ``similarity_score`` merged in.
+            list: Field-selected vMCP dicts with ``similarity_score``
+                merged in.
 
         Raises:
             HTTPException: 400 if ``fields`` is invalid, 503 if search is not

--- a/src/skillberry_store/fast_api/vmcp_api.py
+++ b/src/skillberry_store/fast_api/vmcp_api.py
@@ -104,17 +104,17 @@ def register_vmcp_api(
     def list_vmcp_servers(
         skill_uuid: Optional[str] = None,
         fields: Optional[str] = Query(
-            None,
+            "narrow",
             description=(
-                "Field selection. Omit or 'full' for the complete object "
-                "with the '_enhance' mechanism running — 'running' and "
-                "'runtime' are computed and merged in (default). "
-                "'narrow' returns the minimal set required by the UI "
-                "listing page (still runs enhancement so 'running' is "
-                "available). 'wide' returns every persisted manifest "
-                "field only (enhancement skipped). Or supply a "
-                "comma-separated allowlist (include '_enhance' to "
-                "trigger enhancement)."
+                "Field selection. Omit or 'narrow' for the minimal set "
+                "required by the UI listing page — still runs "
+                "enhancement so 'running' is available (default). "
+                "'wide' returns every persisted manifest field only "
+                "(enhancement skipped). 'full' returns the complete "
+                "object with the '_enhance' mechanism running — "
+                "'running' and 'runtime' are computed and merged in. "
+                "Or supply a comma-separated allowlist (include "
+                "'_enhance' to trigger enhancement)."
             ),
         ),
     ):
@@ -294,16 +294,17 @@ def register_vmcp_api(
         manifest_filter: str = ".",
         lifecycle_state: LifecycleState = LifecycleState.ANY,
         fields: Optional[str] = Query(
-            None,
+            "narrow",
             description=(
                 "Field selection over each match. Same grammar as the "
-                "list endpoint. Default (omit / 'full') triggers "
+                "list endpoint. Default (omit / 'narrow') returns the "
+                "UI listing set (also runs enhancement so 'running' is "
+                "available). 'wide' returns every persisted manifest "
+                "field (enhancement skipped). 'full' triggers "
                 "'_enhance' — 'running' and 'runtime' are merged in. "
-                "'narrow' returns the UI listing set (also runs "
-                "enhancement). 'wide' returns every persisted manifest "
-                "field (enhancement skipped). CSV allowlist also "
-                "supported. Each match is a field-selected vMCP dict "
-                "with 'similarity_score' merged in."
+                "CSV allowlist also supported. Each match is a "
+                "field-selected vMCP dict with 'similarity_score' "
+                "merged in."
             ),
         ),
     ):

--- a/src/skillberry_store/fast_api/vnfs_api.py
+++ b/src/skillberry_store/fast_api/vnfs_api.py
@@ -97,7 +97,7 @@ def register_vnfs_api(
             skill_uuid: Optional skill UUID to filter servers by.
 
         Returns:
-            dict: Dictionary containing virtual_nfs_servers with server metadata.
+            list: List of server metadata dicts (each with runtime status and export path).
 
         Raises:
             HTTPException: 500 if listing fails.

--- a/src/skillberry_store/fast_api/vnfs_api.py
+++ b/src/skillberry_store/fast_api/vnfs_api.py
@@ -93,11 +93,14 @@ def register_vnfs_api(
         fields: Optional[str] = Query(
             None,
             description=(
-                "Field selection. Omit for the full runtime-enriched server "
-                "object (default). Use 'list' for the slim list-view preset "
-                "(keeps runtime-status fields the list UI depends on), "
-                "'full' for the full object, or a comma-separated allowlist "
-                "of field names."
+                "Field selection. Omit or 'full' for the complete object "
+                "with the '_enhance' mechanism running — 'running' and "
+                "'export_path' are computed and merged in (default). "
+                "'narrow' returns the minimal set required by the UI "
+                "listing page (still runs enhancement). 'wide' returns "
+                "every persisted manifest field only (enhancement "
+                "skipped). Or supply a comma-separated allowlist "
+                "(include '_enhance' to trigger enhancement)."
             ),
         ),
     ):
@@ -276,11 +279,14 @@ def register_vnfs_api(
         fields: Optional[str] = Query(
             None,
             description=(
-                "Optional field selection over each matched vNFS server. "
-                "Omit for the legacy '{filename, similarity_score}' shape. "
-                "Use 'list' for the slim list-view preset merged with "
-                "'similarity_score', 'full' for the raw vNFS dict, or a "
-                "comma-separated allowlist of field names."
+                "Field selection over each match. Same grammar as the "
+                "list endpoint. Default (omit / 'full') triggers "
+                "'_enhance' — 'running' and 'export_path' are merged "
+                "in. 'narrow' returns the UI listing set (also runs "
+                "enhancement). 'wide' returns every persisted manifest "
+                "field (enhancement skipped). CSV allowlist also "
+                "supported. Each match is a field-selected vNFS dict "
+                "with 'similarity_score' merged in."
             ),
         ),
     ):
@@ -298,9 +304,8 @@ def register_vnfs_api(
             fields: Optional field-selection spec (see query-param description).
 
         Returns:
-            list: Matches. Legacy ``{"filename", "similarity_score"}`` shape
-                when ``fields`` is omitted; otherwise field-selected vNFS
-                dicts with ``similarity_score`` merged in.
+            list: Field-selected vNFS dicts with ``similarity_score``
+                merged in.
 
         Raises:
             HTTPException: 400 if ``fields`` is invalid, 503 if search is not

--- a/src/skillberry_store/fast_api/vnfs_api.py
+++ b/src/skillberry_store/fast_api/vnfs_api.py
@@ -91,16 +91,16 @@ def register_vnfs_api(
     def list_vnfs_servers(
         skill_uuid: Optional[str] = None,
         fields: Optional[str] = Query(
-            None,
+            "narrow",
             description=(
-                "Field selection. Omit or 'full' for the complete object "
-                "with the '_enhance' mechanism running — 'running' and "
-                "'export_path' are computed and merged in (default). "
-                "'narrow' returns the minimal set required by the UI "
-                "listing page (still runs enhancement). 'wide' returns "
-                "every persisted manifest field only (enhancement "
-                "skipped). Or supply a comma-separated allowlist "
-                "(include '_enhance' to trigger enhancement)."
+                "Field selection. Omit or 'narrow' for the minimal set "
+                "required by the UI listing page — still runs "
+                "enhancement (default). 'wide' returns every persisted "
+                "manifest field only (enhancement skipped). 'full' "
+                "returns the complete object with the '_enhance' "
+                "mechanism running — 'running' and 'export_path' are "
+                "computed and merged in. Or supply a comma-separated "
+                "allowlist (include '_enhance' to trigger enhancement)."
             ),
         ),
     ):
@@ -277,14 +277,14 @@ def register_vnfs_api(
         manifest_filter: str = ".",
         lifecycle_state: LifecycleState = LifecycleState.ANY,
         fields: Optional[str] = Query(
-            None,
+            "narrow",
             description=(
                 "Field selection over each match. Same grammar as the "
-                "list endpoint. Default (omit / 'full') triggers "
-                "'_enhance' — 'running' and 'export_path' are merged "
-                "in. 'narrow' returns the UI listing set (also runs "
-                "enhancement). 'wide' returns every persisted manifest "
-                "field (enhancement skipped). CSV allowlist also "
+                "list endpoint. Default (omit / 'narrow') returns the "
+                "UI listing set (also runs enhancement). 'wide' "
+                "returns every persisted manifest field (enhancement "
+                "skipped). 'full' triggers '_enhance' — 'running' and "
+                "'export_path' are merged in. CSV allowlist also "
                 "supported. Each match is a field-selected vNFS dict "
                 "with 'similarity_score' merged in."
             ),

--- a/src/skillberry_store/fast_api/vnfs_api.py
+++ b/src/skillberry_store/fast_api/vnfs_api.py
@@ -88,22 +88,38 @@ def register_vnfs_api(
         tags=[tags],
         openapi_extra={"x-cli-name": "list-vnfs-servers", "x-mcp-tool": True},
     )
-    def list_vnfs_servers(skill_uuid: Optional[str] = None):
+    def list_vnfs_servers(
+        skill_uuid: Optional[str] = None,
+        fields: Optional[str] = Query(
+            None,
+            description=(
+                "Field selection. Omit for the full runtime-enriched server "
+                "object (default). Use 'list' for the slim list-view preset "
+                "(keeps runtime-status fields the list UI depends on), "
+                "'full' for the full object, or a comma-separated allowlist "
+                "of field names."
+            ),
+        ),
+    ):
         """List all virtual NFS servers in the store.
 
         Retrieves metadata for all virtual NFS servers, optionally filtered by skill UUID.
 
         Args:
             skill_uuid: Optional skill UUID to filter servers by.
+            fields: Optional field-selection spec (see query-param description).
 
         Returns:
             list: List of server metadata dicts (each with runtime status and export path).
+                Fields are filtered when ``fields`` narrows the selection.
 
         Raises:
-            HTTPException: 500 if listing fails.
+            HTTPException: 400 if ``fields`` is invalid, 500 if listing fails.
         """
         try:
-            return service.list_all(skill_uuid=skill_uuid)
+            return service.list_all(skill_uuid=skill_uuid, fields=fields)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
         except Exception as exc:
             raise HTTPException(
                 status_code=500, detail=f"Error listing vNFS servers: {exc}"
@@ -257,6 +273,16 @@ def register_vnfs_api(
         similarity_threshold: float = 1,
         manifest_filter: str = ".",
         lifecycle_state: LifecycleState = LifecycleState.ANY,
+        fields: Optional[str] = Query(
+            None,
+            description=(
+                "Optional field selection over each matched vNFS server. "
+                "Omit for the legacy '{filename, similarity_score}' shape. "
+                "Use 'list' for the slim list-view preset merged with "
+                "'similarity_score', 'full' for the raw vNFS dict, or a "
+                "comma-separated allowlist of field names."
+            ),
+        ),
     ):
         """Search for virtual NFS servers using semantic similarity.
 
@@ -269,12 +295,16 @@ def register_vnfs_api(
             similarity_threshold: Maximum similarity score threshold (default: 1, lower is more similar).
             manifest_filter: Manifest properties to filter (e.g., "tags:python", "state:approved").
             lifecycle_state: State to filter by (e.g., LifecycleState.APPROVED).
+            fields: Optional field-selection spec (see query-param description).
 
         Returns:
-            list: List of matched server names and similarity scores.
+            list: Matches. Legacy ``{"filename", "similarity_score"}`` shape
+                when ``fields`` is omitted; otherwise field-selected vNFS
+                dicts with ``similarity_score`` merged in.
 
         Raises:
-            HTTPException: 503 if search is not available, 500 for other errors.
+            HTTPException: 400 if ``fields`` is invalid, 503 if search is not
+                available, 500 for other errors.
         """
         try:
             return service.search(
@@ -283,7 +313,10 @@ def register_vnfs_api(
                 similarity_threshold=similarity_threshold,
                 manifest_filter=manifest_filter,
                 lifecycle_state=lifecycle_state,
+                fields=fields,
             )
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
         except RuntimeError as e:
             raise HTTPException(status_code=503, detail=str(e))
         except Exception as exc:

--- a/src/skillberry_store/plugins/store_api.py
+++ b/src/skillberry_store/plugins/store_api.py
@@ -286,8 +286,9 @@ class StoreAPI:
     def list_vmcps(self) -> List[Dict[str, Any]]:
         if not self.vmcp_service:
             return []
+        # ``VmcpService.list_all()`` returns a bare list of server dicts.
         result = self.vmcp_service.list_all()
-        return list(result.get("virtual_mcp_servers", {}).values())
+        return list(result) if isinstance(result, list) else []
 
     def start_vmcp(self, uuid_or_name: str, env_id: str = "") -> bool:
         if not self.vmcp_service:

--- a/src/skillberry_store/plugins/store_api.py
+++ b/src/skillberry_store/plugins/store_api.py
@@ -81,7 +81,10 @@ class StoreAPI:
     def list_tools(self, filter_criteria: Optional[Dict] = None) -> List[Dict[str, Any]]:
         if not self.tools_service:
             return []
-        return self.tools_service.list_all(filter_criteria)
+        # Plugins consume the complete tool dict (module_name,
+        # packaging_*, params, dependencies, …). The service default is
+        # ``narrow``, so opt back into ``full`` here.
+        return self.tools_service.list_all(filter_criteria, fields="full")
 
     def update_tool_tags(self, uuid: str, tags: List[str]) -> bool:
         if not self.tools_service:
@@ -161,7 +164,10 @@ class StoreAPI:
     def list_skills(self, filter_criteria: Optional[Dict] = None) -> List[Dict[str, Any]]:
         if not self.skills_service:
             return []
-        return self.skills_service.list_all(filter_criteria)
+        # Plugins consume the complete skill dict (populated tools /
+        # snippets, extra, timestamps). Opt into ``full`` since the
+        # service default is ``narrow``.
+        return self.skills_service.list_all(filter_criteria, fields="full")
 
     def update_skill_tags(self, uuid: str, tags: List[str]) -> bool:
         if not self.skills_service:
@@ -233,7 +239,10 @@ class StoreAPI:
     def list_snippets(self, filter_criteria: Optional[Dict] = None) -> List[Dict[str, Any]]:
         if not self.snippets_service:
             return []
-        return self.snippets_service.list_all(filter_criteria)
+        # Plugins consume the complete snippet dict (including
+        # ``content``). Opt into ``full`` since the service default is
+        # ``narrow``.
+        return self.snippets_service.list_all(filter_criteria, fields="full")
 
     def create_snippet(self, snippet_data: Dict[str, Any]) -> Dict[str, Any]:
         if not self.snippets_service:
@@ -287,7 +296,9 @@ class StoreAPI:
         if not self.vmcp_service:
             return []
         # ``VmcpService.list_all()`` returns a bare list of server dicts.
-        result = self.vmcp_service.list_all()
+        # Plugins consume ``skill_uuid`` (not in the narrow preset) and
+        # the full runtime bundle, so opt into ``full``.
+        result = self.vmcp_service.list_all(fields="full")
         return list(result) if isinstance(result, list) else []
 
     def start_vmcp(self, uuid_or_name: str, env_id: str = "") -> bool:

--- a/src/skillberry_store/services/field_selection.py
+++ b/src/skillberry_store/services/field_selection.py
@@ -14,10 +14,12 @@ endpoints accept an optional ``?fields=`` query param:
 * A comma-separated allowlist (``"uuid,name,description"``) — return
   exactly those keys.
 
-The HTTP layer applies the ``narrow`` default via the FastAPI ``Query``
-default on each endpoint; at the service layer, an omitted ``fields``
-argument (``None``) is still the "no filtering" sentinel (equivalent
-to ``full``) so internal Python callers keep their previous behavior.
+The default (``"narrow"``) is applied at :func:`parse_fields_spec`: a
+missing / empty ``fields_spec`` resolves to the narrow allowlist, so
+every caller — HTTP, plugin, direct service invocation — that doesn't
+name a preset gets narrow. Callers that need the complete object
+(populated skills, tool packaging params, vMCP runtime bundle) must
+opt in with ``fields="full"``.
 
 Presets are declared as *per-field tags* rather than per-preset field
 sets: each field of each object type carries zero or more preset labels,
@@ -199,7 +201,9 @@ def parse_fields_spec(
     """Resolve a ``fields`` query-param value to a concrete field allowlist.
 
     Args:
-        fields_spec: Raw value from the query string. ``None`` / empty /
+        fields_spec: Raw value from the query string. ``None`` / empty
+            means "use the default preset" — currently ``"narrow"``, the
+            minimal set required by the UI listing page for that type.
             ``"full"`` means "no field selection — return every field,
             including flag fields that trigger bundling mechanisms".
             ``"narrow"`` / ``"wide"`` selects the tagged fields for
@@ -210,9 +214,9 @@ def parse_fields_spec(
 
     Returns:
         The set of field names to keep, or ``None`` when no field
-        selection should be applied (default / ``"full"``). Callers use
-        the ``None`` sentinel to short-circuit both field filtering and
-        the "should the flag mechanism run" check (``None`` implies all
+        selection should be applied (``"full"``). Callers use the
+        ``None`` sentinel to short-circuit both field filtering and the
+        "should the flag mechanism run" check (``None`` implies all
         mechanisms run).
 
     Raises:
@@ -220,13 +224,15 @@ def parse_fields_spec(
             names a registered preset but no field of ``object_type``
             carries that tag.
     """
-    if not fields_spec or fields_spec == "full":
-        # Validate the type is known even in the default path so that
-        # a bogus ``object_type`` fails loudly.
-        if object_type not in _FIELD_TAGS_BY_TYPE:
-            raise ValueError(
-                f"No field tags registered for object type '{object_type}'"
-            )
+    # Validate the type is known up front so that a bogus ``object_type``
+    # fails loudly on every path.
+    if object_type not in _FIELD_TAGS_BY_TYPE:
+        raise ValueError(
+            f"No field tags registered for object type '{object_type}'"
+        )
+    if not fields_spec:
+        fields_spec = "narrow"
+    if fields_spec == "full":
         return None
     if fields_spec in _PRESET_NAMES:
         allow = _fields_with_preset(object_type, fields_spec)
@@ -236,7 +242,9 @@ def parse_fields_spec(
             )
         return allow
     allow = {f.strip() for f in fields_spec.split(",") if f.strip()}
-    return allow or None
+    if not allow:
+        allow = _fields_with_preset(object_type, "narrow")
+    return allow
 
 
 def should_run_mechanism(allow: Optional[Set[str]], flag: str) -> bool:

--- a/src/skillberry_store/services/field_selection.py
+++ b/src/skillberry_store/services/field_selection.py
@@ -1,4 +1,4 @@
-"""Field-projection helpers for the bulk list endpoints.
+"""Field-selection helpers for the bulk list endpoints.
 
 The list endpoints (``GET /snippets/``, ``GET /skills/``, ``GET /tools/``) can
 return slim, list-view-oriented objects when the caller passes
@@ -79,14 +79,14 @@ def parse_fields_spec(
 
     Args:
         fields_spec: Raw value from the query string. ``None``, empty, or
-            ``"full"`` means "no projection — return every field". ``"list"``
-            selects the per-type preset. Any other value is parsed as a
-            comma-separated allowlist.
+            ``"full"`` means "no field selection — return every field".
+            ``"list"`` selects the per-type preset. Any other value is parsed
+            as a comma-separated allowlist.
         object_type: Object-type key (``"snippet"``, ``"tool"``, ``"skill"``).
             Only consulted when ``fields_spec == "list"``.
 
     Returns:
-        The set of field names to keep, or ``None`` when no projection
+        The set of field names to keep, or ``None`` when no field selection
         should be applied.
 
     Raises:
@@ -106,10 +106,10 @@ def parse_fields_spec(
     return allow or None
 
 
-def project_item(
+def select_item_fields(
     item: Dict[str, Any], allow: Optional[Set[str]]
 ) -> Dict[str, Any]:
-    """Return a projected view of ``item``.
+    """Return a field-selected view of ``item``.
 
     When ``allow`` is ``None`` the input dict is returned unchanged (the
     caller must not mutate it — cache values are shared references). When
@@ -121,10 +121,10 @@ def project_item(
     return {k: item[k] for k in item.keys() & allow}
 
 
-def project_items(
+def select_items_fields(
     items: Iterable[Dict[str, Any]], allow: Optional[Set[str]]
 ) -> List[Dict[str, Any]]:
-    """Apply :func:`project_item` to each element; always returns a new list."""
+    """Apply :func:`select_item_fields` to each element; always returns a new list."""
     if allow is None:
         return list(items)
-    return [project_item(i, allow) for i in items]
+    return [select_item_fields(i, allow) for i in items]

--- a/src/skillberry_store/services/field_selection.py
+++ b/src/skillberry_store/services/field_selection.py
@@ -4,16 +4,20 @@ The list endpoints (``GET /snippets/``, ``GET /skills/``, ``GET /tools/``,
 ``GET /vmcp_servers/``, ``GET /vnfs_servers/``) and the matching search
 endpoints accept an optional ``?fields=`` query param:
 
-* Omitted / empty / ``"full"`` — return every field of the object,
-  including the underscore-prefixed flag fields that trigger bundling
-  mechanisms (default).
-* ``"narrow"`` — return the minimal set required by the UI listing
-  page for that type.
+* Omitted / empty / ``"narrow"`` — return the minimal set required by
+  the UI listing page for that type (default).
 * ``"wide"`` — return every persisted manifest field for that type,
   but skip the flag fields (and therefore skip the bundling mechanisms
   those flags gate).
+* ``"full"`` — return every field of the object, including the
+  underscore-prefixed flag fields that trigger bundling mechanisms.
 * A comma-separated allowlist (``"uuid,name,description"``) — return
   exactly those keys.
+
+The HTTP layer applies the ``narrow`` default via the FastAPI ``Query``
+default on each endpoint; at the service layer, an omitted ``fields``
+argument (``None``) is still the "no filtering" sentinel (equivalent
+to ``full``) so internal Python callers keep their previous behavior.
 
 Presets are declared as *per-field tags* rather than per-preset field
 sets: each field of each object type carries zero or more preset labels,

--- a/src/skillberry_store/services/field_selection.py
+++ b/src/skillberry_store/services/field_selection.py
@@ -4,17 +4,34 @@ The list endpoints (``GET /snippets/``, ``GET /skills/``, ``GET /tools/``,
 ``GET /vmcp_servers/``, ``GET /vnfs_servers/``) and the matching search
 endpoints accept an optional ``?fields=`` query param:
 
-* Omitted / empty / ``"full"``  — return the full object (default).
-* A registered **preset name** (currently only ``"list"``) — return the
-  fields tagged with that preset for the object's type.
+* Omitted / empty / ``"full"`` — return every field of the object,
+  including the underscore-prefixed flag fields that trigger bundling
+  mechanisms (default).
+* ``"narrow"`` — return the minimal set required by the UI listing
+  page for that type.
+* ``"wide"`` — return every persisted manifest field for that type,
+  but skip the flag fields (and therefore skip the bundling mechanisms
+  those flags gate).
 * A comma-separated allowlist (``"uuid,name,description"``) — return
-  exactly those fields.
+  exactly those keys.
 
 Presets are declared as *per-field tags* rather than per-preset field
 sets: each field of each object type carries zero or more preset labels,
-and the preset resolver returns "all fields carrying that label." Adding
-a new preset is a matter of labelling fields; no changes to the
-resolver are required.
+and the preset resolver returns "all fields carrying that label."
+
+Boolean flag fields — names prefixed with ``"_"`` — do not represent
+persisted data. Instead they activate a bundling mechanism inside the
+owning service (skill population, vmcp/vnfs runtime enhancement).
+Convention:
+
+* A flag field carries ``"full"`` (always) and ``"narrow"`` when the
+  listing page needs the mechanism's output.
+* A flag field is **never** tagged ``"wide"`` — ``"wide"`` is manifest
+  data only.
+* The service consults the resolved allowlist: it triggers the
+  mechanism iff the flag is in the allowlist (or the allowlist is
+  ``None``, i.e. full/default). Sub-fields of the bundled payload that
+  are not in the allowlist are skipped where cheap to do so.
 
 The preset associations live server-side only. Clients (UI, CLI, MCP,
 SDK) only ever send the preset *name* — they never need to know which
@@ -28,110 +45,114 @@ from typing import Any, Dict, Iterable, List, Optional, Set
 # ─── field-tag tables ──────────────────────────────────────────────────
 #
 # ``FieldTags`` is the shape used per object type: a map from a field
-# name to the set of preset names that field belongs to. Fields not
-# present in the map (or with an empty tag set) are only returned when
-# the caller asks for the full object (``fields=None`` / ``"full"``).
-#
-# The five tables below migrate the legacy ``*_LIST_FIELDS`` sets: every
-# field previously in that set is tagged ``{"list"}``, every other
-# field carries no tag.
+# name to the set of preset names that field belongs to.
 
 FieldTags = Dict[str, Set[str]]
 
+# Common manifest fields — every persisted-schema field appears in
+# ``wide`` and ``full``; ``narrow`` only names the ones the UI listing
+# page actually renders/filters/sorts on.
+
 SNIPPET_FIELD_TAGS: FieldTags = {
-    "uuid":         {"list"},
-    "name":         {"list"},
-    "description":  {"list"},
-    "state":        {"list"},
-    "tags":         {"list"},
-    "version":      {"list"},
-    "extra":        {"list"},
-    "parent":       {"list"},
-    "created_at":   {"list"},
-    "modified_at":  {"list"},
-    "author":       {"list"},
-    "content_type": {"list"},
-    # "content" — heavy payload; omitted from the "list" preset.
+    # UI-facing (narrow) — rendered by the Snippets listing page.
+    "uuid":         {"narrow", "wide", "full"},
+    "name":         {"narrow", "wide", "full"},
+    "description":  {"narrow", "wide", "full"},
+    "state":        {"narrow", "wide", "full"},
+    "tags":         {"narrow", "wide", "full"},
+    "version":      {"narrow", "wide", "full"},
+    "content_type": {"narrow", "wide", "full"},
+    # Persisted but not UI-facing — wide/full only.
+    "extra":        {"wide", "full"},
+    "parent":       {"wide", "full"},
+    "created_at":   {"wide", "full"},
+    "modified_at":  {"wide", "full"},
+    "content":      {"wide", "full"},
 }
 
 TOOL_FIELD_TAGS: FieldTags = {
-    "uuid":                 {"list"},
-    "name":                 {"list"},
-    "description":          {"list"},
-    "state":                {"list"},
-    "tags":                 {"list"},
-    "version":              {"list"},
-    "extra":                {"list"},
-    "parent":               {"list"},
-    "created_at":           {"list"},
-    "modified_at":          {"list"},
-    "author":               {"list"},
-    "module_name":          {"list"},
-    "programming_language": {"list"},
-    "packaging_format":     {"list"},
-    # "params" / "returns" / "dependencies" / "packaging_params" —
-    # heavy; omitted from the "list" preset.
+    "uuid":                 {"narrow", "wide", "full"},
+    "name":                 {"narrow", "wide", "full"},
+    "description":          {"narrow", "wide", "full"},
+    "state":                {"narrow", "wide", "full"},
+    "tags":                 {"narrow", "wide", "full"},
+    "version":              {"narrow", "wide", "full"},
+    "module_name":          {"narrow", "wide", "full"},
+    "extra":                {"wide", "full"},
+    "parent":               {"wide", "full"},
+    "created_at":           {"wide", "full"},
+    "modified_at":          {"wide", "full"},
+    "programming_language": {"wide", "full"},
+    "packaging_format":     {"wide", "full"},
+    "packaging_params":     {"wide", "full"},
+    "params":               {"wide", "full"},
+    "returns":              {"wide", "full"},
+    "dependencies":         {"wide", "full"},
 }
 
 SKILL_FIELD_TAGS: FieldTags = {
-    "uuid":          {"list"},
-    "name":          {"list"},
-    "description":   {"list"},
-    "state":         {"list"},
-    "tags":          {"list"},
-    "version":       {"list"},
-    "extra":         {"list"},
-    "parent":        {"list"},
-    "created_at":    {"list"},
-    "modified_at":   {"list"},
-    "author":        {"list"},
-    "tool_uuids":    {"list"},
-    "snippet_uuids": {"list"},
-    # Populated "tools" / "snippets" arrays are inlined by
-    # ``SkillsService.populate_objects`` at get-time; the list preset
-    # deliberately omits them so callers use ``tool_uuids`` /
-    # ``snippet_uuids``.
+    "uuid":          {"narrow", "wide", "full"},
+    "name":          {"narrow", "wide", "full"},
+    "description":   {"narrow", "wide", "full"},
+    "state":         {"narrow", "wide", "full"},
+    "tags":          {"narrow", "wide", "full"},
+    "version":       {"narrow", "wide", "full"},
+    "tool_uuids":    {"narrow", "wide", "full"},
+    "snippet_uuids": {"narrow", "wide", "full"},
+    "extra":         {"wide", "full"},
+    "parent":        {"wide", "full"},
+    "created_at":    {"wide", "full"},
+    "modified_at":   {"wide", "full"},
+    # Flag + bundled outputs (only in ``full``): the ``_populate`` flag
+    # triggers ``SkillsService.populate_objects`` which inlines the full
+    # tool/snippet objects into ``tools`` / ``snippets``.
+    "_populate":     {"full"},
+    "tools":         {"full"},
+    "snippets":      {"full"},
 }
 
-# vMCP / vNFS list presets include the runtime-status fields
-# (``running``, ``runtime`` for vMCP; ``running``, ``export_path`` for
-# vNFS) — the list UI depends on them.
+# vMCP: the list UI shows a Status column (Running/Stopped) that reads
+# ``running``. To produce ``running`` the service must run its
+# enhancement mechanism, gated by ``_enhance``. Once enhancement is on,
+# the whole bundled payload (``running`` + ``runtime``) comes with it —
+# the list view ignores ``runtime`` but it costs nothing to include it
+# in the narrow preset and keeps the mechanism simple.
 
 VMCP_FIELD_TAGS: FieldTags = {
-    "uuid":        {"list"},
-    "name":        {"list"},
-    "description": {"list"},
-    "state":       {"list"},
-    "tags":        {"list"},
-    "version":     {"list"},
-    "extra":       {"list"},
-    "parent":      {"list"},
-    "created_at":  {"list"},
-    "modified_at": {"list"},
-    "author":      {"list"},
-    "port":        {"list"},
-    "skill_uuid":  {"list"},
-    "running":     {"list"},
-    "runtime":     {"list"},
+    "uuid":        {"narrow", "wide", "full"},
+    "name":        {"narrow", "wide", "full"},
+    "description": {"narrow", "wide", "full"},
+    "state":       {"narrow", "wide", "full"},
+    "tags":        {"narrow", "wide", "full"},
+    "version":     {"narrow", "wide", "full"},
+    "port":        {"narrow", "wide", "full"},
+    "skill_uuid":  {"wide", "full"},
+    "extra":       {"wide", "full"},
+    "parent":      {"wide", "full"},
+    "created_at":  {"wide", "full"},
+    "modified_at": {"wide", "full"},
+    "_enhance":    {"narrow", "full"},
+    "running":     {"narrow", "full"},
+    "runtime":     {"narrow", "full"},
 }
 
 VNFS_FIELD_TAGS: FieldTags = {
-    "uuid":        {"list"},
-    "name":        {"list"},
-    "description": {"list"},
-    "state":       {"list"},
-    "tags":        {"list"},
-    "version":     {"list"},
-    "extra":       {"list"},
-    "parent":      {"list"},
-    "created_at":  {"list"},
-    "modified_at": {"list"},
-    "author":      {"list"},
-    "port":        {"list"},
-    "skill_uuid":  {"list"},
-    "protocol":    {"list"},
-    "running":     {"list"},
-    "export_path": {"list"},
+    "uuid":        {"narrow", "wide", "full"},
+    "name":        {"narrow", "wide", "full"},
+    "description": {"narrow", "wide", "full"},
+    "state":       {"narrow", "wide", "full"},
+    "tags":        {"narrow", "wide", "full"},
+    "version":     {"narrow", "wide", "full"},
+    "port":        {"narrow", "wide", "full"},
+    "protocol":    {"narrow", "wide", "full"},
+    "skill_uuid":  {"wide", "full"},
+    "extra":       {"wide", "full"},
+    "parent":      {"wide", "full"},
+    "created_at":  {"wide", "full"},
+    "modified_at": {"wide", "full"},
+    "_enhance":    {"narrow", "full"},
+    "running":     {"narrow", "full"},
+    "export_path": {"narrow", "full"},
 }
 
 _FIELD_TAGS_BY_TYPE: Dict[str, FieldTags] = {
@@ -141,6 +162,11 @@ _FIELD_TAGS_BY_TYPE: Dict[str, FieldTags] = {
     "vmcp":    VMCP_FIELD_TAGS,
     "vnfs":    VNFS_FIELD_TAGS,
 }
+
+# Fixed set of preset names the resolver recognizes as such (as
+# opposed to a comma-separated allowlist). Adding a new preset name
+# means adding it here AND tagging fields with it.
+_PRESET_NAMES: Set[str] = {"narrow", "wide", "full"}
 
 
 # ─── preset resolution ─────────────────────────────────────────────────
@@ -160,29 +186,6 @@ def _fields_with_preset(object_type: str, preset: str) -> Set[str]:
     return {name for name, presets in tags.items() if preset in presets}
 
 
-def _all_known_presets() -> Set[str]:
-    """Union of every preset name declared anywhere in the tag registry."""
-    seen: Set[str] = set()
-    for tags in _FIELD_TAGS_BY_TYPE.values():
-        for names in tags.values():
-            seen |= names
-    return seen
-
-
-# ─── back-compat computed constants ────────────────────────────────────
-#
-# These retain the pre-refactor names/values so any importer (currently
-# only the server-side tests) keeps working. They are *derived* from the
-# tag tables — the single source of truth for the "list" preset is now
-# the ``{"list"}`` label on each field above.
-
-SNIPPET_LIST_FIELDS: Set[str] = _fields_with_preset("snippet", "list")
-TOOL_LIST_FIELDS:    Set[str] = _fields_with_preset("tool",    "list")
-SKILL_LIST_FIELDS:   Set[str] = _fields_with_preset("skill",   "list")
-VMCP_LIST_FIELDS:    Set[str] = _fields_with_preset("vmcp",    "list")
-VNFS_LIST_FIELDS:    Set[str] = _fields_with_preset("vnfs",    "list")
-
-
 # ─── public API ────────────────────────────────────────────────────────
 
 
@@ -193,25 +196,35 @@ def parse_fields_spec(
 
     Args:
         fields_spec: Raw value from the query string. ``None`` / empty /
-            ``"full"`` means "no field selection — return every field".
-            A registered preset name (matches any tag in the field-tag
-            tables) selects the tagged fields for ``object_type``. Any
-            other value is parsed as a comma-separated allowlist.
+            ``"full"`` means "no field selection — return every field,
+            including flag fields that trigger bundling mechanisms".
+            ``"narrow"`` / ``"wide"`` selects the tagged fields for
+            ``object_type``. Any other value is parsed as a
+            comma-separated allowlist.
         object_type: Object-type key (``"snippet"``, ``"tool"``,
             ``"skill"``, ``"vmcp"``, ``"vnfs"``).
 
     Returns:
         The set of field names to keep, or ``None`` when no field
-        selection should be applied.
+        selection should be applied (default / ``"full"``). Callers use
+        the ``None`` sentinel to short-circuit both field filtering and
+        the "should the flag mechanism run" check (``None`` implies all
+        mechanisms run).
 
     Raises:
-        ValueError: If ``fields_spec`` matches a registered preset name
-            but that preset is not declared for ``object_type`` (i.e.
-            no field of ``object_type`` carries that tag).
+        ValueError: If ``object_type`` is unknown, or if ``fields_spec``
+            names a registered preset but no field of ``object_type``
+            carries that tag.
     """
     if not fields_spec or fields_spec == "full":
+        # Validate the type is known even in the default path so that
+        # a bogus ``object_type`` fails loudly.
+        if object_type not in _FIELD_TAGS_BY_TYPE:
+            raise ValueError(
+                f"No field tags registered for object type '{object_type}'"
+            )
         return None
-    if fields_spec in _all_known_presets():
+    if fields_spec in _PRESET_NAMES:
         allow = _fields_with_preset(object_type, fields_spec)
         if not allow:
             raise ValueError(
@@ -220,6 +233,24 @@ def parse_fields_spec(
         return allow
     allow = {f.strip() for f in fields_spec.split(",") if f.strip()}
     return allow or None
+
+
+def should_run_mechanism(allow: Optional[Set[str]], flag: str) -> bool:
+    """Return whether the mechanism gated by ``flag`` should run.
+
+    Args:
+        allow: The resolved allowlist from :func:`parse_fields_spec`.
+            ``None`` means "no filtering / full preset" — every
+            mechanism runs.
+        flag: The underscore-prefixed flag field name (e.g. ``"_populate"``,
+            ``"_enhance"``).
+
+    Returns:
+        True iff the mechanism should run: either ``allow`` is ``None``
+        (default/full) or ``flag`` is explicitly in ``allow`` (narrow
+        preset for vmcp/vnfs; explicit CSV request; etc.).
+    """
+    return allow is None or flag in allow
 
 
 def select_item_fields(

--- a/src/skillberry_store/services/field_selection.py
+++ b/src/skillberry_store/services/field_selection.py
@@ -65,10 +65,52 @@ SKILL_LIST_FIELDS: Set[str] = {
     "snippet_uuids",
 }
 
+# vMCP / vNFS list presets include the runtime-status fields (``running``,
+# ``runtime`` for vMCP; ``running``, ``export_path`` for vNFS) — the list UI
+# depends on them.
+VMCP_LIST_FIELDS: Set[str] = {
+    "uuid",
+    "name",
+    "description",
+    "state",
+    "tags",
+    "version",
+    "extra",
+    "parent",
+    "created_at",
+    "modified_at",
+    "author",
+    "port",
+    "skill_uuid",
+    "running",
+    "runtime",
+}
+
+VNFS_LIST_FIELDS: Set[str] = {
+    "uuid",
+    "name",
+    "description",
+    "state",
+    "tags",
+    "version",
+    "extra",
+    "parent",
+    "created_at",
+    "modified_at",
+    "author",
+    "port",
+    "skill_uuid",
+    "protocol",
+    "running",
+    "export_path",
+}
+
 _LIST_PRESETS: Dict[str, Set[str]] = {
     "snippet": SNIPPET_LIST_FIELDS,
     "tool": TOOL_LIST_FIELDS,
     "skill": SKILL_LIST_FIELDS,
+    "vmcp": VMCP_LIST_FIELDS,
+    "vnfs": VNFS_LIST_FIELDS,
 }
 
 

--- a/src/skillberry_store/services/field_selection.py
+++ b/src/skillberry_store/services/field_selection.py
@@ -35,9 +35,9 @@ Convention:
 * A flag field is **never** tagged ``"wide"`` — ``"wide"`` is manifest
   data only.
 * The service consults the resolved allowlist: it triggers the
-  mechanism iff the flag is in the allowlist (or the allowlist is
-  ``None``, i.e. full/default). Sub-fields of the bundled payload that
-  are not in the allowlist are skipped where cheap to do so.
+  mechanism iff the flag is in the allowlist. Sub-fields of the
+  bundled payload that are not in the allowlist are skipped where
+  cheap to do so.
 
 The preset associations live server-side only. Clients (UI, CLI, MCP,
 SDK) only ever send the preset *name* — they never need to know which
@@ -46,7 +46,7 @@ fields it expands to.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable, List, Optional, Set
+from typing import Any, Dict, Iterable, List, Set
 
 # ─── field-tag tables ──────────────────────────────────────────────────
 #
@@ -196,28 +196,24 @@ def _fields_with_preset(object_type: str, preset: str) -> Set[str]:
 
 
 def parse_fields_spec(
-    fields_spec: Optional[str], object_type: str
-) -> Optional[Set[str]]:
+    fields_spec: str | None, object_type: str
+) -> Set[str]:
     """Resolve a ``fields`` query-param value to a concrete field allowlist.
 
     Args:
         fields_spec: Raw value from the query string. ``None`` / empty
             means "use the default preset" — currently ``"narrow"``, the
             minimal set required by the UI listing page for that type.
-            ``"full"`` means "no field selection — return every field,
-            including flag fields that trigger bundling mechanisms".
-            ``"narrow"`` / ``"wide"`` selects the tagged fields for
-            ``object_type``. Any other value is parsed as a
+            ``"narrow"`` / ``"wide"`` / ``"full"`` selects the tagged
+            fields for ``object_type``. Any other value is parsed as a
             comma-separated allowlist.
         object_type: Object-type key (``"snippet"``, ``"tool"``,
             ``"skill"``, ``"vmcp"``, ``"vnfs"``).
 
     Returns:
-        The set of field names to keep, or ``None`` when no field
-        selection should be applied (``"full"``). Callers use the
-        ``None`` sentinel to short-circuit both field filtering and the
-        "should the flag mechanism run" check (``None`` implies all
-        mechanisms run).
+        The set of field names to keep. Every preset  resolves through 
+        the FieldTags table for ``object_type``, so what each preset 
+        covers is controlled entirely by those declarations.
 
     Raises:
         ValueError: If ``object_type`` is unknown, or if ``fields_spec``
@@ -232,8 +228,6 @@ def parse_fields_spec(
         )
     if not fields_spec:
         fields_spec = "narrow"
-    if fields_spec == "full":
-        return None
     if fields_spec in _PRESET_NAMES:
         allow = _fields_with_preset(object_type, fields_spec)
         if not allow:
@@ -247,43 +241,36 @@ def parse_fields_spec(
     return allow
 
 
-def should_run_mechanism(allow: Optional[Set[str]], flag: str) -> bool:
+def should_run_mechanism(allow: Set[str], flag: str) -> bool:
     """Return whether the mechanism gated by ``flag`` should run.
 
     Args:
         allow: The resolved allowlist from :func:`parse_fields_spec`.
-            ``None`` means "no filtering / full preset" — every
-            mechanism runs.
         flag: The underscore-prefixed flag field name (e.g. ``"_populate"``,
             ``"_enhance"``).
 
     Returns:
-        True iff the mechanism should run: either ``allow`` is ``None``
-        (default/full) or ``flag`` is explicitly in ``allow`` (narrow
-        preset for vmcp/vnfs; explicit CSV request; etc.).
+        True iff ``flag`` is in ``allow`` — which happens when the
+        selected preset tags the flag (``"full"`` tags every flag;
+        ``"narrow"`` tags the flags whose bundled output the UI needs)
+        or when an explicit CSV allowlist names it.
     """
-    return allow is None or flag in allow
+    return flag in allow
 
 
 def select_item_fields(
-    item: Dict[str, Any], allow: Optional[Set[str]]
+    item: Dict[str, Any], allow: Set[str]
 ) -> Dict[str, Any]:
     """Return a field-selected view of ``item``.
 
-    When ``allow`` is ``None`` the input dict is returned unchanged (the
-    caller must not mutate it — cache values are shared references). When
-    ``allow`` is a set, a fresh dict is returned containing only those keys
-    that both appear in ``item`` and in ``allow`` — safe to mutate.
+    A fresh dict is returned containing only those keys that both
+    appear in ``item`` and in ``allow`` — safe to mutate.
     """
-    if allow is None:
-        return item
     return {k: item[k] for k in item.keys() & allow}
 
 
 def select_items_fields(
-    items: Iterable[Dict[str, Any]], allow: Optional[Set[str]]
+    items: Iterable[Dict[str, Any]], allow: Set[str]
 ) -> List[Dict[str, Any]]:
     """Apply :func:`select_item_fields` to each element; always returns a new list."""
-    if allow is None:
-        return list(items)
     return [select_item_fields(i, allow) for i in items]

--- a/src/skillberry_store/services/field_selection.py
+++ b/src/skillberry_store/services/field_selection.py
@@ -1,117 +1,189 @@
-"""Field-selection helpers for the bulk list endpoints.
+"""Field-selection helpers for the bulk list / search endpoints.
 
-The list endpoints (``GET /snippets/``, ``GET /skills/``, ``GET /tools/``) can
-return slim, list-view-oriented objects when the caller passes
-``?fields=list``, or a caller-defined allowlist via
-``?fields=uuid,name,description,...``. When no ``fields`` param is set the
-endpoints return the full objects — preserving the current behavior for
-every existing consumer (CLI, SDK, MCP).
+The list endpoints (``GET /snippets/``, ``GET /skills/``, ``GET /tools/``,
+``GET /vmcp_servers/``, ``GET /vnfs_servers/``) and the matching search
+endpoints accept an optional ``?fields=`` query param:
 
-The three presets below intentionally omit only the payload-heavy fields
-(snippet ``content``; tool ``params`` / ``returns`` / ``dependencies`` /
-``packaging_params``; skill inlined ``tools`` / ``snippets``). Metadata used
-by list-view UIs stays in.
+* Omitted / empty / ``"full"``  — return the full object (default).
+* A registered **preset name** (currently only ``"list"``) — return the
+  fields tagged with that preset for the object's type.
+* A comma-separated allowlist (``"uuid,name,description"``) — return
+  exactly those fields.
+
+Presets are declared as *per-field tags* rather than per-preset field
+sets: each field of each object type carries zero or more preset labels,
+and the preset resolver returns "all fields carrying that label." Adding
+a new preset is a matter of labelling fields; no changes to the
+resolver are required.
+
+The preset associations live server-side only. Clients (UI, CLI, MCP,
+SDK) only ever send the preset *name* — they never need to know which
+fields it expands to.
 """
 
 from __future__ import annotations
 
 from typing import Any, Dict, Iterable, List, Optional, Set
 
-SNIPPET_LIST_FIELDS: Set[str] = {
-    "uuid",
-    "name",
-    "description",
-    "state",
-    "tags",
-    "version",
-    "extra",
-    "parent",
-    "created_at",
-    "modified_at",
-    "author",
-    "content_type",
+# ─── field-tag tables ──────────────────────────────────────────────────
+#
+# ``FieldTags`` is the shape used per object type: a map from a field
+# name to the set of preset names that field belongs to. Fields not
+# present in the map (or with an empty tag set) are only returned when
+# the caller asks for the full object (``fields=None`` / ``"full"``).
+#
+# The five tables below migrate the legacy ``*_LIST_FIELDS`` sets: every
+# field previously in that set is tagged ``{"list"}``, every other
+# field carries no tag.
+
+FieldTags = Dict[str, Set[str]]
+
+SNIPPET_FIELD_TAGS: FieldTags = {
+    "uuid":         {"list"},
+    "name":         {"list"},
+    "description":  {"list"},
+    "state":        {"list"},
+    "tags":         {"list"},
+    "version":      {"list"},
+    "extra":        {"list"},
+    "parent":       {"list"},
+    "created_at":   {"list"},
+    "modified_at":  {"list"},
+    "author":       {"list"},
+    "content_type": {"list"},
+    # "content" — heavy payload; omitted from the "list" preset.
 }
 
-TOOL_LIST_FIELDS: Set[str] = {
-    "uuid",
-    "name",
-    "description",
-    "state",
-    "tags",
-    "version",
-    "extra",
-    "parent",
-    "created_at",
-    "modified_at",
-    "author",
-    "module_name",
-    "programming_language",
-    "packaging_format",
+TOOL_FIELD_TAGS: FieldTags = {
+    "uuid":                 {"list"},
+    "name":                 {"list"},
+    "description":          {"list"},
+    "state":                {"list"},
+    "tags":                 {"list"},
+    "version":              {"list"},
+    "extra":                {"list"},
+    "parent":               {"list"},
+    "created_at":           {"list"},
+    "modified_at":          {"list"},
+    "author":               {"list"},
+    "module_name":          {"list"},
+    "programming_language": {"list"},
+    "packaging_format":     {"list"},
+    # "params" / "returns" / "dependencies" / "packaging_params" —
+    # heavy; omitted from the "list" preset.
 }
 
-SKILL_LIST_FIELDS: Set[str] = {
-    "uuid",
-    "name",
-    "description",
-    "state",
-    "tags",
-    "version",
-    "extra",
-    "parent",
-    "created_at",
-    "modified_at",
-    "author",
-    "tool_uuids",
-    "snippet_uuids",
+SKILL_FIELD_TAGS: FieldTags = {
+    "uuid":          {"list"},
+    "name":          {"list"},
+    "description":   {"list"},
+    "state":         {"list"},
+    "tags":          {"list"},
+    "version":       {"list"},
+    "extra":         {"list"},
+    "parent":        {"list"},
+    "created_at":    {"list"},
+    "modified_at":   {"list"},
+    "author":        {"list"},
+    "tool_uuids":    {"list"},
+    "snippet_uuids": {"list"},
+    # Populated "tools" / "snippets" arrays are inlined by
+    # ``SkillsService.populate_objects`` at get-time; the list preset
+    # deliberately omits them so callers use ``tool_uuids`` /
+    # ``snippet_uuids``.
 }
 
-# vMCP / vNFS list presets include the runtime-status fields (``running``,
-# ``runtime`` for vMCP; ``running``, ``export_path`` for vNFS) — the list UI
-# depends on them.
-VMCP_LIST_FIELDS: Set[str] = {
-    "uuid",
-    "name",
-    "description",
-    "state",
-    "tags",
-    "version",
-    "extra",
-    "parent",
-    "created_at",
-    "modified_at",
-    "author",
-    "port",
-    "skill_uuid",
-    "running",
-    "runtime",
+# vMCP / vNFS list presets include the runtime-status fields
+# (``running``, ``runtime`` for vMCP; ``running``, ``export_path`` for
+# vNFS) — the list UI depends on them.
+
+VMCP_FIELD_TAGS: FieldTags = {
+    "uuid":        {"list"},
+    "name":        {"list"},
+    "description": {"list"},
+    "state":       {"list"},
+    "tags":        {"list"},
+    "version":     {"list"},
+    "extra":       {"list"},
+    "parent":      {"list"},
+    "created_at":  {"list"},
+    "modified_at": {"list"},
+    "author":      {"list"},
+    "port":        {"list"},
+    "skill_uuid":  {"list"},
+    "running":     {"list"},
+    "runtime":     {"list"},
 }
 
-VNFS_LIST_FIELDS: Set[str] = {
-    "uuid",
-    "name",
-    "description",
-    "state",
-    "tags",
-    "version",
-    "extra",
-    "parent",
-    "created_at",
-    "modified_at",
-    "author",
-    "port",
-    "skill_uuid",
-    "protocol",
-    "running",
-    "export_path",
+VNFS_FIELD_TAGS: FieldTags = {
+    "uuid":        {"list"},
+    "name":        {"list"},
+    "description": {"list"},
+    "state":       {"list"},
+    "tags":        {"list"},
+    "version":     {"list"},
+    "extra":       {"list"},
+    "parent":      {"list"},
+    "created_at":  {"list"},
+    "modified_at": {"list"},
+    "author":      {"list"},
+    "port":        {"list"},
+    "skill_uuid":  {"list"},
+    "protocol":    {"list"},
+    "running":     {"list"},
+    "export_path": {"list"},
 }
 
-_LIST_PRESETS: Dict[str, Set[str]] = {
-    "snippet": SNIPPET_LIST_FIELDS,
-    "tool": TOOL_LIST_FIELDS,
-    "skill": SKILL_LIST_FIELDS,
-    "vmcp": VMCP_LIST_FIELDS,
-    "vnfs": VNFS_LIST_FIELDS,
+_FIELD_TAGS_BY_TYPE: Dict[str, FieldTags] = {
+    "snippet": SNIPPET_FIELD_TAGS,
+    "tool":    TOOL_FIELD_TAGS,
+    "skill":   SKILL_FIELD_TAGS,
+    "vmcp":    VMCP_FIELD_TAGS,
+    "vnfs":    VNFS_FIELD_TAGS,
 }
+
+
+# ─── preset resolution ─────────────────────────────────────────────────
+
+
+def _fields_with_preset(object_type: str, preset: str) -> Set[str]:
+    """Return the set of fields tagged with ``preset`` for ``object_type``.
+
+    Raises:
+        ValueError: If ``object_type`` has no registered field-tag table.
+    """
+    tags = _FIELD_TAGS_BY_TYPE.get(object_type)
+    if tags is None:
+        raise ValueError(
+            f"No field tags registered for object type '{object_type}'"
+        )
+    return {name for name, presets in tags.items() if preset in presets}
+
+
+def _all_known_presets() -> Set[str]:
+    """Union of every preset name declared anywhere in the tag registry."""
+    seen: Set[str] = set()
+    for tags in _FIELD_TAGS_BY_TYPE.values():
+        for names in tags.values():
+            seen |= names
+    return seen
+
+
+# ─── back-compat computed constants ────────────────────────────────────
+#
+# These retain the pre-refactor names/values so any importer (currently
+# only the server-side tests) keeps working. They are *derived* from the
+# tag tables — the single source of truth for the "list" preset is now
+# the ``{"list"}`` label on each field above.
+
+SNIPPET_LIST_FIELDS: Set[str] = _fields_with_preset("snippet", "list")
+TOOL_LIST_FIELDS:    Set[str] = _fields_with_preset("tool",    "list")
+SKILL_LIST_FIELDS:   Set[str] = _fields_with_preset("skill",   "list")
+VMCP_LIST_FIELDS:    Set[str] = _fields_with_preset("vmcp",    "list")
+VNFS_LIST_FIELDS:    Set[str] = _fields_with_preset("vnfs",    "list")
+
+
+# ─── public API ────────────────────────────────────────────────────────
 
 
 def parse_fields_spec(
@@ -120,30 +192,32 @@ def parse_fields_spec(
     """Resolve a ``fields`` query-param value to a concrete field allowlist.
 
     Args:
-        fields_spec: Raw value from the query string. ``None``, empty, or
+        fields_spec: Raw value from the query string. ``None`` / empty /
             ``"full"`` means "no field selection — return every field".
-            ``"list"`` selects the per-type preset. Any other value is parsed
-            as a comma-separated allowlist.
-        object_type: Object-type key (``"snippet"``, ``"tool"``, ``"skill"``).
-            Only consulted when ``fields_spec == "list"``.
+            A registered preset name (matches any tag in the field-tag
+            tables) selects the tagged fields for ``object_type``. Any
+            other value is parsed as a comma-separated allowlist.
+        object_type: Object-type key (``"snippet"``, ``"tool"``,
+            ``"skill"``, ``"vmcp"``, ``"vnfs"``).
 
     Returns:
-        The set of field names to keep, or ``None`` when no field selection
-        should be applied.
+        The set of field names to keep, or ``None`` when no field
+        selection should be applied.
 
     Raises:
-        ValueError: If ``fields_spec == "list"`` but no preset is registered
-            for ``object_type``.
+        ValueError: If ``fields_spec`` matches a registered preset name
+            but that preset is not declared for ``object_type`` (i.e.
+            no field of ``object_type`` carries that tag).
     """
     if not fields_spec or fields_spec == "full":
         return None
-    if fields_spec == "list":
-        preset = _LIST_PRESETS.get(object_type)
-        if preset is None:
+    if fields_spec in _all_known_presets():
+        allow = _fields_with_preset(object_type, fields_spec)
+        if not allow:
             raise ValueError(
-                f"No list preset registered for object type '{object_type}'"
+                f"No '{fields_spec}' preset registered for object type '{object_type}'"
             )
-        return set(preset)
+        return allow
     allow = {f.strip() for f in fields_spec.split(",") if f.strip()}
     return allow or None
 

--- a/src/skillberry_store/services/list_projections.py
+++ b/src/skillberry_store/services/list_projections.py
@@ -1,0 +1,130 @@
+"""Field-projection helpers for the bulk list endpoints.
+
+The list endpoints (``GET /snippets/``, ``GET /skills/``, ``GET /tools/``) can
+return slim, list-view-oriented objects when the caller passes
+``?fields=list``, or a caller-defined allowlist via
+``?fields=uuid,name,description,...``. When no ``fields`` param is set the
+endpoints return the full objects — preserving the current behavior for
+every existing consumer (CLI, SDK, MCP).
+
+The three presets below intentionally omit only the payload-heavy fields
+(snippet ``content``; tool ``params`` / ``returns`` / ``dependencies`` /
+``packaging_params``; skill inlined ``tools`` / ``snippets``). Metadata used
+by list-view UIs stays in.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional, Set
+
+SNIPPET_LIST_FIELDS: Set[str] = {
+    "uuid",
+    "name",
+    "description",
+    "state",
+    "tags",
+    "version",
+    "extra",
+    "parent",
+    "created_at",
+    "modified_at",
+    "author",
+    "content_type",
+}
+
+TOOL_LIST_FIELDS: Set[str] = {
+    "uuid",
+    "name",
+    "description",
+    "state",
+    "tags",
+    "version",
+    "extra",
+    "parent",
+    "created_at",
+    "modified_at",
+    "author",
+    "module_name",
+    "programming_language",
+    "packaging_format",
+}
+
+SKILL_LIST_FIELDS: Set[str] = {
+    "uuid",
+    "name",
+    "description",
+    "state",
+    "tags",
+    "version",
+    "extra",
+    "parent",
+    "created_at",
+    "modified_at",
+    "author",
+    "tool_uuids",
+    "snippet_uuids",
+}
+
+_LIST_PRESETS: Dict[str, Set[str]] = {
+    "snippet": SNIPPET_LIST_FIELDS,
+    "tool": TOOL_LIST_FIELDS,
+    "skill": SKILL_LIST_FIELDS,
+}
+
+
+def parse_fields_spec(
+    fields_spec: Optional[str], object_type: str
+) -> Optional[Set[str]]:
+    """Resolve a ``fields`` query-param value to a concrete field allowlist.
+
+    Args:
+        fields_spec: Raw value from the query string. ``None``, empty, or
+            ``"full"`` means "no projection — return every field". ``"list"``
+            selects the per-type preset. Any other value is parsed as a
+            comma-separated allowlist.
+        object_type: Object-type key (``"snippet"``, ``"tool"``, ``"skill"``).
+            Only consulted when ``fields_spec == "list"``.
+
+    Returns:
+        The set of field names to keep, or ``None`` when no projection
+        should be applied.
+
+    Raises:
+        ValueError: If ``fields_spec == "list"`` but no preset is registered
+            for ``object_type``.
+    """
+    if not fields_spec or fields_spec == "full":
+        return None
+    if fields_spec == "list":
+        preset = _LIST_PRESETS.get(object_type)
+        if preset is None:
+            raise ValueError(
+                f"No list preset registered for object type '{object_type}'"
+            )
+        return set(preset)
+    allow = {f.strip() for f in fields_spec.split(",") if f.strip()}
+    return allow or None
+
+
+def project_item(
+    item: Dict[str, Any], allow: Optional[Set[str]]
+) -> Dict[str, Any]:
+    """Return a projected view of ``item``.
+
+    When ``allow`` is ``None`` the input dict is returned unchanged (the
+    caller must not mutate it — cache values are shared references). When
+    ``allow`` is a set, a fresh dict is returned containing only those keys
+    that both appear in ``item`` and in ``allow`` — safe to mutate.
+    """
+    if allow is None:
+        return item
+    return {k: item[k] for k in item.keys() & allow}
+
+
+def project_items(
+    items: Iterable[Dict[str, Any]], allow: Optional[Set[str]]
+) -> List[Dict[str, Any]]:
+    """Apply :func:`project_item` to each element; always returns a new list."""
+    if allow is None:
+        return list(items)
+    return [project_item(i, allow) for i in items]

--- a/src/skillberry_store/services/skills_service.py
+++ b/src/skillberry_store/services/skills_service.py
@@ -294,18 +294,25 @@ class SkillsService:
     ) -> List[Dict[str, Any]]:
         """List all skills with optional filtering and field selection.
 
-        With no ``fields`` (or ``"full"``), each skill dict is returned with
-        its ``tool_uuids`` and ``snippet_uuids`` resolved into inlined
-        ``tools`` / ``snippets`` objects (current behavior, but on fresh
-        copies so the shared cache values are never mutated). With
-        ``fields="list"`` (or a custom allowlist), ``populate_objects`` is
-        skipped entirely — callers get the raw ``tool_uuids`` /
-        ``snippet_uuids`` lists and can size them with ``.length``.
+        Field-selection semantics (see
+        :mod:`skillberry_store.services.field_selection`):
+
+        * ``fields`` omitted / ``"full"`` — every field is returned, and
+          the ``_populate`` mechanism runs (``tool_uuids`` /
+          ``snippet_uuids`` are resolved into inlined ``tools`` /
+          ``snippets`` full objects).
+        * ``fields="narrow"`` — the minimal set the UI listing page
+          renders (uuid, name, description, state, tags, version,
+          tool_uuids, snippet_uuids). ``_populate`` is *not* tagged in
+          narrow, so no inlining runs.
+        * ``fields="wide"`` — every persisted manifest field, but no
+          flag fields → no inlining.
+        * Explicit CSV allowlist — inlining runs iff ``"_populate"`` is
+          in the allowlist.
 
         Args:
             filters: Optional dictionary of field:value pairs to filter by.
-            fields: Optional field-selection spec (``None`` / ``"full"`` /
-                ``"list"`` / comma-separated allowlist).
+            fields: Optional field-selection spec.
 
         Returns:
             List[Dict[str, Any]]: Skill metadata dictionaries sorted by
@@ -314,6 +321,7 @@ class SkillsService:
         from skillberry_store.services.field_selection import (
             parse_fields_spec,
             select_items_fields,
+            should_run_mechanism,
         )
 
         list_skills_counter.inc()
@@ -325,7 +333,7 @@ class SkillsService:
                 ]
             items.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
             allow = parse_fields_spec(fields, "skill")
-            if allow is None:
+            if should_run_mechanism(allow, "_populate"):
                 enriched: List[Dict[str, Any]] = []
                 for item in items:
                     fresh = dict(item)
@@ -336,7 +344,7 @@ class SkillsService:
                         fresh.setdefault("tools", [])
                         fresh.setdefault("snippets", [])
                     enriched.append(fresh)
-                return enriched
+                return select_items_fields(enriched, allow)
             return select_items_fields(items, allow)
         except Exception as e:
             logger.error(f"Error listing skills: {e}")
@@ -368,21 +376,18 @@ class SkillsService:
                 (e.g. ``"tags:python"``, ``"state:approved"``).
             lifecycle_state: Lifecycle state filter. Defaults to
                 ``LifecycleState.ANY`` when ``None`` is passed.
-            fields: Optional field-selection spec. When ``None`` (default),
-                each match is returned as the legacy
-                ``{"filename", "similarity_score"}`` pair (``filename`` is the
-                skill UUID for parity with the previous behavior). Otherwise
-                the same grammar as list field-selection applies (``"list"``
-                / ``"full"`` / comma-separated allowlist) and each match is
-                returned as a field-selected skill dict with
-                ``similarity_score`` merged in. In line with ``list_all``,
-                the field-selected path does not populate the inlined
-                ``tools`` / ``snippets`` arrays — callers that need those
-                should fetch each skill by UUID.
+            fields: Optional field-selection spec — same grammar as
+                :meth:`list_all` (``None`` / ``"full"`` / ``"narrow"`` /
+                ``"wide"`` / CSV allowlist). Each match is a
+                field-selected skill dict with ``similarity_score``
+                merged in. Default (``None``) is ``"full"`` — the
+                ``_populate`` mechanism runs and ``tools`` / ``snippets``
+                are inlined.
 
         Returns:
             List[Dict[str, Any]]: Matches sorted by ``modified_at`` desc.
-                Shape depends on ``fields`` (see above).
+                Each entry is a field-selected skill dict plus a
+                ``similarity_score`` key.
 
         Raises:
             RuntimeError: If the service was constructed without a
@@ -393,6 +398,7 @@ class SkillsService:
         from skillberry_store.services.field_selection import (
             parse_fields_spec,
             select_item_fields,
+            should_run_mechanism,
         )
 
         search_skills_counter.inc()
@@ -432,16 +438,15 @@ class SkillsService:
                 lifecycle_state=lifecycle_state,
             )
             filtered_skills.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
-            if fields is None:
-                return [
-                    {
-                        "filename": s.get("name", ""),
-                        "similarity_score": s.get("similarity_score", 0.0),
-                    }
-                    for s in filtered_skills
-                    if s.get("name")
-                ]
             allow = parse_fields_spec(fields, "skill")
+            if should_run_mechanism(allow, "_populate"):
+                for s in filtered_skills:
+                    try:
+                        self.populate_objects(s)
+                    except RuntimeError as e:
+                        logger.warning(str(e))
+                        s.setdefault("tools", [])
+                        s.setdefault("snippets", [])
             return [
                 {
                     **select_item_fields(s, allow),

--- a/src/skillberry_store/services/skills_service.py
+++ b/src/skillberry_store/services/skills_service.py
@@ -287,16 +287,35 @@ class SkillsService:
             logger.error(f"Error retrieving skill '{uuid_or_name}': {e}")
             raise
 
-    def list_all(self, filters: Optional[Dict] = None) -> List[Dict[str, Any]]:
-        """List all skills with optional filtering and populated objects.
+    def list_all(
+        self,
+        filters: Optional[Dict] = None,
+        fields: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """List all skills with optional filtering and field projection.
+
+        With no ``fields`` (or ``"full"``), each skill dict is returned with
+        its ``tool_uuids`` and ``snippet_uuids`` resolved into inlined
+        ``tools`` / ``snippets`` objects (current behavior, but on fresh
+        copies so the shared cache values are never mutated). With
+        ``fields="list"`` (or a custom allowlist), ``populate_objects`` is
+        skipped entirely — callers get the raw ``tool_uuids`` /
+        ``snippet_uuids`` lists and can size them with ``.length``.
 
         Args:
             filters: Optional dictionary of field:value pairs to filter by.
+            fields: Optional projection spec (``None`` / ``"full"`` /
+                ``"list"`` / comma-separated allowlist).
 
         Returns:
-            List[Dict[str, Any]]: List of skill metadata dictionaries with tools and snippets populated,
-                                  sorted by modified_at descending.
+            List[Dict[str, Any]]: Skill metadata dictionaries sorted by
+                modified_at descending.
         """
+        from skillberry_store.services.list_projections import (
+            parse_fields_spec,
+            project_items,
+        )
+
         list_skills_counter.inc()
         try:
             items = self.handler.list_all_dicts()
@@ -304,15 +323,21 @@ class SkillsService:
                 items = [
                     i for i in items if all(i.get(k) == v for k, v in filters.items())
                 ]
-            for item in items:
-                try:
-                    self.populate_objects(item)
-                except RuntimeError as e:
-                    logger.warning(str(e))
-                    item.setdefault("tools", [])
-                    item.setdefault("snippets", [])
             items.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
-            return items
+            allow = parse_fields_spec(fields, "skill")
+            if allow is None:
+                enriched: List[Dict[str, Any]] = []
+                for item in items:
+                    fresh = dict(item)
+                    try:
+                        self.populate_objects(fresh)
+                    except RuntimeError as e:
+                        logger.warning(str(e))
+                        fresh.setdefault("tools", [])
+                        fresh.setdefault("snippets", [])
+                    enriched.append(fresh)
+                return enriched
+            return project_items(items, allow)
         except Exception as e:
             logger.error(f"Error listing skills: {e}")
             raise

--- a/src/skillberry_store/services/skills_service.py
+++ b/src/skillberry_store/services/skills_service.py
@@ -297,14 +297,14 @@ class SkillsService:
         Field-selection semantics (see
         :mod:`skillberry_store.services.field_selection`):
 
-        * ``fields`` omitted / ``"full"`` — every field is returned, and
-          the ``_populate`` mechanism runs (``tool_uuids`` /
+        * ``fields`` omitted / ``"narrow"`` — the minimal set the UI
+          listing page renders (uuid, name, description, state, tags,
+          version, tool_uuids, snippet_uuids). ``_populate`` is *not*
+          tagged in narrow, so no inlining runs. This is the default.
+        * ``fields="full"`` — every field is returned, and the
+          ``_populate`` mechanism runs (``tool_uuids`` /
           ``snippet_uuids`` are resolved into inlined ``tools`` /
           ``snippets`` full objects).
-        * ``fields="narrow"`` — the minimal set the UI listing page
-          renders (uuid, name, description, state, tags, version,
-          tool_uuids, snippet_uuids). ``_populate`` is *not* tagged in
-          narrow, so no inlining runs.
         * ``fields="wide"`` — every persisted manifest field, but no
           flag fields → no inlining.
         * Explicit CSV allowlist — inlining runs iff ``"_populate"`` is
@@ -377,12 +377,14 @@ class SkillsService:
             lifecycle_state: Lifecycle state filter. Defaults to
                 ``LifecycleState.ANY`` when ``None`` is passed.
             fields: Optional field-selection spec — same grammar as
-                :meth:`list_all` (``None`` / ``"full"`` / ``"narrow"`` /
-                ``"wide"`` / CSV allowlist). Each match is a
+                :meth:`list_all` (``None`` / ``"narrow"`` / ``"wide"``
+                / ``"full"`` / CSV allowlist). Each match is a
                 field-selected skill dict with ``similarity_score``
-                merged in. Default (``None``) is ``"full"`` — the
-                ``_populate`` mechanism runs and ``tools`` / ``snippets``
-                are inlined.
+                merged in. Default (``None``) resolves to ``"narrow"``
+                — the ``_populate`` mechanism does NOT run under
+                narrow; callers read ``tool_uuids`` / ``snippet_uuids``
+                for counts. Pass ``"full"`` to inline ``tools`` /
+                ``snippets``.
 
         Returns:
             List[Dict[str, Any]]: Matches sorted by ``modified_at`` desc.

--- a/src/skillberry_store/services/skills_service.py
+++ b/src/skillberry_store/services/skills_service.py
@@ -292,7 +292,7 @@ class SkillsService:
         filters: Optional[Dict] = None,
         fields: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
-        """List all skills with optional filtering and field projection.
+        """List all skills with optional filtering and field selection.
 
         With no ``fields`` (or ``"full"``), each skill dict is returned with
         its ``tool_uuids`` and ``snippet_uuids`` resolved into inlined
@@ -304,16 +304,16 @@ class SkillsService:
 
         Args:
             filters: Optional dictionary of field:value pairs to filter by.
-            fields: Optional projection spec (``None`` / ``"full"`` /
+            fields: Optional field-selection spec (``None`` / ``"full"`` /
                 ``"list"`` / comma-separated allowlist).
 
         Returns:
             List[Dict[str, Any]]: Skill metadata dictionaries sorted by
                 modified_at descending.
         """
-        from skillberry_store.services.list_projections import (
+        from skillberry_store.services.field_selection import (
             parse_fields_spec,
-            project_items,
+            select_items_fields,
         )
 
         list_skills_counter.inc()
@@ -337,7 +337,7 @@ class SkillsService:
                         fresh.setdefault("snippets", [])
                     enriched.append(fresh)
                 return enriched
-            return project_items(items, allow)
+            return select_items_fields(items, allow)
         except Exception as e:
             logger.error(f"Error listing skills: {e}")
             raise
@@ -368,14 +368,15 @@ class SkillsService:
                 (e.g. ``"tags:python"``, ``"state:approved"``).
             lifecycle_state: Lifecycle state filter. Defaults to
                 ``LifecycleState.ANY`` when ``None`` is passed.
-            fields: Optional projection spec. When ``None`` (default), each
-                match is returned as the legacy ``{"filename", "similarity_score"}``
-                pair (``filename`` is the skill UUID for parity with the
-                previous behavior). Otherwise the same grammar as list
-                projection applies (``"list"`` / ``"full"`` / comma-separated
-                allowlist) and each match is returned as a projected skill
-                dict with ``similarity_score`` merged in. In line with
-                ``list_all``, the projected path does not populate the inlined
+            fields: Optional field-selection spec. When ``None`` (default),
+                each match is returned as the legacy
+                ``{"filename", "similarity_score"}`` pair (``filename`` is the
+                skill UUID for parity with the previous behavior). Otherwise
+                the same grammar as list field-selection applies (``"list"``
+                / ``"full"`` / comma-separated allowlist) and each match is
+                returned as a field-selected skill dict with
+                ``similarity_score`` merged in. In line with ``list_all``,
+                the field-selected path does not populate the inlined
                 ``tools`` / ``snippets`` arrays — callers that need those
                 should fetch each skill by UUID.
 
@@ -389,9 +390,9 @@ class SkillsService:
         """
         from skillberry_store.modules.lifecycle import LifecycleState
         from skillberry_store.fast_api.search_filters import apply_search_filters
-        from skillberry_store.services.list_projections import (
+        from skillberry_store.services.field_selection import (
             parse_fields_spec,
-            project_item,
+            select_item_fields,
         )
 
         search_skills_counter.inc()
@@ -443,7 +444,7 @@ class SkillsService:
             allow = parse_fields_spec(fields, "skill")
             return [
                 {
-                    **project_item(s, allow),
+                    **select_item_fields(s, allow),
                     "similarity_score": s.get("similarity_score", 0.0),
                 }
                 for s in filtered_skills

--- a/src/skillberry_store/services/skills_service.py
+++ b/src/skillberry_store/services/skills_service.py
@@ -349,6 +349,7 @@ class SkillsService:
         similarity_threshold: float = 1.0,
         manifest_filter: str = ".",
         lifecycle_state: Optional["LifecycleState"] = None,
+        fields: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """Search skills by semantic similarity to a search term.
 
@@ -367,9 +368,20 @@ class SkillsService:
                 (e.g. ``"tags:python"``, ``"state:approved"``).
             lifecycle_state: Lifecycle state filter. Defaults to
                 ``LifecycleState.ANY`` when ``None`` is passed.
+            fields: Optional projection spec. When ``None`` (default), each
+                match is returned as the legacy ``{"filename", "similarity_score"}``
+                pair (``filename`` is the skill UUID for parity with the
+                previous behavior). Otherwise the same grammar as list
+                projection applies (``"list"`` / ``"full"`` / comma-separated
+                allowlist) and each match is returned as a projected skill
+                dict with ``similarity_score`` merged in. In line with
+                ``list_all``, the projected path does not populate the inlined
+                ``tools`` / ``snippets`` arrays — callers that need those
+                should fetch each skill by UUID.
 
         Returns:
-            List[Dict[str, Any]]: Matches, each ``{"filename": <name>, "similarity_score": <float>}``.
+            List[Dict[str, Any]]: Matches sorted by ``modified_at`` desc.
+                Shape depends on ``fields`` (see above).
 
         Raises:
             RuntimeError: If the service was constructed without a
@@ -377,6 +389,10 @@ class SkillsService:
         """
         from skillberry_store.modules.lifecycle import LifecycleState
         from skillberry_store.fast_api.search_filters import apply_search_filters
+        from skillberry_store.services.list_projections import (
+            parse_fields_spec,
+            project_item,
+        )
 
         search_skills_counter.inc()
         try:
@@ -401,11 +417,12 @@ class SkillsService:
                 if not skill_uuid:
                     continue
                 try:
-                    skill_dict = self.handler.read_dict(skill_uuid)
-                    skill_dict["similarity_score"] = matched.get(
+                    fetched = self.handler.read_dict(skill_uuid)
+                    candidate = dict(fetched)
+                    candidate["similarity_score"] = matched.get(
                         "similarity_score", 0.0
                     )
-                    candidates.append(skill_dict)
+                    candidates.append(candidate)
                 except Exception as e:
                     logger.warning(f"Could not load skill {skill_uuid}: {e}")
             filtered_skills = apply_search_filters(
@@ -414,9 +431,19 @@ class SkillsService:
                 lifecycle_state=lifecycle_state,
             )
             filtered_skills.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
+            if fields is None:
+                return [
+                    {
+                        "filename": s.get("name", ""),
+                        "similarity_score": s.get("similarity_score", 0.0),
+                    }
+                    for s in filtered_skills
+                    if s.get("name")
+                ]
+            allow = parse_fields_spec(fields, "skill")
             return [
                 {
-                    "filename": s.get("name", ""),
+                    **project_item(s, allow),
                     "similarity_score": s.get("similarity_score", 0.0),
                 }
                 for s in filtered_skills

--- a/src/skillberry_store/services/snippets_service.py
+++ b/src/skillberry_store/services/snippets_service.py
@@ -202,23 +202,23 @@ class SnippetsService:
         filters: Optional[Dict] = None,
         fields: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
-        """List all snippets with optional filtering and field projection.
+        """List all snippets with optional filtering and field selection.
 
         Args:
             filters: Optional dictionary of field:value pairs to filter by.
-            fields: Optional projection spec. ``None`` or ``"full"`` returns
-                every field (current behavior). ``"list"`` returns the slim
-                per-type preset (drops the heavy ``content`` field). A
-                comma-separated string selects a caller-defined allowlist.
+            fields: Optional field-selection spec. ``None`` or ``"full"``
+                returns every field (current behavior). ``"list"`` returns
+                the slim per-type preset (drops the heavy ``content`` field).
+                A comma-separated string selects a caller-defined allowlist.
 
         Returns:
             List[Dict[str, Any]]: List of snippet metadata dictionaries,
-                sorted by modified_at descending. Fields are projected
+                sorted by modified_at descending. Fields are filtered
                 according to ``fields``.
         """
-        from skillberry_store.services.list_projections import (
+        from skillberry_store.services.field_selection import (
             parse_fields_spec,
-            project_items,
+            select_items_fields,
         )
 
         list_snippets_counter.inc()
@@ -230,7 +230,7 @@ class SnippetsService:
                 ]
             items.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
             allow = parse_fields_spec(fields, "snippet")
-            return project_items(items, allow)
+            return select_items_fields(items, allow)
         except Exception as e:
             logger.error(f"Error listing snippets: {e}")
             raise
@@ -261,11 +261,12 @@ class SnippetsService:
                 (e.g. ``"tags:python"``, ``"state:approved"``).
             lifecycle_state: Lifecycle state filter. Defaults to
                 ``LifecycleState.ANY`` when ``None`` is passed.
-            fields: Optional projection spec. When ``None`` (default), each
-                match is returned as the legacy ``{"filename", "similarity_score"}``
-                pair. Otherwise the same grammar as list projection applies
-                (``"list"`` / ``"full"`` / comma-separated allowlist) and each
-                match is returned as a projected snippet dict with
+            fields: Optional field-selection spec. When ``None`` (default),
+                each match is returned as the legacy
+                ``{"filename", "similarity_score"}`` pair. Otherwise the same
+                grammar as list field-selection applies (``"list"`` /
+                ``"full"`` / comma-separated allowlist) and each match is
+                returned as a field-selected snippet dict with
                 ``similarity_score`` merged in.
 
         Returns:
@@ -278,9 +279,9 @@ class SnippetsService:
         """
         from skillberry_store.modules.lifecycle import LifecycleState
         from skillberry_store.fast_api.search_filters import apply_search_filters
-        from skillberry_store.services.list_projections import (
+        from skillberry_store.services.field_selection import (
             parse_fields_spec,
-            project_item,
+            select_item_fields,
         )
 
         search_snippets_counter.inc()
@@ -328,7 +329,7 @@ class SnippetsService:
             allow = parse_fields_spec(fields, "snippet")
             return [
                 {
-                    **project_item(s, allow),
+                    **select_item_fields(s, allow),
                     "similarity_score": s.get("similarity_score", 0.0),
                 }
                 for s in result_snippets

--- a/src/skillberry_store/services/snippets_service.py
+++ b/src/skillberry_store/services/snippets_service.py
@@ -242,6 +242,7 @@ class SnippetsService:
         similarity_threshold: float = 1.0,
         manifest_filter: str = ".",
         lifecycle_state: Optional["LifecycleState"] = None,
+        fields: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """Search snippets by semantic similarity to a search term.
 
@@ -260,9 +261,16 @@ class SnippetsService:
                 (e.g. ``"tags:python"``, ``"state:approved"``).
             lifecycle_state: Lifecycle state filter. Defaults to
                 ``LifecycleState.ANY`` when ``None`` is passed.
+            fields: Optional projection spec. When ``None`` (default), each
+                match is returned as the legacy ``{"filename", "similarity_score"}``
+                pair. Otherwise the same grammar as list projection applies
+                (``"list"`` / ``"full"`` / comma-separated allowlist) and each
+                match is returned as a projected snippet dict with
+                ``similarity_score`` merged in.
 
         Returns:
-            List[Dict[str, Any]]: Matches, each ``{"filename": <name>, "similarity_score": <float>}``.
+            List[Dict[str, Any]]: Matches sorted by ``modified_at`` desc.
+                Shape depends on ``fields`` (see above).
 
         Raises:
             RuntimeError: If the service was constructed without a
@@ -270,6 +278,10 @@ class SnippetsService:
         """
         from skillberry_store.modules.lifecycle import LifecycleState
         from skillberry_store.fast_api.search_filters import apply_search_filters
+        from skillberry_store.services.list_projections import (
+            parse_fields_spec,
+            project_item,
+        )
 
         search_snippets_counter.inc()
         try:
@@ -292,9 +304,10 @@ class SnippetsService:
                 if not name:
                     continue
                 try:
-                    d = self.get(name)
-                    d["similarity_score"] = m.get("similarity_score", 0.0)
-                    candidates.append(d)
+                    fetched = self.get(name)
+                    candidate = dict(fetched)
+                    candidate["similarity_score"] = m.get("similarity_score", 0.0)
+                    candidates.append(candidate)
                 except Exception:
                     pass
             result_snippets = apply_search_filters(
@@ -303,9 +316,19 @@ class SnippetsService:
                 lifecycle_state=lifecycle_state,
             )
             result_snippets.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
+            if fields is None:
+                return [
+                    {
+                        "filename": s.get("name", ""),
+                        "similarity_score": s.get("similarity_score", 0.0),
+                    }
+                    for s in result_snippets
+                    if s.get("name")
+                ]
+            allow = parse_fields_spec(fields, "snippet")
             return [
                 {
-                    "filename": s.get("name", ""),
+                    **project_item(s, allow),
                     "similarity_score": s.get("similarity_score", 0.0),
                 }
                 for s in result_snippets

--- a/src/skillberry_store/services/snippets_service.py
+++ b/src/skillberry_store/services/snippets_service.py
@@ -197,15 +197,30 @@ class SnippetsService:
             logger.error(f"Error retrieving snippet '{uuid_or_name}': {e}")
             raise
 
-    def list_all(self, filters: Optional[Dict] = None) -> List[Dict[str, Any]]:
-        """List all snippets with optional filtering.
+    def list_all(
+        self,
+        filters: Optional[Dict] = None,
+        fields: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """List all snippets with optional filtering and field projection.
 
         Args:
             filters: Optional dictionary of field:value pairs to filter by.
+            fields: Optional projection spec. ``None`` or ``"full"`` returns
+                every field (current behavior). ``"list"`` returns the slim
+                per-type preset (drops the heavy ``content`` field). A
+                comma-separated string selects a caller-defined allowlist.
 
         Returns:
-            List[Dict[str, Any]]: List of snippet metadata dictionaries, sorted by modified_at descending.
+            List[Dict[str, Any]]: List of snippet metadata dictionaries,
+                sorted by modified_at descending. Fields are projected
+                according to ``fields``.
         """
+        from skillberry_store.services.list_projections import (
+            parse_fields_spec,
+            project_items,
+        )
+
         list_snippets_counter.inc()
         try:
             items = self.handler.list_all_dicts()
@@ -214,7 +229,8 @@ class SnippetsService:
                     i for i in items if all(i.get(k) == v for k, v in filters.items())
                 ]
             items.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
-            return items
+            allow = parse_fields_spec(fields, "snippet")
+            return project_items(items, allow)
         except Exception as e:
             logger.error(f"Error listing snippets: {e}")
             raise

--- a/src/skillberry_store/services/snippets_service.py
+++ b/src/skillberry_store/services/snippets_service.py
@@ -206,8 +206,10 @@ class SnippetsService:
 
         Args:
             filters: Optional dictionary of field:value pairs to filter by.
-            fields: Optional field-selection spec (``None`` / ``"full"``
-                / ``"narrow"`` / ``"wide"`` / CSV allowlist). See
+            fields: Optional field-selection spec (``None`` /
+                ``"narrow"`` / ``"wide"`` / ``"full"`` / CSV
+                allowlist). ``None`` and ``"narrow"`` both resolve to
+                the narrow preset (the default). See
                 :mod:`skillberry_store.services.field_selection`.
 
         Returns:
@@ -261,11 +263,11 @@ class SnippetsService:
             lifecycle_state: Lifecycle state filter. Defaults to
                 ``LifecycleState.ANY`` when ``None`` is passed.
             fields: Optional field-selection spec — same grammar as
-                :meth:`list_all` (``None`` / ``"full"`` / ``"narrow"`` /
-                ``"wide"`` / CSV allowlist). Each match is a
+                :meth:`list_all` (``None`` / ``"narrow"`` / ``"wide"``
+                / ``"full"`` / CSV allowlist). Each match is a
                 field-selected snippet dict with ``similarity_score``
-                merged in. Default (``None``) is ``"full"`` — every
-                field is returned.
+                merged in. Default (``None``) resolves to ``"narrow"``
+                — the minimal UI listing set.
 
         Returns:
             List[Dict[str, Any]]: Matches sorted by ``modified_at`` desc.

--- a/src/skillberry_store/services/snippets_service.py
+++ b/src/skillberry_store/services/snippets_service.py
@@ -206,10 +206,9 @@ class SnippetsService:
 
         Args:
             filters: Optional dictionary of field:value pairs to filter by.
-            fields: Optional field-selection spec. ``None`` or ``"full"``
-                returns every field (current behavior). ``"list"`` returns
-                the slim per-type preset (drops the heavy ``content`` field).
-                A comma-separated string selects a caller-defined allowlist.
+            fields: Optional field-selection spec (``None`` / ``"full"``
+                / ``"narrow"`` / ``"wide"`` / CSV allowlist). See
+                :mod:`skillberry_store.services.field_selection`.
 
         Returns:
             List[Dict[str, Any]]: List of snippet metadata dictionaries,
@@ -261,17 +260,17 @@ class SnippetsService:
                 (e.g. ``"tags:python"``, ``"state:approved"``).
             lifecycle_state: Lifecycle state filter. Defaults to
                 ``LifecycleState.ANY`` when ``None`` is passed.
-            fields: Optional field-selection spec. When ``None`` (default),
-                each match is returned as the legacy
-                ``{"filename", "similarity_score"}`` pair. Otherwise the same
-                grammar as list field-selection applies (``"list"`` /
-                ``"full"`` / comma-separated allowlist) and each match is
-                returned as a field-selected snippet dict with
-                ``similarity_score`` merged in.
+            fields: Optional field-selection spec — same grammar as
+                :meth:`list_all` (``None`` / ``"full"`` / ``"narrow"`` /
+                ``"wide"`` / CSV allowlist). Each match is a
+                field-selected snippet dict with ``similarity_score``
+                merged in. Default (``None``) is ``"full"`` — every
+                field is returned.
 
         Returns:
             List[Dict[str, Any]]: Matches sorted by ``modified_at`` desc.
-                Shape depends on ``fields`` (see above).
+                Each entry is a field-selected snippet dict plus a
+                ``similarity_score`` key.
 
         Raises:
             RuntimeError: If the service was constructed without a
@@ -317,15 +316,6 @@ class SnippetsService:
                 lifecycle_state=lifecycle_state,
             )
             result_snippets.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
-            if fields is None:
-                return [
-                    {
-                        "filename": s.get("name", ""),
-                        "similarity_score": s.get("similarity_score", 0.0),
-                    }
-                    for s in result_snippets
-                    if s.get("name")
-                ]
             allow = parse_fields_spec(fields, "snippet")
             return [
                 {

--- a/src/skillberry_store/services/tools_service.py
+++ b/src/skillberry_store/services/tools_service.py
@@ -429,8 +429,10 @@ class ToolsService:
 
         Args:
             filters: Optional dictionary of field:value pairs to filter by.
-            fields: Optional field-selection spec (``None`` / ``"full"``
-                / ``"narrow"`` / ``"wide"`` / CSV allowlist). See
+            fields: Optional field-selection spec (``None`` /
+                ``"narrow"`` / ``"wide"`` / ``"full"`` / CSV
+                allowlist). ``None`` and ``"narrow"`` both resolve to
+                the narrow preset (the default). See
                 :mod:`skillberry_store.services.field_selection`.
 
         Returns:
@@ -485,11 +487,11 @@ class ToolsService:
             lifecycle_state: Lifecycle state filter. Defaults to
                 ``LifecycleState.ANY`` when ``None`` is passed.
             fields: Optional field-selection spec — same grammar as
-                :meth:`list_all` (``None`` / ``"full"`` / ``"narrow"`` /
-                ``"wide"`` / CSV allowlist). Each match is a
-                field-selected tool dict with ``similarity_score`` merged
-                in. Default (``None``) is ``"full"`` — every field is
-                returned.
+                :meth:`list_all` (``None`` / ``"narrow"`` / ``"wide"``
+                / ``"full"`` / CSV allowlist). Each match is a
+                field-selected tool dict with ``similarity_score``
+                merged in. Default (``None``) resolves to ``"narrow"``
+                — the minimal UI listing set.
 
         Returns:
             List[Dict[str, Any]]: Matches sorted by ``modified_at`` desc.

--- a/src/skillberry_store/services/tools_service.py
+++ b/src/skillberry_store/services/tools_service.py
@@ -429,11 +429,9 @@ class ToolsService:
 
         Args:
             filters: Optional dictionary of field:value pairs to filter by.
-            fields: Optional field-selection spec. ``None`` or ``"full"``
-                returns every field (current behavior). ``"list"`` drops the
-                heavy ``params`` / ``returns`` / ``dependencies`` /
-                ``packaging_params`` fields. A comma-separated string
-                selects a caller-defined allowlist.
+            fields: Optional field-selection spec (``None`` / ``"full"``
+                / ``"narrow"`` / ``"wide"`` / CSV allowlist). See
+                :mod:`skillberry_store.services.field_selection`.
 
         Returns:
             List[Dict[str, Any]]: List of tool metadata dictionaries, sorted
@@ -486,17 +484,17 @@ class ToolsService:
                 all entities.
             lifecycle_state: Lifecycle state filter. Defaults to
                 ``LifecycleState.ANY`` when ``None`` is passed.
-            fields: Optional field-selection spec. When ``None`` (default),
-                each match is returned as the legacy
-                ``{"filename", "similarity_score"}`` pair. Otherwise the same
-                grammar as list field-selection applies (``"list"`` /
-                ``"full"`` / comma-separated allowlist) and each match is
-                returned as a field-selected tool dict with
-                ``similarity_score`` merged in.
+            fields: Optional field-selection spec — same grammar as
+                :meth:`list_all` (``None`` / ``"full"`` / ``"narrow"`` /
+                ``"wide"`` / CSV allowlist). Each match is a
+                field-selected tool dict with ``similarity_score`` merged
+                in. Default (``None``) is ``"full"`` — every field is
+                returned.
 
         Returns:
             List[Dict[str, Any]]: Matches sorted by ``modified_at`` desc.
-                Shape depends on ``fields`` (see above).
+                Each entry is a field-selected tool dict plus a
+                ``similarity_score`` key.
 
         Raises:
             RuntimeError: If the service was constructed without a
@@ -546,15 +544,6 @@ class ToolsService:
                 lifecycle_state=lifecycle_state,
             )
             filtered_tools.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
-            if fields is None:
-                return [
-                    {
-                        "filename": t.get("name", ""),
-                        "similarity_score": t.get("similarity_score", 0.0),
-                    }
-                    for t in filtered_tools
-                    if t.get("name")
-                ]
             allow = parse_fields_spec(fields, "tool")
             return [
                 {

--- a/src/skillberry_store/services/tools_service.py
+++ b/src/skillberry_store/services/tools_service.py
@@ -425,24 +425,24 @@ class ToolsService:
         filters: Optional[Dict] = None,
         fields: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
-        """List all tools with optional filtering and field projection.
+        """List all tools with optional filtering and field selection.
 
         Args:
             filters: Optional dictionary of field:value pairs to filter by.
-            fields: Optional projection spec. ``None`` or ``"full"`` returns
-                every field (current behavior). ``"list"`` drops the heavy
-                ``params`` / ``returns`` / ``dependencies`` /
+            fields: Optional field-selection spec. ``None`` or ``"full"``
+                returns every field (current behavior). ``"list"`` drops the
+                heavy ``params`` / ``returns`` / ``dependencies`` /
                 ``packaging_params`` fields. A comma-separated string
                 selects a caller-defined allowlist.
 
         Returns:
             List[Dict[str, Any]]: List of tool metadata dictionaries, sorted
-                by modified_at descending. Fields are projected according
+                by modified_at descending. Fields are filtered according
                 to ``fields``.
         """
-        from skillberry_store.services.list_projections import (
+        from skillberry_store.services.field_selection import (
             parse_fields_spec,
-            project_items,
+            select_items_fields,
         )
 
         list_tools_counter.inc()
@@ -454,7 +454,7 @@ class ToolsService:
                 ]
             items.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
             allow = parse_fields_spec(fields, "tool")
-            return project_items(items, allow)
+            return select_items_fields(items, allow)
         except Exception as e:
             logger.error(f"Error listing tools: {e}\n{traceback.format_exc()}")
             raise
@@ -486,11 +486,12 @@ class ToolsService:
                 all entities.
             lifecycle_state: Lifecycle state filter. Defaults to
                 ``LifecycleState.ANY`` when ``None`` is passed.
-            fields: Optional projection spec. When ``None`` (default), each
-                match is returned as the legacy ``{"filename", "similarity_score"}``
-                pair. Otherwise the same grammar as list projection applies
-                (``"list"`` / ``"full"`` / comma-separated allowlist) and each
-                match is returned as a projected tool dict with
+            fields: Optional field-selection spec. When ``None`` (default),
+                each match is returned as the legacy
+                ``{"filename", "similarity_score"}`` pair. Otherwise the same
+                grammar as list field-selection applies (``"list"`` /
+                ``"full"`` / comma-separated allowlist) and each match is
+                returned as a field-selected tool dict with
                 ``similarity_score`` merged in.
 
         Returns:
@@ -503,9 +504,9 @@ class ToolsService:
         """
         from skillberry_store.modules.lifecycle import LifecycleState
         from skillberry_store.fast_api.search_filters import apply_search_filters
-        from skillberry_store.services.list_projections import (
+        from skillberry_store.services.field_selection import (
             parse_fields_spec,
-            project_item,
+            select_item_fields,
         )
 
         search_tools_counter.inc()
@@ -557,7 +558,7 @@ class ToolsService:
             allow = parse_fields_spec(fields, "tool")
             return [
                 {
-                    **project_item(t, allow),
+                    **select_item_fields(t, allow),
                     "similarity_score": t.get("similarity_score", 0.0),
                 }
                 for t in filtered_tools

--- a/src/skillberry_store/services/tools_service.py
+++ b/src/skillberry_store/services/tools_service.py
@@ -466,6 +466,7 @@ class ToolsService:
         similarity_threshold: float = 1.0,
         manifest_filter: str = ".",
         lifecycle_state: Optional["LifecycleState"] = None,
+        fields: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """Search tools by semantic similarity to a search term.
 
@@ -485,9 +486,16 @@ class ToolsService:
                 all entities.
             lifecycle_state: Lifecycle state filter. Defaults to
                 ``LifecycleState.ANY`` when ``None`` is passed.
+            fields: Optional projection spec. When ``None`` (default), each
+                match is returned as the legacy ``{"filename", "similarity_score"}``
+                pair. Otherwise the same grammar as list projection applies
+                (``"list"`` / ``"full"`` / comma-separated allowlist) and each
+                match is returned as a projected tool dict with
+                ``similarity_score`` merged in.
 
         Returns:
-            List[Dict[str, Any]]: Matches, each ``{"filename": <name>, "similarity_score": <float>}``.
+            List[Dict[str, Any]]: Matches sorted by ``modified_at`` desc.
+                Shape depends on ``fields`` (see above).
 
         Raises:
             RuntimeError: If the service was constructed without a
@@ -495,6 +503,10 @@ class ToolsService:
         """
         from skillberry_store.modules.lifecycle import LifecycleState
         from skillberry_store.fast_api.search_filters import apply_search_filters
+        from skillberry_store.services.list_projections import (
+            parse_fields_spec,
+            project_item,
+        )
 
         search_tools_counter.inc()
         try:
@@ -519,11 +531,12 @@ class ToolsService:
                 if not tool_name:
                     continue
                 try:
-                    tool_dict = self.get(tool_name)
-                    tool_dict["similarity_score"] = matched.get(
+                    fetched = self.get(tool_name)
+                    candidate = dict(fetched)
+                    candidate["similarity_score"] = matched.get(
                         "similarity_score", 0.0
                     )
-                    candidates.append(tool_dict)
+                    candidates.append(candidate)
                 except Exception as e:
                     logger.warning(f"Could not load tool {tool_name}: {e}")
             filtered_tools = apply_search_filters(
@@ -532,9 +545,19 @@ class ToolsService:
                 lifecycle_state=lifecycle_state,
             )
             filtered_tools.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
+            if fields is None:
+                return [
+                    {
+                        "filename": t.get("name", ""),
+                        "similarity_score": t.get("similarity_score", 0.0),
+                    }
+                    for t in filtered_tools
+                    if t.get("name")
+                ]
+            allow = parse_fields_spec(fields, "tool")
             return [
                 {
-                    "filename": t.get("name", ""),
+                    **project_item(t, allow),
                     "similarity_score": t.get("similarity_score", 0.0),
                 }
                 for t in filtered_tools

--- a/src/skillberry_store/services/tools_service.py
+++ b/src/skillberry_store/services/tools_service.py
@@ -420,15 +420,31 @@ class ToolsService:
             logger.error(f"Error retrieving module for '{uuid_or_name}': {e}")
             raise
 
-    def list_all(self, filters: Optional[Dict] = None) -> List[Dict[str, Any]]:
-        """List all tools with optional filtering.
+    def list_all(
+        self,
+        filters: Optional[Dict] = None,
+        fields: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """List all tools with optional filtering and field projection.
 
         Args:
             filters: Optional dictionary of field:value pairs to filter by.
+            fields: Optional projection spec. ``None`` or ``"full"`` returns
+                every field (current behavior). ``"list"`` drops the heavy
+                ``params`` / ``returns`` / ``dependencies`` /
+                ``packaging_params`` fields. A comma-separated string
+                selects a caller-defined allowlist.
 
         Returns:
-            List[Dict[str, Any]]: List of tool metadata dictionaries, sorted by modified_at descending.
+            List[Dict[str, Any]]: List of tool metadata dictionaries, sorted
+                by modified_at descending. Fields are projected according
+                to ``fields``.
         """
+        from skillberry_store.services.list_projections import (
+            parse_fields_spec,
+            project_items,
+        )
+
         list_tools_counter.inc()
         try:
             items = self.handler.list_all_dicts()
@@ -437,7 +453,8 @@ class ToolsService:
                     i for i in items if all(i.get(k) == v for k, v in filters.items())
                 ]
             items.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
-            return items
+            allow = parse_fields_spec(fields, "tool")
+            return project_items(items, allow)
         except Exception as e:
             logger.error(f"Error listing tools: {e}\n{traceback.format_exc()}")
             raise

--- a/src/skillberry_store/services/vmcp_service.py
+++ b/src/skillberry_store/services/vmcp_service.py
@@ -266,10 +266,10 @@ class VmcpService:
         Field-selection semantics (see
         :mod:`skillberry_store.services.field_selection`):
 
-        * ``fields`` omitted / ``"full"`` / ``"narrow"`` — the
+        * ``fields`` omitted / ``"narrow"`` / ``"full"`` — the
           ``_enhance`` mechanism runs; ``running`` and ``runtime`` are
           computed and merged into each server dict before field
-          selection is applied.
+          selection is applied. Default is ``"narrow"``.
         * ``fields="wide"`` — persisted manifest fields only; enhancement
           is skipped (no subprocess-manager calls).
         * Explicit CSV allowlist — enhancement runs iff ``"_enhance"``
@@ -359,12 +359,12 @@ class VmcpService:
             lifecycle_state: Lifecycle state filter. Defaults to
                 ``LifecycleState.ANY`` when ``None`` is passed.
             fields: Optional field-selection spec — same grammar as
-                :meth:`list_all` (``None`` / ``"full"`` / ``"narrow"`` /
-                ``"wide"`` / CSV allowlist). Each match is a
-                field-selected VMCP dict with ``similarity_score`` merged
-                in. Default (``None``) is ``"full"`` — the ``_enhance``
-                mechanism runs and ``running`` / ``runtime`` are merged
-                in.
+                :meth:`list_all` (``None`` / ``"narrow"`` / ``"wide"``
+                / ``"full"`` / CSV allowlist). Each match is a
+                field-selected VMCP dict with ``similarity_score``
+                merged in. Default (``None``) resolves to ``"narrow"``
+                — narrow tags ``_enhance`` for vMCP, so the mechanism
+                runs and ``running`` / ``runtime`` are merged in.
 
         Returns:
             List[Dict[str, Any]]: Matches sorted by ``modified_at`` desc.

--- a/src/skillberry_store/services/vmcp_service.py
+++ b/src/skillberry_store/services/vmcp_service.py
@@ -256,7 +256,7 @@ class VmcpService:
             logger.error(f"Error retrieving vmcp server '{uuid_or_name}': {e}")
             raise
 
-    def list_all(self, skill_uuid: Optional[str] = None) -> Dict[str, Any]:
+    def list_all(self, skill_uuid: Optional[str] = None) -> List[Dict[str, Any]]:
         """List all VMCP servers with runtime status.
 
         Args:
@@ -264,8 +264,8 @@ class VmcpService:
                 ``skill_uuid`` matches this value.
 
         Returns:
-            Dict[str, Any]: Dictionary with 'virtual_mcp_servers' key containing server info
-                           indexed by UUID, including runtime status.
+            List[Dict[str, Any]]: Server info dicts with runtime status, sorted
+                by ``modified_at`` descending.
         """
         list_vmcp_counter.inc()
         try:
@@ -310,7 +310,7 @@ class VmcpService:
                         f"Error loading vmcp server '{item.get('name')}': {e}"
                     )
             servers.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
-            return {"virtual_mcp_servers": {s["uuid"]: s for s in servers}}
+            return servers
         except Exception as e:
             logger.error(f"Error listing vmcp servers: {e}")
             raise

--- a/src/skillberry_store/services/vmcp_service.py
+++ b/src/skillberry_store/services/vmcp_service.py
@@ -256,17 +256,32 @@ class VmcpService:
             logger.error(f"Error retrieving vmcp server '{uuid_or_name}': {e}")
             raise
 
-    def list_all(self, skill_uuid: Optional[str] = None) -> List[Dict[str, Any]]:
+    def list_all(
+        self,
+        skill_uuid: Optional[str] = None,
+        fields: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
         """List all VMCP servers with runtime status.
 
         Args:
             skill_uuid: When provided, restrict the result to servers whose
                 ``skill_uuid`` matches this value.
+            fields: Optional field-selection spec (``None`` / ``"full"`` /
+                ``"list"`` / comma-separated allowlist). See
+                :mod:`skillberry_store.services.field_selection`. The runtime
+                enrichment fields (``running`` / ``runtime``) are always
+                populated before selection.
 
         Returns:
             List[Dict[str, Any]]: Server info dicts with runtime status, sorted
-                by ``modified_at`` descending.
+                by ``modified_at`` descending. Fields are filtered according
+                to ``fields``.
         """
+        from skillberry_store.services.field_selection import (
+            parse_fields_spec,
+            select_items_fields,
+        )
+
         list_vmcp_counter.inc()
         try:
             items = self.handler.list_all_dicts()
@@ -310,7 +325,8 @@ class VmcpService:
                         f"Error loading vmcp server '{item.get('name')}': {e}"
                     )
             servers.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
-            return servers
+            allow = parse_fields_spec(fields, "vmcp")
+            return select_items_fields(servers, allow)
         except Exception as e:
             logger.error(f"Error listing vmcp servers: {e}")
             raise
@@ -322,6 +338,7 @@ class VmcpService:
         similarity_threshold: float = 1.0,
         manifest_filter: str = ".",
         lifecycle_state: Optional["LifecycleState"] = None,
+        fields: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """Search VMCP servers by semantic similarity to a search term.
 
@@ -340,9 +357,17 @@ class VmcpService:
                 (e.g. ``"tags:python"``, ``"state:approved"``).
             lifecycle_state: Lifecycle state filter. Defaults to
                 ``LifecycleState.ANY`` when ``None`` is passed.
+            fields: Optional field-selection spec. When ``None`` (default),
+                each match is returned as the legacy
+                ``{"filename", "similarity_score"}`` pair. Otherwise the same
+                grammar as list field-selection applies (``"list"`` /
+                ``"full"`` / comma-separated allowlist) and each match is
+                returned as a field-selected VMCP dict with
+                ``similarity_score`` merged in.
 
         Returns:
-            List[Dict[str, Any]]: Matches, each ``{"filename": <name>, "similarity_score": <float>}``.
+            List[Dict[str, Any]]: Matches sorted by ``modified_at`` desc.
+                Shape depends on ``fields`` (see above).
 
         Raises:
             RuntimeError: If the service was constructed without a
@@ -350,6 +375,10 @@ class VmcpService:
         """
         from skillberry_store.modules.lifecycle import LifecycleState
         from skillberry_store.fast_api.search_filters import apply_search_filters
+        from skillberry_store.services.field_selection import (
+            parse_fields_spec,
+            select_item_fields,
+        )
 
         search_vmcp_counter.inc()
         try:
@@ -372,9 +401,10 @@ class VmcpService:
                 if not vmcp_uuid:
                     continue
                 try:
-                    d = self.handler.read_dict(vmcp_uuid)
-                    d["similarity_score"] = m.get("similarity_score", 0.0)
-                    candidates.append(d)
+                    fetched = self.handler.read_dict(vmcp_uuid)
+                    candidate = dict(fetched)
+                    candidate["similarity_score"] = m.get("similarity_score", 0.0)
+                    candidates.append(candidate)
                 except Exception as exc:
                     logger.warning(f"Could not load vmcp '{vmcp_uuid}': {exc}")
             result_items = apply_search_filters(
@@ -383,9 +413,19 @@ class VmcpService:
                 lifecycle_state=lifecycle_state,
             )
             result_items.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
+            if fields is None:
+                return [
+                    {
+                        "filename": s.get("name", ""),
+                        "similarity_score": s.get("similarity_score", 0.0),
+                    }
+                    for s in result_items
+                    if s.get("name")
+                ]
+            allow = parse_fields_spec(fields, "vmcp")
             return [
                 {
-                    "filename": s.get("name", ""),
+                    **select_item_fields(s, allow),
                     "similarity_score": s.get("similarity_score", 0.0),
                 }
                 for s in result_items

--- a/src/skillberry_store/services/vmcp_service.py
+++ b/src/skillberry_store/services/vmcp_service.py
@@ -261,25 +261,34 @@ class VmcpService:
         skill_uuid: Optional[str] = None,
         fields: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
-        """List all VMCP servers with runtime status.
+        """List all VMCP servers, optionally enhanced with runtime status.
+
+        Field-selection semantics (see
+        :mod:`skillberry_store.services.field_selection`):
+
+        * ``fields`` omitted / ``"full"`` / ``"narrow"`` — the
+          ``_enhance`` mechanism runs; ``running`` and ``runtime`` are
+          computed and merged into each server dict before field
+          selection is applied.
+        * ``fields="wide"`` — persisted manifest fields only; enhancement
+          is skipped (no subprocess-manager calls).
+        * Explicit CSV allowlist — enhancement runs iff ``"_enhance"``
+          is in the allowlist.
 
         Args:
             skill_uuid: When provided, restrict the result to servers whose
                 ``skill_uuid`` matches this value.
-            fields: Optional field-selection spec (``None`` / ``"full"`` /
-                ``"list"`` / comma-separated allowlist). See
-                :mod:`skillberry_store.services.field_selection`. The runtime
-                enrichment fields (``running`` / ``runtime``) are always
-                populated before selection.
+            fields: Optional field-selection spec.
 
         Returns:
-            List[Dict[str, Any]]: Server info dicts with runtime status, sorted
-                by ``modified_at`` descending. Fields are filtered according
-                to ``fields``.
+            List[Dict[str, Any]]: Server info dicts sorted by
+                ``modified_at`` descending, field-selected according to
+                ``fields``.
         """
         from skillberry_store.services.field_selection import (
             parse_fields_spec,
             select_items_fields,
+            should_run_mechanism,
         )
 
         list_vmcp_counter.inc()
@@ -287,28 +296,22 @@ class VmcpService:
             items = self.handler.list_all_dicts()
             if skill_uuid:
                 items = [i for i in items if i.get("skill_uuid") == skill_uuid]
-            servers = []
+            allow = parse_fields_spec(fields, "vmcp")
+            enhance = should_run_mechanism(allow, "_enhance")
+            servers: List[Dict[str, Any]] = []
             for item in items:
                 try:
-                    runtime = None
-                    try:
-                        runtime = self.server_manager.get_server(
-                            item.get("name", ""), item.get("uuid", "")
-                        )
-                    except Exception:
-                        pass
-                    info = {
-                        "uuid": item.get("uuid"),
-                        "name": item.get("name"),
-                        "description": item.get("description"),
-                        "version": item.get("version"),
-                        "state": item.get("state"),
-                        "tags": item.get("tags", []),
-                        "port": item.get("port"),
-                        "skill_uuid": item.get("skill_uuid"),
-                        "modified_at": item.get("modified_at", ""),
-                        "running": runtime is not None,
-                        "runtime": (
+                    info = dict(item)
+                    if enhance:
+                        runtime = None
+                        try:
+                            runtime = self.server_manager.get_server(
+                                item.get("name", ""), item.get("uuid", "")
+                            )
+                        except Exception:
+                            pass
+                        info["running"] = runtime is not None
+                        info["runtime"] = (
                             {
                                 "name": runtime.name,
                                 "description": runtime.description,
@@ -317,15 +320,13 @@ class VmcpService:
                             }
                             if runtime
                             else None
-                        ),
-                    }
+                        )
                     servers.append(info)
                 except Exception as e:
                     logger.warning(
                         f"Error loading vmcp server '{item.get('name')}': {e}"
                     )
             servers.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
-            allow = parse_fields_spec(fields, "vmcp")
             return select_items_fields(servers, allow)
         except Exception as e:
             logger.error(f"Error listing vmcp servers: {e}")
@@ -357,17 +358,18 @@ class VmcpService:
                 (e.g. ``"tags:python"``, ``"state:approved"``).
             lifecycle_state: Lifecycle state filter. Defaults to
                 ``LifecycleState.ANY`` when ``None`` is passed.
-            fields: Optional field-selection spec. When ``None`` (default),
-                each match is returned as the legacy
-                ``{"filename", "similarity_score"}`` pair. Otherwise the same
-                grammar as list field-selection applies (``"list"`` /
-                ``"full"`` / comma-separated allowlist) and each match is
-                returned as a field-selected VMCP dict with
-                ``similarity_score`` merged in.
+            fields: Optional field-selection spec — same grammar as
+                :meth:`list_all` (``None`` / ``"full"`` / ``"narrow"`` /
+                ``"wide"`` / CSV allowlist). Each match is a
+                field-selected VMCP dict with ``similarity_score`` merged
+                in. Default (``None``) is ``"full"`` — the ``_enhance``
+                mechanism runs and ``running`` / ``runtime`` are merged
+                in.
 
         Returns:
             List[Dict[str, Any]]: Matches sorted by ``modified_at`` desc.
-                Shape depends on ``fields`` (see above).
+                Each entry is a field-selected VMCP dict plus a
+                ``similarity_score`` key.
 
         Raises:
             RuntimeError: If the service was constructed without a
@@ -378,6 +380,7 @@ class VmcpService:
         from skillberry_store.services.field_selection import (
             parse_fields_spec,
             select_item_fields,
+            should_run_mechanism,
         )
 
         search_vmcp_counter.inc()
@@ -413,16 +416,27 @@ class VmcpService:
                 lifecycle_state=lifecycle_state,
             )
             result_items.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
-            if fields is None:
-                return [
-                    {
-                        "filename": s.get("name", ""),
-                        "similarity_score": s.get("similarity_score", 0.0),
-                    }
-                    for s in result_items
-                    if s.get("name")
-                ]
             allow = parse_fields_spec(fields, "vmcp")
+            if should_run_mechanism(allow, "_enhance"):
+                for s in result_items:
+                    runtime = None
+                    try:
+                        runtime = self.server_manager.get_server(
+                            s.get("name", ""), s.get("uuid", "")
+                        )
+                    except Exception:
+                        pass
+                    s["running"] = runtime is not None
+                    s["runtime"] = (
+                        {
+                            "name": runtime.name,
+                            "description": runtime.description,
+                            "port": runtime.port,
+                            "tools": runtime.tool_uuids,
+                        }
+                        if runtime
+                        else None
+                    )
             return [
                 {
                     **select_item_fields(s, allow),

--- a/src/skillberry_store/services/vnfs_service.py
+++ b/src/skillberry_store/services/vnfs_service.py
@@ -219,25 +219,33 @@ class VnfsService:
         skill_uuid: Optional[str] = None,
         fields: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
-        """List all vNFS servers with runtime status.
+        """List all vNFS servers, optionally enhanced with runtime status.
+
+        Field-selection semantics (see
+        :mod:`skillberry_store.services.field_selection`):
+
+        * ``fields`` omitted / ``"full"`` / ``"narrow"`` — the
+          ``_enhance`` mechanism runs; ``running`` and ``export_path``
+          are computed and merged into each server dict.
+        * ``fields="wide"`` — persisted manifest fields only; enhancement
+          is skipped.
+        * Explicit CSV allowlist — enhancement runs iff ``"_enhance"``
+          is in the allowlist.
 
         Args:
             skill_uuid: When provided, restrict the result to servers whose
                 ``skill_uuid`` matches this value.
-            fields: Optional field-selection spec (``None`` / ``"full"`` /
-                ``"list"`` / comma-separated allowlist). See
-                :mod:`skillberry_store.services.field_selection`. The runtime
-                enrichment fields (``running`` / ``export_path``) are always
-                populated before selection.
+            fields: Optional field-selection spec.
 
         Returns:
-            List[Dict[str, Any]]: Server info dicts with runtime status and
-                export paths, sorted by ``modified_at`` descending. Fields
-                are filtered according to ``fields``.
+            List[Dict[str, Any]]: Server info dicts sorted by
+                ``modified_at`` descending, field-selected according to
+                ``fields``.
         """
         from skillberry_store.services.field_selection import (
             parse_fields_spec,
             select_items_fields,
+            should_run_mechanism,
         )
 
         list_vnfs_counter.inc()
@@ -245,37 +253,30 @@ class VnfsService:
             items = self.handler.list_all_dicts()
             if skill_uuid:
                 items = [i for i in items if i.get("skill_uuid") == skill_uuid]
-            servers = []
+            allow = parse_fields_spec(fields, "vnfs")
+            enhance = should_run_mechanism(allow, "_enhance")
+            servers: List[Dict[str, Any]] = []
             for item in items:
                 try:
-                    runtime = None
-                    try:
-                        runtime = self.server_manager.get_server(
-                            item.get("name", ""), item.get("uuid", "")
+                    info = dict(item)
+                    if enhance:
+                        runtime = None
+                        try:
+                            runtime = self.server_manager.get_server(
+                                item.get("name", ""), item.get("uuid", "")
+                            )
+                        except Exception:
+                            pass
+                        info["running"] = runtime is not None and runtime.running
+                        info["export_path"] = (
+                            str(runtime.export_path) if runtime else None
                         )
-                    except Exception:
-                        pass
-                    info = {
-                        "uuid": item.get("uuid"),
-                        "name": item.get("name"),
-                        "description": item.get("description"),
-                        "version": item.get("version"),
-                        "state": item.get("state"),
-                        "tags": item.get("tags", []),
-                        "port": item.get("port"),
-                        "skill_uuid": item.get("skill_uuid"),
-                        "protocol": item.get("protocol", "webdav"),
-                        "modified_at": item.get("modified_at", ""),
-                        "running": runtime is not None and runtime.running,
-                        "export_path": str(runtime.export_path) if runtime else None,
-                    }
                     servers.append(info)
                 except Exception as e:
                     logger.warning(
                         f"Error loading vnfs server '{item.get('name')}': {e}"
                     )
             servers.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
-            allow = parse_fields_spec(fields, "vnfs")
             return select_items_fields(servers, allow)
         except Exception as exc:
             logger.error(f"Error listing vnfs servers: {exc}")
@@ -307,17 +308,18 @@ class VnfsService:
                 (e.g. ``"tags:python"``, ``"state:approved"``).
             lifecycle_state: Lifecycle state filter. Defaults to
                 ``LifecycleState.ANY`` when ``None`` is passed.
-            fields: Optional field-selection spec. When ``None`` (default),
-                each match is returned as the legacy
-                ``{"filename", "similarity_score"}`` pair. Otherwise the same
-                grammar as list field-selection applies (``"list"`` /
-                ``"full"`` / comma-separated allowlist) and each match is
-                returned as a field-selected vNFS dict with
-                ``similarity_score`` merged in.
+            fields: Optional field-selection spec — same grammar as
+                :meth:`list_all` (``None`` / ``"full"`` / ``"narrow"`` /
+                ``"wide"`` / CSV allowlist). Each match is a
+                field-selected vNFS dict with ``similarity_score`` merged
+                in. Default (``None``) is ``"full"`` — the ``_enhance``
+                mechanism runs and ``running`` / ``export_path`` are
+                merged in.
 
         Returns:
             List[Dict[str, Any]]: Matches sorted by ``modified_at`` desc.
-                Shape depends on ``fields`` (see above).
+                Each entry is a field-selected vNFS dict plus a
+                ``similarity_score`` key.
 
         Raises:
             RuntimeError: If the service was constructed without a
@@ -328,6 +330,7 @@ class VnfsService:
         from skillberry_store.services.field_selection import (
             parse_fields_spec,
             select_item_fields,
+            should_run_mechanism,
         )
 
         search_vnfs_counter.inc()
@@ -363,16 +366,20 @@ class VnfsService:
                 lifecycle_state=lifecycle_state,
             )
             result_items.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
-            if fields is None:
-                return [
-                    {
-                        "filename": s.get("name", ""),
-                        "similarity_score": s.get("similarity_score", 0.0),
-                    }
-                    for s in result_items
-                    if s.get("name")
-                ]
             allow = parse_fields_spec(fields, "vnfs")
+            if should_run_mechanism(allow, "_enhance"):
+                for s in result_items:
+                    runtime = None
+                    try:
+                        runtime = self.server_manager.get_server(
+                            s.get("name", ""), s.get("uuid", "")
+                        )
+                    except Exception:
+                        pass
+                    s["running"] = runtime is not None and runtime.running
+                    s["export_path"] = (
+                        str(runtime.export_path) if runtime else None
+                    )
             return [
                 {
                     **select_item_fields(s, allow),

--- a/src/skillberry_store/services/vnfs_service.py
+++ b/src/skillberry_store/services/vnfs_service.py
@@ -214,7 +214,7 @@ class VnfsService:
             logger.error(f"Error retrieving vnfs server '{uuid_or_name}': {exc}")
             raise
 
-    def list_all(self, skill_uuid: Optional[str] = None) -> Dict[str, Any]:
+    def list_all(self, skill_uuid: Optional[str] = None) -> List[Dict[str, Any]]:
         """List all vNFS servers with runtime status.
 
         Args:
@@ -222,8 +222,8 @@ class VnfsService:
                 ``skill_uuid`` matches this value.
 
         Returns:
-            Dict[str, Any]: Dictionary with 'virtual_nfs_servers' key containing server info
-                           indexed by UUID, including runtime status and export paths.
+            List[Dict[str, Any]]: Server info dicts with runtime status and
+                export paths, sorted by ``modified_at`` descending.
         """
         list_vnfs_counter.inc()
         try:
@@ -260,7 +260,7 @@ class VnfsService:
                         f"Error loading vnfs server '{item.get('name')}': {e}"
                     )
             servers.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
-            return {"virtual_nfs_servers": {s["uuid"]: s for s in servers}}
+            return servers
         except Exception as exc:
             logger.error(f"Error listing vnfs servers: {exc}")
             raise

--- a/src/skillberry_store/services/vnfs_service.py
+++ b/src/skillberry_store/services/vnfs_service.py
@@ -224,9 +224,10 @@ class VnfsService:
         Field-selection semantics (see
         :mod:`skillberry_store.services.field_selection`):
 
-        * ``fields`` omitted / ``"full"`` / ``"narrow"`` — the
+        * ``fields`` omitted / ``"narrow"`` / ``"full"`` — the
           ``_enhance`` mechanism runs; ``running`` and ``export_path``
-          are computed and merged into each server dict.
+          are computed and merged into each server dict. Default is
+          ``"narrow"``.
         * ``fields="wide"`` — persisted manifest fields only; enhancement
           is skipped.
         * Explicit CSV allowlist — enhancement runs iff ``"_enhance"``
@@ -309,12 +310,12 @@ class VnfsService:
             lifecycle_state: Lifecycle state filter. Defaults to
                 ``LifecycleState.ANY`` when ``None`` is passed.
             fields: Optional field-selection spec — same grammar as
-                :meth:`list_all` (``None`` / ``"full"`` / ``"narrow"`` /
-                ``"wide"`` / CSV allowlist). Each match is a
-                field-selected vNFS dict with ``similarity_score`` merged
-                in. Default (``None``) is ``"full"`` — the ``_enhance``
-                mechanism runs and ``running`` / ``export_path`` are
-                merged in.
+                :meth:`list_all` (``None`` / ``"narrow"`` / ``"wide"``
+                / ``"full"`` / CSV allowlist). Each match is a
+                field-selected vNFS dict with ``similarity_score``
+                merged in. Default (``None``) resolves to ``"narrow"``
+                — narrow tags ``_enhance`` for vNFS, so the mechanism
+                runs and ``running`` / ``export_path`` are merged in.
 
         Returns:
             List[Dict[str, Any]]: Matches sorted by ``modified_at`` desc.

--- a/src/skillberry_store/services/vnfs_service.py
+++ b/src/skillberry_store/services/vnfs_service.py
@@ -214,17 +214,32 @@ class VnfsService:
             logger.error(f"Error retrieving vnfs server '{uuid_or_name}': {exc}")
             raise
 
-    def list_all(self, skill_uuid: Optional[str] = None) -> List[Dict[str, Any]]:
+    def list_all(
+        self,
+        skill_uuid: Optional[str] = None,
+        fields: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
         """List all vNFS servers with runtime status.
 
         Args:
             skill_uuid: When provided, restrict the result to servers whose
                 ``skill_uuid`` matches this value.
+            fields: Optional field-selection spec (``None`` / ``"full"`` /
+                ``"list"`` / comma-separated allowlist). See
+                :mod:`skillberry_store.services.field_selection`. The runtime
+                enrichment fields (``running`` / ``export_path``) are always
+                populated before selection.
 
         Returns:
             List[Dict[str, Any]]: Server info dicts with runtime status and
-                export paths, sorted by ``modified_at`` descending.
+                export paths, sorted by ``modified_at`` descending. Fields
+                are filtered according to ``fields``.
         """
+        from skillberry_store.services.field_selection import (
+            parse_fields_spec,
+            select_items_fields,
+        )
+
         list_vnfs_counter.inc()
         try:
             items = self.handler.list_all_dicts()
@@ -260,7 +275,8 @@ class VnfsService:
                         f"Error loading vnfs server '{item.get('name')}': {e}"
                     )
             servers.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
-            return servers
+            allow = parse_fields_spec(fields, "vnfs")
+            return select_items_fields(servers, allow)
         except Exception as exc:
             logger.error(f"Error listing vnfs servers: {exc}")
             raise
@@ -272,6 +288,7 @@ class VnfsService:
         similarity_threshold: float = 1.0,
         manifest_filter: str = ".",
         lifecycle_state: Optional["LifecycleState"] = None,
+        fields: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """Search vNFS servers by semantic similarity to a search term.
 
@@ -290,9 +307,17 @@ class VnfsService:
                 (e.g. ``"tags:python"``, ``"state:approved"``).
             lifecycle_state: Lifecycle state filter. Defaults to
                 ``LifecycleState.ANY`` when ``None`` is passed.
+            fields: Optional field-selection spec. When ``None`` (default),
+                each match is returned as the legacy
+                ``{"filename", "similarity_score"}`` pair. Otherwise the same
+                grammar as list field-selection applies (``"list"`` /
+                ``"full"`` / comma-separated allowlist) and each match is
+                returned as a field-selected vNFS dict with
+                ``similarity_score`` merged in.
 
         Returns:
-            List[Dict[str, Any]]: Matches, each ``{"filename": <name>, "similarity_score": <float>}``.
+            List[Dict[str, Any]]: Matches sorted by ``modified_at`` desc.
+                Shape depends on ``fields`` (see above).
 
         Raises:
             RuntimeError: If the service was constructed without a
@@ -300,6 +325,10 @@ class VnfsService:
         """
         from skillberry_store.modules.lifecycle import LifecycleState
         from skillberry_store.fast_api.search_filters import apply_search_filters
+        from skillberry_store.services.field_selection import (
+            parse_fields_spec,
+            select_item_fields,
+        )
 
         search_vnfs_counter.inc()
         try:
@@ -322,9 +351,10 @@ class VnfsService:
                 if not vnfs_uuid:
                     continue
                 try:
-                    d = self.handler.read_dict(vnfs_uuid)
-                    d["similarity_score"] = m.get("similarity_score", 0.0)
-                    candidates.append(d)
+                    fetched = self.handler.read_dict(vnfs_uuid)
+                    candidate = dict(fetched)
+                    candidate["similarity_score"] = m.get("similarity_score", 0.0)
+                    candidates.append(candidate)
                 except Exception as exc:
                     logger.warning(f"Could not load vnfs '{vnfs_uuid}': {exc}")
             result_items = apply_search_filters(
@@ -333,9 +363,19 @@ class VnfsService:
                 lifecycle_state=lifecycle_state,
             )
             result_items.sort(key=lambda x: x.get("modified_at", ""), reverse=True)
+            if fields is None:
+                return [
+                    {
+                        "filename": s.get("name", ""),
+                        "similarity_score": s.get("similarity_score", 0.0),
+                    }
+                    for s in result_items
+                    if s.get("name")
+                ]
+            allow = parse_fields_spec(fields, "vnfs")
             return [
                 {
-                    "filename": s.get("name", ""),
+                    **select_item_fields(s, allow),
                     "similarity_score": s.get("similarity_score", 0.0),
                 }
                 for s in result_items

--- a/src/skillberry_store/tests/e2e/test_backup_restore.py
+++ b/src/skillberry_store/tests/e2e/test_backup_restore.py
@@ -113,19 +113,14 @@ async def _snapshot(client: httpx.AsyncClient) -> dict:
     assert r.status_code == 200
     skills = _strip(r.json(), set())
 
+    # List endpoints return bare arrays.
     r = await client.get(f"{BASE_URL}/vmcp_servers/")
     assert r.status_code == 200
-    vmcp = _strip(
-        list(r.json().get("virtual_mcp_servers", {}).values()),
-        _VMCP_RUNTIME_FIELDS,
-    )
+    vmcp = _strip(r.json(), _VMCP_RUNTIME_FIELDS)
 
     r = await client.get(f"{BASE_URL}/vnfs_servers/")
     assert r.status_code == 200
-    vnfs = _strip(
-        list(r.json().get("virtual_nfs_servers", {}).values()),
-        _VNFS_RUNTIME_FIELDS,
-    )
+    vnfs = _strip(r.json(), _VNFS_RUNTIME_FIELDS)
 
     return {
         "tools": tools,

--- a/src/skillberry_store/tests/e2e/test_mcp_tools.py
+++ b/src/skillberry_store/tests/e2e/test_mcp_tools.py
@@ -78,11 +78,11 @@ async def create_vmcp_server_with_tool(client, tool_name: str, tool_code: bytes,
     print(f"List response status: {list_response.status_code}")
     server_running = False
     if list_response.status_code == 200:
-        servers = list_response.json().get("virtual_mcp_servers", {})
-        print(f"Available VMCP servers (UUIDs): {list(servers.keys())}")
-        # Find server by name in the values (dict is now keyed by UUID)
+        # List endpoint returns a bare array.
+        servers = list_response.json()
+        print(f"Available VMCP servers (UUIDs): {[s.get('uuid') for s in servers]}")
         server_info = None
-        for server in servers.values():
+        for server in servers:
             if server.get('name') == vmcp_server_name:
                 server_info = server
                 break
@@ -483,11 +483,11 @@ async def test_get_tool_module_with_mcp_packaging(run_sbs):
         print(f"List response status: {list_response.status_code}")
         server_running = False
         if list_response.status_code == 200:
-            servers = list_response.json().get("virtual_mcp_servers", {})
-            print(f"Available VMCP servers (UUIDs): {list(servers.keys())}")
-            # Find server by name in the values (dict is now keyed by UUID)
+            # List endpoint returns a bare array.
+            servers = list_response.json()
+            print(f"Available VMCP servers (UUIDs): {[s.get('uuid') for s in servers]}")
             server_info = None
-            for server in servers.values():
+            for server in servers:
                 if server.get('name') == vmcp_server_name:
                     server_info = server
                     break

--- a/src/skillberry_store/tests/e2e/test_mcp_tools.py
+++ b/src/skillberry_store/tests/e2e/test_mcp_tools.py
@@ -202,13 +202,15 @@ def placeholder():
         print("\n" + "="*60)
         print("Step 4a: Verifying tool is in tools list...")
         print("="*60)
-        list_response = await client.get(f"{BASE_URL}/tools/")
+        # Ask for the wide preset so packaging_format / packaging_params
+        # (not in the narrow listing default) are returned.
+        list_response = await client.get(f"{BASE_URL}/tools/?fields=wide")
         assert list_response.status_code == 200, f"Failed to list tools: {list_response.text}"
         tools_list = list_response.json()
         tool_names = [t.get("name") for t in tools_list]
         print(f"Available tools: {tool_names}")
         assert tool_name in tool_names, f"Tool '{tool_name}' not found in tools list"
-        
+
         # Find our tool in the list and verify its properties
         our_tool = next((t for t in tools_list if t.get("name") == tool_name), None)
         assert our_tool is not None, f"Tool '{tool_name}' not found in tools list"

--- a/src/skillberry_store/tests/e2e/test_purge_all.py
+++ b/src/skillberry_store/tests/e2e/test_purge_all.py
@@ -118,14 +118,15 @@ async def test_purge_all_clears_all_objects(run_sbs):
         assert r.status_code == 200
         assert len(r.json()) > 0, "Expected tools before purge"
 
+        # List endpoints return bare arrays.
         r = await client.get(f"{BASE_URL}/vmcp_servers/")
         assert r.status_code == 200
-        vmcp_before = r.json().get("virtual_mcp_servers", {})
+        vmcp_before = r.json()
         assert len(vmcp_before) >= 2, "Expected at least 2 VMCP servers before purge"
 
         r = await client.get(f"{BASE_URL}/vnfs_servers/")
         assert r.status_code == 200
-        vnfs_before = r.json().get("virtual_nfs_servers", {})
+        vnfs_before = r.json()
         assert len(vnfs_before) >= 2, "Expected at least 2 VNFS servers before purge"
 
         # ── 4. Purge everything ───────────────────────────────────────────────
@@ -149,14 +150,14 @@ async def test_purge_all_clears_all_objects(run_sbs):
 
         r = await client.get(f"{BASE_URL}/vmcp_servers/")
         assert r.status_code == 200
-        vmcp_after = r.json().get("virtual_mcp_servers", {})
-        assert vmcp_after == {}, (
-            f"Expected empty VMCP dict after purge, got: {vmcp_after}"
+        vmcp_after = r.json()
+        assert vmcp_after == [], (
+            f"Expected empty VMCP list after purge, got: {vmcp_after}"
         )
 
         r = await client.get(f"{BASE_URL}/vnfs_servers/")
         assert r.status_code == 200
-        vnfs_after = r.json().get("virtual_nfs_servers", {})
-        assert vnfs_after == {}, (
-            f"Expected empty VNFS dict after purge, got: {vnfs_after}"
+        vnfs_after = r.json()
+        assert vnfs_after == [], (
+            f"Expected empty VNFS list after purge, got: {vnfs_after}"
         )

--- a/src/skillberry_store/tests/e2e/test_skills_api.py
+++ b/src/skillberry_store/tests/e2e/test_skills_api.py
@@ -385,9 +385,10 @@ async def test_search_skills(run_sbs):
         results = search_response.json()
         assert len(results) > 0, "Should find at least one matching skill"
         
-        # Verify data_analysis_skill is in results
-        filenames = [r.get("filename") for r in results]
-        assert "data_analysis_skill" in filenames, f"data_analysis_skill should be in search results, got: {filenames}"
+        # Verify data_analysis_skill is in results. Default search shape
+        # is the full object with ``similarity_score`` merged in.
+        names = [r.get("name") for r in results]
+        assert "data_analysis_skill" in names, f"data_analysis_skill should be in search results, got: {names}"
         
         # Test search for "web development"
         search_response = await client.get(

--- a/src/skillberry_store/tests/e2e/test_snippets_api.py
+++ b/src/skillberry_store/tests/e2e/test_snippets_api.py
@@ -274,9 +274,11 @@ async def test_search_snippets(run_sbs):
         results = search_response.json()
         assert len(results) > 0, "Should find at least one matching snippet"
         
-        # Verify python_logging_snippet is in results
-        filenames = [r.get("filename") for r in results]
-        assert "python_logging_snippet" in filenames, f"python_logging_snippet should be in search results, got: {filenames}"
+        # Verify python_logging_snippet is in results. Default search
+        # shape is the full object with ``similarity_score`` merged in —
+        # read the ``name`` field.
+        names = [r.get("name") for r in results]
+        assert "python_logging_snippet" in names, f"python_logging_snippet should be in search results, got: {names}"
         
         # Test search for "HTTP requests"
         search_response = await client.get(

--- a/src/skillberry_store/tests/e2e/test_snippets_api.py
+++ b/src/skillberry_store/tests/e2e/test_snippets_api.py
@@ -275,7 +275,7 @@ async def test_search_snippets(run_sbs):
         assert len(results) > 0, "Should find at least one matching snippet"
         
         # Verify python_logging_snippet is in results. Default search
-        # shape is the full object with ``similarity_score`` merged in —
+        # shape is the narrow object with ``similarity_score`` merged in —
         # read the ``name`` field.
         names = [r.get("name") for r in results]
         assert "python_logging_snippet" in names, f"python_logging_snippet should be in search results, got: {names}"

--- a/src/skillberry_store/tests/e2e/test_tools_api.py
+++ b/src/skillberry_store/tests/e2e/test_tools_api.py
@@ -732,9 +732,10 @@ async def test_search_tools(run_sbs):
         results = search_response.json()
         assert len(results) > 0, "Should find at least one matching tool"
         
-        # Verify calculator_tool is in results
-        filenames = [r.get("filename") for r in results]
-        assert "calculator_tool" in filenames, f"calculator_tool should be in search results, got: {filenames}"
+        # Verify calculator_tool is in results. Default search shape is
+        # the full object with ``similarity_score`` merged in.
+        names = [r.get("name") for r in results]
+        assert "calculator_tool" in names, f"calculator_tool should be in search results, got: {names}"
         
         # Test search for "string"
         search_response = await client.get(

--- a/src/skillberry_store/tests/e2e/test_vmcp_api.py
+++ b/src/skillberry_store/tests/e2e/test_vmcp_api.py
@@ -66,16 +66,12 @@ async def test_list_vmcp_servers(run_sbs):
     async with httpx.AsyncClient() as client:
         response = await client.get(f"{BASE_URL}/vmcp_servers/")
         assert response.status_code == 200
-        data = response.json()
-        assert isinstance(data, dict)
-        assert "virtual_mcp_servers" in data
-        vmcp_servers = data["virtual_mcp_servers"]
-        # API returns a dict of server objects keyed by UUID
-        assert isinstance(vmcp_servers, dict)
+        # List endpoint returns a bare array (parity with skills/tools/snippets).
+        vmcp_servers = response.json()
+        assert isinstance(vmcp_servers, list)
         assert len(vmcp_servers) > 0
-        
-        # Check that our test VMCP server exists by checking server names in values
-        server_names = [server.get("name") for server in vmcp_servers.values()]
+
+        server_names = [server.get("name") for server in vmcp_servers]
         assert "test_vmcp_server" in server_names
 
 
@@ -404,11 +400,11 @@ async def test_multiple_vmcp_servers_same_name_different_uuid(run_sbs):
         # Verify both servers are in the list
         list_response = await client.get(f"{BASE_URL}/vmcp_servers/")
         assert list_response.status_code == 200
-        servers = list_response.json().get("virtual_mcp_servers", {})
-        
-        # Both servers should be accessible (they share a name but have different UUIDs)
-        # The list API returns servers keyed by UUID, so both are visible in the dict
-        same_name_servers = [s for s in servers.values() if s.get("name") == server_name]
+        # List endpoint returns a bare array.
+        servers = list_response.json()
+
+        # Both servers should be accessible (they share a name but have different UUIDs).
+        same_name_servers = [s for s in servers if s.get("name") == server_name]
         assert len(same_name_servers) >= 2, "Should have at least 2 servers with same name"
         
         # Both should be retrievable by UUID

--- a/src/skillberry_store/tests/e2e/test_vmcp_api.py
+++ b/src/skillberry_store/tests/e2e/test_vmcp_api.py
@@ -285,9 +285,10 @@ async def test_search_vmcp_servers(run_sbs):
         results = search_response.json()
         assert len(results) > 0, "Should find at least one matching VMCP server"
         
-        # Verify python_vmcp_server is in results
-        filenames = [r.get("filename") for r in results]
-        assert "python_vmcp_server" in filenames, f"python_vmcp_server should be in search results, got: {filenames}"
+        # Verify python_vmcp_server is in results. Default search shape
+        # is the full object with ``similarity_score`` merged in.
+        names = [r.get("name") for r in results]
+        assert "python_vmcp_server" in names, f"python_vmcp_server should be in search results, got: {names}"
         
         # Test search for "HTTP requests"
         search_response = await client.get(

--- a/src/skillberry_store/tests/e2e/test_vnfs_api.py
+++ b/src/skillberry_store/tests/e2e/test_vnfs_api.py
@@ -416,9 +416,10 @@ async def test_search_vnfs_servers(run_sbs, imported_skill_uuid):
         results = search_response.json()
         assert len(results) > 0, "Should find at least one matching VNFS server"
         
-        # Verify python_vnfs_server is in results
-        filenames = [r.get("filename") for r in results]
-        assert "python_vnfs_server" in filenames, f"python_vnfs_server should be in search results, got: {filenames}"
+        # Verify python_vnfs_server is in results. Default search shape
+        # is the full object with ``similarity_score`` merged in.
+        names = [r.get("name") for r in results]
+        assert "python_vnfs_server" in names, f"python_vnfs_server should be in search results, got: {names}"
         
         # Test search for "file transfers"
         search_response = await client.get(

--- a/src/skillberry_store/tests/e2e/test_vnfs_api.py
+++ b/src/skillberry_store/tests/e2e/test_vnfs_api.py
@@ -90,17 +90,13 @@ async def test_list_vnfs_servers(run_sbs, imported_skill_uuid):
     async with httpx.AsyncClient() as client:
         response = await client.get(f"{BASE_URL}/vnfs_servers/")
         assert response.status_code == 200
-        data = response.json()
-        assert isinstance(data, dict)
-        assert "virtual_nfs_servers" in data
-        vnfs_servers = data["virtual_nfs_servers"]
-        # API returns a dict of server objects keyed by UUID
-        assert isinstance(vnfs_servers, dict)
+        # List endpoint returns a bare array (parity with skills/tools/snippets).
+        vnfs_servers = response.json()
+        assert isinstance(vnfs_servers, list)
         assert len(vnfs_servers) > 0
-        
-        # Check that our test VNFS server is in the dict keys
-        find_name= "test_vnfs_server"
-        matching_name_servers = [s for s in vnfs_servers.values() if s.get("name") == find_name]
+
+        find_name = "test_vnfs_server"
+        matching_name_servers = [s for s in vnfs_servers if s.get("name") == find_name]
         assert len(matching_name_servers) > 0, f"Server not found with name: {find_name}"
 
 
@@ -188,9 +184,9 @@ async def test_create_vnfs_server_same_name_different_uuid(run_sbs, imported_ski
         # Verify both servers exist
         get_response = await client.get(f"{BASE_URL}/vnfs_servers/")
         assert get_response.status_code == 200
-        response_data = get_response.json()
-        servers_dict = response_data.get("virtual_nfs_servers", {})
-        same_name_servers = [s for s in servers_dict.values() if s.get("name") == "same_name_server"]
+        # List endpoint returns a bare array.
+        servers = get_response.json()
+        same_name_servers = [s for s in servers if s.get("name") == "same_name_server"]
         assert len(same_name_servers) >= 2, "Should have at least 2 servers with same name"
         
         # Clean up both servers

--- a/src/skillberry_store/tests/fast_api/test_server.py
+++ b/src/skillberry_store/tests/fast_api/test_server.py
@@ -95,3 +95,54 @@ def test_list_snippets_custom_allowlist(fresh_sbs):
     assert isinstance(body, list)
     for entry in body:
         assert set(entry.keys()) == {"uuid", "name"}
+
+
+def _search_snippets_via_mocked_vector(client: TestClient, matched_name: str, **params):
+    """Patch the snippet handler's vector index to force ``matched_name`` as
+    the only search hit; issue a search request with the extra ``params``.
+
+    Search vectorization is stochastic and slow in tests; the projection
+    layer under test is orthogonal to how the vector search ranks things,
+    so we stub the index and verify projection.
+    """
+    from unittest.mock import patch
+    from skillberry_store.modules.object_handler import get_object_handler
+
+    handler = get_object_handler("snippet")
+    with patch.object(
+        handler.descriptions,
+        "search_description",
+        return_value=[{"filename": matched_name, "similarity_score": 0.1}],
+    ):
+        return client.get("/search/snippets", params={"search_term": "q", **params})
+
+
+def test_search_snippets_default_returns_legacy_shape(fresh_sbs):
+    """Default search shape must remain ``{filename, similarity_score}``."""
+    client = TestClient(fresh_sbs)
+    _create_snippet(client, "phase1_search_legacy", "body-a")
+
+    resp = _search_snippets_via_mocked_vector(client, "phase1_search_legacy")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert isinstance(body, list) and len(body) == 1
+    assert set(body[0].keys()) == {"filename", "similarity_score"}
+    assert body[0]["filename"] == "phase1_search_legacy"
+
+
+def test_search_snippets_fields_list_returns_projected_with_score(fresh_sbs):
+    """``?fields=list`` returns slim snippet dicts with score merged in."""
+    client = TestClient(fresh_sbs)
+    _create_snippet(client, "phase1_search_slim", "long body content")
+
+    resp = _search_snippets_via_mocked_vector(
+        client, "phase1_search_slim", fields="list"
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert isinstance(body, list) and len(body) == 1
+    r = body[0]
+    assert r["name"] == "phase1_search_slim"
+    assert r["similarity_score"] == 0.1
+    assert "uuid" in r
+    assert "content" not in r

--- a/src/skillberry_store/tests/fast_api/test_server.py
+++ b/src/skillberry_store/tests/fast_api/test_server.py
@@ -5,14 +5,93 @@ from skillberry_store.fast_api.server import SBS
 from skillberry_store.tests.utils import clean_test_tmp_dir
 
 
-def test_health_endpoint():
-    """Test that the health endpoint returns the expected response."""
+@pytest.fixture
+def fresh_sbs():
+    """Give each test a clean disk + freshly initialised singletons.
+
+    The SBS module maintains process-lifetime caches (object handlers,
+    service registry); without resetting them a second call to ``SBS()``
+    reuses stale in-memory state pointing at a wiped directory.
+    """
+    from skillberry_store.modules import object_handler
+    from skillberry_store.services import registry
 
     clean_test_tmp_dir()
+    object_handler.clear_object_handlers()
+    registry.clear_services()
     app = SBS()
-    client = TestClient(app)
+    yield app
+    object_handler.clear_object_handlers()
+    registry.clear_services()
+
+
+def test_health_endpoint(fresh_sbs):
+    """Test that the health endpoint returns the expected response."""
+    client = TestClient(fresh_sbs)
 
     response = client.get("/health")
 
     assert response.status_code == 200
     assert response.json() == {"status": "healthy"}
+
+
+def _create_snippet(client: TestClient, name: str, content: str) -> None:
+    resp = client.post(
+        "/snippets/",
+        params={
+            "name": name,
+            "description": f"desc for {name}",
+            "content": content,
+            "version": "1.0.0",
+            "content_type": "text/plain",
+            "state": "approved",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def test_list_snippets_default_returns_bare_array_with_content(fresh_sbs):
+    """Default listing (no fields param) preserves the current wire shape."""
+    client = TestClient(fresh_sbs)
+
+    _create_snippet(client, "phase1_full_a", "hello world")
+
+    resp = client.get("/snippets/")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert isinstance(body, list)
+    entry = next(s for s in body if s["name"] == "phase1_full_a")
+    assert entry["content"] == "hello world"
+
+
+def test_list_snippets_fields_list_drops_content(fresh_sbs):
+    """?fields=list returns the slim preset (no heavy `content` field)."""
+    client = TestClient(fresh_sbs)
+
+    _create_snippet(client, "phase1_slim_a", "body-a")
+    _create_snippet(client, "phase1_slim_b", "body-b")
+
+    resp = client.get("/snippets/", params={"fields": "list"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert isinstance(body, list)
+    assert len(body) >= 2
+    names = {s["name"] for s in body}
+    assert {"phase1_slim_a", "phase1_slim_b"}.issubset(names)
+    for s in body:
+        assert "content" not in s
+        assert "uuid" in s
+
+
+def test_list_snippets_custom_allowlist(fresh_sbs):
+    """?fields=uuid,name returns only those keys per item."""
+    client = TestClient(fresh_sbs)
+
+    _create_snippet(client, "phase1_csv_a", "body-a")
+
+    resp = client.get("/snippets/", params={"fields": "uuid,name"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert isinstance(body, list)
+    for entry in body:
+        assert set(entry.keys()) == {"uuid", "name"}

--- a/src/skillberry_store/tests/fast_api/test_server.py
+++ b/src/skillberry_store/tests/fast_api/test_server.py
@@ -64,14 +64,14 @@ def test_list_snippets_default_returns_bare_array_with_content(fresh_sbs):
     assert entry["content"] == "hello world"
 
 
-def test_list_snippets_fields_list_drops_content(fresh_sbs):
-    """?fields=list returns the slim preset (no heavy `content` field)."""
+def test_list_snippets_fields_narrow_drops_content(fresh_sbs):
+    """?fields=narrow returns the minimal listing-page set (no `content`)."""
     client = TestClient(fresh_sbs)
 
     _create_snippet(client, "phase1_slim_a", "body-a")
     _create_snippet(client, "phase1_slim_b", "body-b")
 
-    resp = client.get("/snippets/", params={"fields": "list"})
+    resp = client.get("/snippets/", params={"fields": "narrow"})
     assert resp.status_code == 200
     body = resp.json()
     assert isinstance(body, list)
@@ -81,6 +81,19 @@ def test_list_snippets_fields_list_drops_content(fresh_sbs):
     for s in body:
         assert "content" not in s
         assert "uuid" in s
+
+
+def test_list_snippets_fields_wide_keeps_content(fresh_sbs):
+    """``wide`` returns every persisted manifest field, including `content`."""
+    client = TestClient(fresh_sbs)
+
+    _create_snippet(client, "phase1_wide_a", "body-wide")
+
+    resp = client.get("/snippets/", params={"fields": "wide"})
+    assert resp.status_code == 200
+    body = resp.json()
+    entry = next(s for s in body if s["name"] == "phase1_wide_a")
+    assert entry["content"] == "body-wide"
 
 
 def test_list_snippets_custom_allowlist(fresh_sbs):
@@ -117,26 +130,29 @@ def _search_snippets_via_mocked_vector(client: TestClient, matched_name: str, **
         return client.get("/search/snippets", params={"search_term": "q", **params})
 
 
-def test_search_snippets_default_returns_legacy_shape(fresh_sbs):
-    """Default search shape must remain ``{filename, similarity_score}``."""
+def test_search_snippets_default_returns_full_with_score(fresh_sbs):
+    """Default (no ``fields``) is equivalent to ``full`` — the whole
+    snippet dict with ``similarity_score`` merged in."""
     client = TestClient(fresh_sbs)
-    _create_snippet(client, "phase1_search_legacy", "body-a")
+    _create_snippet(client, "phase1_search_full", "body-a")
 
-    resp = _search_snippets_via_mocked_vector(client, "phase1_search_legacy")
+    resp = _search_snippets_via_mocked_vector(client, "phase1_search_full")
     assert resp.status_code == 200, resp.text
     body = resp.json()
     assert isinstance(body, list) and len(body) == 1
-    assert set(body[0].keys()) == {"filename", "similarity_score"}
-    assert body[0]["filename"] == "phase1_search_legacy"
+    r = body[0]
+    assert r["name"] == "phase1_search_full"
+    assert r["content"] == "body-a"
+    assert r["similarity_score"] == 0.1
 
 
-def test_search_snippets_fields_list_returns_projected_with_score(fresh_sbs):
-    """``?fields=list`` returns slim snippet dicts with score merged in."""
+def test_search_snippets_fields_narrow_returns_projected_with_score(fresh_sbs):
+    """``?fields=narrow`` returns slim snippet dicts with score merged in."""
     client = TestClient(fresh_sbs)
     _create_snippet(client, "phase1_search_slim", "long body content")
 
     resp = _search_snippets_via_mocked_vector(
-        client, "phase1_search_slim", fields="list"
+        client, "phase1_search_slim", fields="narrow"
     )
     assert resp.status_code == 200, resp.text
     body = resp.json()

--- a/src/skillberry_store/tests/fast_api/test_server.py
+++ b/src/skillberry_store/tests/fast_api/test_server.py
@@ -50,8 +50,9 @@ def _create_snippet(client: TestClient, name: str, content: str) -> None:
     assert resp.status_code == 200, resp.text
 
 
-def test_list_snippets_default_returns_bare_array_with_content(fresh_sbs):
-    """Default listing (no fields param) preserves the current wire shape."""
+def test_list_snippets_default_is_narrow(fresh_sbs):
+    """Default listing (no fields param) is the ``narrow`` preset — the
+    minimal UI listing set, so heavy fields like ``content`` are dropped."""
     client = TestClient(fresh_sbs)
 
     _create_snippet(client, "phase1_full_a", "hello world")
@@ -61,6 +62,20 @@ def test_list_snippets_default_returns_bare_array_with_content(fresh_sbs):
     body = resp.json()
     assert isinstance(body, list)
     entry = next(s for s in body if s["name"] == "phase1_full_a")
+    assert "content" not in entry
+    assert "uuid" in entry
+
+
+def test_list_snippets_fields_full_keeps_content(fresh_sbs):
+    """Explicit ``?fields=full`` opts back into the complete object."""
+    client = TestClient(fresh_sbs)
+
+    _create_snippet(client, "phase1_full_b", "hello world")
+
+    resp = client.get("/snippets/", params={"fields": "full"})
+    assert resp.status_code == 200
+    body = resp.json()
+    entry = next(s for s in body if s["name"] == "phase1_full_b")
     assert entry["content"] == "hello world"
 
 
@@ -130,9 +145,9 @@ def _search_snippets_via_mocked_vector(client: TestClient, matched_name: str, **
         return client.get("/search/snippets", params={"search_term": "q", **params})
 
 
-def test_search_snippets_default_returns_full_with_score(fresh_sbs):
-    """Default (no ``fields``) is equivalent to ``full`` — the whole
-    snippet dict with ``similarity_score`` merged in."""
+def test_search_snippets_default_is_narrow_with_score(fresh_sbs):
+    """Default (no ``fields``) is equivalent to ``narrow`` — a slim
+    snippet dict with ``similarity_score`` merged in, no ``content``."""
     client = TestClient(fresh_sbs)
     _create_snippet(client, "phase1_search_full", "body-a")
 
@@ -142,6 +157,24 @@ def test_search_snippets_default_returns_full_with_score(fresh_sbs):
     assert isinstance(body, list) and len(body) == 1
     r = body[0]
     assert r["name"] == "phase1_search_full"
+    assert "content" not in r
+    assert r["similarity_score"] == 0.1
+
+
+def test_search_snippets_fields_full_returns_full_with_score(fresh_sbs):
+    """Explicit ``?fields=full`` opts back into the complete snippet
+    dict with ``similarity_score`` merged in."""
+    client = TestClient(fresh_sbs)
+    _create_snippet(client, "phase1_search_explicit_full", "body-a")
+
+    resp = _search_snippets_via_mocked_vector(
+        client, "phase1_search_explicit_full", fields="full"
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert isinstance(body, list) and len(body) == 1
+    r = body[0]
+    assert r["name"] == "phase1_search_explicit_full"
     assert r["content"] == "body-a"
     assert r["similarity_score"] == 0.1
 

--- a/src/skillberry_store/tests/fast_api/test_server.py
+++ b/src/skillberry_store/tests/fast_api/test_server.py
@@ -101,9 +101,9 @@ def _search_snippets_via_mocked_vector(client: TestClient, matched_name: str, **
     """Patch the snippet handler's vector index to force ``matched_name`` as
     the only search hit; issue a search request with the extra ``params``.
 
-    Search vectorization is stochastic and slow in tests; the projection
+    Search vectorization is stochastic and slow in tests; the field-selection
     layer under test is orthogonal to how the vector search ranks things,
-    so we stub the index and verify projection.
+    so we stub the index and verify field selection.
     """
     from unittest.mock import patch
     from skillberry_store.modules.object_handler import get_object_handler

--- a/src/skillberry_store/tests/modules/test_vmcp_server.py
+++ b/src/skillberry_store/tests/modules/test_vmcp_server.py
@@ -5,6 +5,26 @@ from skillberry_store.modules.vmcp_server import VirtualMcpServer
 import socket
 
 
+@pytest.fixture(autouse=True)
+def _stub_object_handlers(monkeypatch):
+    """Stub ``get_object_handler`` for every test in this module.
+
+    ``VirtualMcpServer.__init__`` calls ``get_object_handler("tool")`` and
+    ``get_object_handler("snippet")`` at construction time, which require
+    the process-wide singletons to have been initialised by ``SBS()``.
+    These constructor tests mock every method that would actually use the
+    handlers (``_register_tools``/``_register_prompts``/``_start_server``),
+    so a bare ``MagicMock`` is sufficient to bypass the singleton gate and
+    keep the tests hermetic (previously they only passed by inheriting
+    initialised state from an earlier test in the pytest session).
+    """
+    from skillberry_store.modules import vmcp_server as _vmcp_mod
+
+    monkeypatch.setattr(
+        _vmcp_mod, "get_object_handler", lambda _name: MagicMock()
+    )
+
+
 @patch("skillberry_store.modules.vmcp_server.VirtualMcpServer._start_server")
 @patch("skillberry_store.modules.vmcp_server.VirtualMcpServer._register_prompts")
 @patch("skillberry_store.modules.vmcp_server.VirtualMcpServer._register_tools")

--- a/src/skillberry_store/tests/services/test_descriptions_sync.py
+++ b/src/skillberry_store/tests/services/test_descriptions_sync.py
@@ -42,9 +42,14 @@ def skill_handler(tmp_path):
 
 
 def _search_names(service, term: str) -> list[str]:
-    """Return the list of names returned by service.search() for *term*."""
+    """Return the list of names returned by service.search() for *term*.
+
+    ``service.search`` defaults to ``fields=full`` and returns the whole
+    projected object with ``similarity_score`` merged in — read ``name``
+    from each match.
+    """
     results = service.search(term, max_number_of_results=10, similarity_threshold=100.0)
-    return [r["filename"] for r in results]
+    return [r["name"] for r in results]
 
 
 # ---------------------------------------------------------------------------

--- a/src/skillberry_store/tests/services/test_field_selection.py
+++ b/src/skillberry_store/tests/services/test_field_selection.py
@@ -1,56 +1,166 @@
-"""Unit tests for the field-selection helpers used by list endpoints."""
+"""Unit tests for the field-selection helpers used by list/search endpoints."""
 
 import pytest
 
 from skillberry_store.services import field_selection as fs
 from skillberry_store.services.field_selection import (
-    SKILL_LIST_FIELDS,
-    SNIPPET_LIST_FIELDS,
-    TOOL_LIST_FIELDS,
-    VMCP_LIST_FIELDS,
-    VNFS_LIST_FIELDS,
+    _FIELD_TAGS_BY_TYPE,
+    _PRESET_NAMES,
     parse_fields_spec,
     select_item_fields,
     select_items_fields,
+    should_run_mechanism,
 )
+
+
+ALL_TYPES = ["snippet", "tool", "skill", "vmcp", "vnfs"]
+
+
+# ── parse_fields_spec: default / full ────────────────────────────────
 
 
 def test_parse_none_returns_none():
     assert parse_fields_spec(None, "snippet") is None
+
+
+def test_parse_empty_returns_none():
     assert parse_fields_spec("", "snippet") is None
 
 
 def test_parse_full_returns_none():
+    """``"full"`` resolves to the no-filtering sentinel (``None``) — all
+    fields are returned and all bundling mechanisms run."""
     assert parse_fields_spec("full", "snippet") is None
 
 
-def test_parse_list_returns_preset_copy():
-    result = parse_fields_spec("list", "snippet")
-    assert result == SNIPPET_LIST_FIELDS
-    result.add("_scratch")
-    assert "_scratch" not in SNIPPET_LIST_FIELDS
-
-
-def test_parse_list_per_type():
-    assert parse_fields_spec("list", "snippet") == SNIPPET_LIST_FIELDS
-    assert parse_fields_spec("list", "tool") == TOOL_LIST_FIELDS
-    assert parse_fields_spec("list", "skill") == SKILL_LIST_FIELDS
-    assert parse_fields_spec("list", "vmcp") == VMCP_LIST_FIELDS
-    assert parse_fields_spec("list", "vnfs") == VNFS_LIST_FIELDS
-
-
-def test_parse_list_unknown_type_raises():
+def test_parse_none_unknown_type_raises():
     with pytest.raises(ValueError, match="No field tags registered"):
-        parse_fields_spec("list", "unknown")
+        parse_fields_spec(None, "unknown")
+
+
+# ── parse_fields_spec: narrow / wide ─────────────────────────────────
+
+
+def test_parse_narrow_returns_narrow_set_per_type():
+    assert parse_fields_spec("narrow", "snippet") == fs._fields_with_preset(
+        "snippet", "narrow"
+    )
+    assert parse_fields_spec("narrow", "tool") == fs._fields_with_preset(
+        "tool", "narrow"
+    )
+    assert parse_fields_spec("narrow", "skill") == fs._fields_with_preset(
+        "skill", "narrow"
+    )
+    assert parse_fields_spec("narrow", "vmcp") == fs._fields_with_preset(
+        "vmcp", "narrow"
+    )
+    assert parse_fields_spec("narrow", "vnfs") == fs._fields_with_preset(
+        "vnfs", "narrow"
+    )
+
+
+def test_parse_wide_returns_wide_set_per_type():
+    for t in ALL_TYPES:
+        assert parse_fields_spec("wide", t) == fs._fields_with_preset(t, "wide")
+
+
+def test_parse_preset_unknown_type_raises():
+    with pytest.raises(ValueError, match="No field tags registered"):
+        parse_fields_spec("narrow", "unknown")
+
+
+def test_parse_returned_set_is_fresh_copy():
+    """Mutating the returned set must not affect the underlying tag table."""
+    result = parse_fields_spec("narrow", "snippet")
+    result.add("_scratch")
+    assert "_scratch" not in fs._fields_with_preset("snippet", "narrow")
+
+
+# ── parse_fields_spec: CSV allowlist ─────────────────────────────────
 
 
 def test_parse_csv_allowlist():
     assert parse_fields_spec("uuid,name", "snippet") == {"uuid", "name"}
+
+
+def test_parse_csv_strips_whitespace_and_empty():
     assert parse_fields_spec(" uuid , name , ", "snippet") == {"uuid", "name"}
 
 
-def test_parse_csv_empty_string_falls_through_to_none():
+def test_parse_csv_all_commas_falls_through_to_none():
+    """No tokens → treated as default (full)."""
     assert parse_fields_spec(",,,", "snippet") is None
+
+
+def test_registered_preset_name_never_falls_through_to_csv(monkeypatch):
+    """``"narrow"`` must always resolve as a preset, never as a literal
+    field name via the CSV path."""
+    monkeypatch.setitem(
+        fs._FIELD_TAGS_BY_TYPE,
+        "snippet",
+        {"uuid": {"narrow"}, "detail": {"narrow"}},
+    )
+    assert parse_fields_spec("narrow", "snippet") == {"uuid", "detail"}
+
+
+def test_csv_can_include_flag_field():
+    """Explicit CSV allowlists may name a flag field to trigger a
+    bundling mechanism."""
+    result = parse_fields_spec("uuid,name,_populate", "skill")
+    assert result == {"uuid", "name", "_populate"}
+
+
+# ── should_run_mechanism ─────────────────────────────────────────────
+
+
+def test_should_run_mechanism_none_allow_runs():
+    """``None`` (full/default) triggers every mechanism."""
+    assert should_run_mechanism(None, "_populate") is True
+    assert should_run_mechanism(None, "_enhance") is True
+
+
+def test_should_run_mechanism_flag_in_allow():
+    assert should_run_mechanism({"uuid", "_populate"}, "_populate") is True
+    assert should_run_mechanism({"uuid", "_enhance"}, "_enhance") is True
+
+
+def test_should_run_mechanism_flag_absent():
+    assert should_run_mechanism({"uuid", "name"}, "_populate") is False
+    assert should_run_mechanism({"uuid", "name"}, "_enhance") is False
+
+
+def test_narrow_skill_does_not_trigger_populate():
+    """Skill narrow deliberately excludes ``_populate`` — the list page
+    reads counts from ``tool_uuids`` / ``snippet_uuids`` without needing
+    the inlined arrays."""
+    allow = parse_fields_spec("narrow", "skill")
+    assert should_run_mechanism(allow, "_populate") is False
+
+
+def test_narrow_vmcp_triggers_enhance():
+    """vMCP narrow must trigger ``_enhance`` — the Status column reads
+    ``running``, which only appears when enhancement runs."""
+    allow = parse_fields_spec("narrow", "vmcp")
+    assert should_run_mechanism(allow, "_enhance") is True
+
+
+def test_narrow_vnfs_triggers_enhance():
+    allow = parse_fields_spec("narrow", "vnfs")
+    assert should_run_mechanism(allow, "_enhance") is True
+
+
+def test_wide_never_triggers_bundling_mechanisms():
+    """Principle: ``wide`` is manifest data only. Flag fields are not in
+    wide, so none of the bundling mechanisms activate."""
+    for t in ALL_TYPES:
+        allow = parse_fields_spec("wide", t)
+        for flag in ("_populate", "_enhance"):
+            assert should_run_mechanism(allow, flag) is False, (
+                f"{t}.wide unexpectedly triggers {flag}"
+            )
+
+
+# ── select_item_fields ───────────────────────────────────────────────
 
 
 def test_select_item_fields_none_returns_input_ref():
@@ -91,109 +201,158 @@ def test_select_items_fields_none_returns_new_list_with_same_refs():
     assert result[0] is items[0]
 
 
-def test_snippet_preset_omits_content():
-    assert "content" not in SNIPPET_LIST_FIELDS
+# ── invariants on the preset registry ────────────────────────────────
 
 
-def test_tool_preset_omits_heavy_fields():
-    for k in ("params", "returns", "dependencies", "packaging_params"):
-        assert k not in TOOL_LIST_FIELDS
+def test_registered_preset_names():
+    """The public preset names are exactly the three called out by the
+    spec — narrow / wide / full — plus nothing else."""
+    assert _PRESET_NAMES == {"narrow", "wide", "full"}
 
 
-def test_skill_preset_omits_populated_arrays():
-    assert "tools" not in SKILL_LIST_FIELDS
-    assert "snippets" not in SKILL_LIST_FIELDS
-    assert "tool_uuids" in SKILL_LIST_FIELDS
-    assert "snippet_uuids" in SKILL_LIST_FIELDS
+def test_every_type_has_narrow_wide_full():
+    """Each registered type must define at least one field tagged with
+    every preset name."""
+    for t in ALL_TYPES:
+        for preset in ("narrow", "wide", "full"):
+            assert fs._fields_with_preset(t, preset), (
+                f"type '{t}' has no fields tagged '{preset}'"
+            )
 
 
-def test_vmcp_preset_keeps_runtime_status_fields():
-    # The list UI depends on ``running`` / ``runtime`` — they must survive
-    # the slim projection.
-    assert "running" in VMCP_LIST_FIELDS
-    assert "runtime" in VMCP_LIST_FIELDS
+def test_narrow_subset_of_full_per_type():
+    """``narrow`` must be a subset of ``full`` for every type."""
+    for t in ALL_TYPES:
+        narrow = fs._fields_with_preset(t, "narrow")
+        full = fs._fields_with_preset(t, "full")
+        assert narrow <= full, (
+            f"type '{t}' narrow={narrow} not subset of full={full}"
+        )
 
 
-def test_vnfs_preset_keeps_runtime_status_fields():
-    assert "running" in VNFS_LIST_FIELDS
-    assert "export_path" in VNFS_LIST_FIELDS
+def test_wide_subset_of_full_per_type():
+    for t in ALL_TYPES:
+        wide = fs._fields_with_preset(t, "wide")
+        full = fs._fields_with_preset(t, "full")
+        assert wide <= full, (
+            f"type '{t}' wide={wide} not subset of full={full}"
+        )
 
 
-# ── tag-based preset registry ─────────────────────────────────────────
+def test_wide_never_contains_flag_fields():
+    """Boolean flag fields (prefix ``_``) trigger bundling mechanisms —
+    they belong to ``full`` (and to ``narrow`` when the list UI needs
+    the mechanism's output) but never to ``wide``."""
+    for t in ALL_TYPES:
+        wide = fs._fields_with_preset(t, "wide")
+        flags = {name for name in wide if name.startswith("_")}
+        assert not flags, f"type '{t}' has flag fields in wide: {flags}"
 
 
-def test_list_constants_match_tagged_fields_per_type():
-    """The public ``*_LIST_FIELDS`` constants are computed views over the
-    ``"list"`` tag of each type's field-tag table. Any drift (a field
-    tagged ``"list"`` but missing from the constant, or vice-versa) is a
-    bug in the registry."""
-    assert SNIPPET_LIST_FIELDS == fs._fields_with_preset("snippet", "list")
-    assert TOOL_LIST_FIELDS == fs._fields_with_preset("tool", "list")
-    assert SKILL_LIST_FIELDS == fs._fields_with_preset("skill", "list")
-    assert VMCP_LIST_FIELDS == fs._fields_with_preset("vmcp", "list")
-    assert VNFS_LIST_FIELDS == fs._fields_with_preset("vnfs", "list")
+def test_full_covers_every_declared_field():
+    """Every field in each type's tag table must carry the ``full``
+    preset — ``full`` is the total set."""
+    for t, tags in _FIELD_TAGS_BY_TYPE.items():
+        for name, presets in tags.items():
+            assert "full" in presets, (
+                f"type '{t}' field '{name}' not tagged 'full' (presets={presets})"
+            )
 
 
-def test_all_known_presets_currently_only_list():
-    """Today the registry only declares the ``"list"`` preset. This test
-    documents that invariant; adding a new preset should require an
-    intentional update here."""
-    assert fs._all_known_presets() == {"list"}
+# ── per-type narrow shape (the UI listing-page contract) ─────────────
 
 
-def test_field_can_carry_multiple_presets(monkeypatch):
-    """Tagging a single field with more than one preset must resolve
-    correctly for each preset independently — the core new-model
-    invariant."""
-    monkeypatch.setitem(
-        fs._FIELD_TAGS_BY_TYPE,
-        "snippet",
-        {
-            "uuid": {"list", "summary"},
-            "name": {"list", "summary"},
-            "description": {"list"},
-            "content": set(),
-        },
-    )
-    assert parse_fields_spec("list", "snippet") == {"uuid", "name", "description"}
-    assert parse_fields_spec("summary", "snippet") == {"uuid", "name"}
+def test_snippet_narrow_shape():
+    assert fs._fields_with_preset("snippet", "narrow") == {
+        "uuid",
+        "name",
+        "description",
+        "state",
+        "tags",
+        "version",
+        "content_type",
+    }
 
 
-def test_known_preset_undeclared_for_type_raises(monkeypatch):
-    """If a preset name is declared for *some* type but no field of the
-    target type carries it, requesting it must raise — no silent CSV
-    fallback that would return ``{}`` per item."""
-    # ``"summary"`` is declared for snippet but not for tool.
-    monkeypatch.setitem(
-        fs._FIELD_TAGS_BY_TYPE,
-        "snippet",
-        {"uuid": {"list", "summary"}, "name": {"list"}},
-    )
-    monkeypatch.setitem(
-        fs._FIELD_TAGS_BY_TYPE,
-        "tool",
-        {"uuid": {"list"}, "name": {"list"}},
-    )
-    assert parse_fields_spec("summary", "snippet") == {"uuid"}
-    with pytest.raises(ValueError, match="No 'summary' preset"):
-        parse_fields_spec("summary", "tool")
+def test_tool_narrow_shape():
+    assert fs._fields_with_preset("tool", "narrow") == {
+        "uuid",
+        "name",
+        "description",
+        "state",
+        "tags",
+        "version",
+        "module_name",
+    }
 
 
-def test_csv_still_supported_for_arbitrary_allowlist():
-    """A caller-defined CSV must still resolve to the literal token set —
-    the "unknown-preset-name" branch only triggers when the token is a
-    registered preset name for some type."""
-    assert parse_fields_spec("uuid,name,port", "vmcp") == {"uuid", "name", "port"}
+def test_skill_narrow_shape():
+    assert fs._fields_with_preset("skill", "narrow") == {
+        "uuid",
+        "name",
+        "description",
+        "state",
+        "tags",
+        "version",
+        "tool_uuids",
+        "snippet_uuids",
+    }
 
 
-def test_registered_preset_name_never_falls_through_to_csv(monkeypatch):
-    """Backstop: a bare token that happens to be a known preset name must
-    always take the preset path, never the CSV path — regardless of the
-    caller's intent."""
-    monkeypatch.setitem(
-        fs._FIELD_TAGS_BY_TYPE,
-        "snippet",
-        {"uuid": {"list"}, "detail": {"list"}},
-    )
-    # ``"list"`` is a known preset — this must NOT parse as ``{"list"}``.
-    assert parse_fields_spec("list", "snippet") == {"uuid", "detail"}
+def test_vmcp_narrow_shape():
+    """vMCP narrow includes ``_enhance``, ``running``, and ``runtime`` —
+    enhancement runs and both bundled outputs come with it (the list
+    view happens to render only ``running``)."""
+    assert fs._fields_with_preset("vmcp", "narrow") == {
+        "uuid",
+        "name",
+        "description",
+        "state",
+        "tags",
+        "version",
+        "port",
+        "_enhance",
+        "running",
+        "runtime",
+    }
+
+
+def test_vnfs_narrow_shape():
+    assert fs._fields_with_preset("vnfs", "narrow") == {
+        "uuid",
+        "name",
+        "description",
+        "state",
+        "tags",
+        "version",
+        "port",
+        "protocol",
+        "_enhance",
+        "running",
+        "export_path",
+    }
+
+
+# ── wide invariant: every persisted schema field, no flags ───────────
+
+
+def test_wide_contains_manifest_base_fields():
+    """Every type inherits from ManifestSchema — its base fields must be
+    in ``wide`` (and ``full``) for every type."""
+    base = {
+        "uuid",
+        "name",
+        "version",
+        "description",
+        "state",
+        "tags",
+        "extra",
+        "parent",
+        "created_at",
+        "modified_at",
+    }
+    for t in ALL_TYPES:
+        wide = fs._fields_with_preset(t, "wide")
+        assert base <= wide, (
+            f"type '{t}' wide is missing manifest fields: {base - wide}"
+        )

--- a/src/skillberry_store/tests/services/test_field_selection.py
+++ b/src/skillberry_store/tests/services/test_field_selection.py
@@ -6,6 +6,8 @@ from skillberry_store.services.field_selection import (
     SKILL_LIST_FIELDS,
     SNIPPET_LIST_FIELDS,
     TOOL_LIST_FIELDS,
+    VMCP_LIST_FIELDS,
+    VNFS_LIST_FIELDS,
     parse_fields_spec,
     select_item_fields,
     select_items_fields,
@@ -32,6 +34,8 @@ def test_parse_list_per_type():
     assert parse_fields_spec("list", "snippet") == SNIPPET_LIST_FIELDS
     assert parse_fields_spec("list", "tool") == TOOL_LIST_FIELDS
     assert parse_fields_spec("list", "skill") == SKILL_LIST_FIELDS
+    assert parse_fields_spec("list", "vmcp") == VMCP_LIST_FIELDS
+    assert parse_fields_spec("list", "vnfs") == VNFS_LIST_FIELDS
 
 
 def test_parse_list_unknown_type_raises():
@@ -100,3 +104,15 @@ def test_skill_preset_omits_populated_arrays():
     assert "snippets" not in SKILL_LIST_FIELDS
     assert "tool_uuids" in SKILL_LIST_FIELDS
     assert "snippet_uuids" in SKILL_LIST_FIELDS
+
+
+def test_vmcp_preset_keeps_runtime_status_fields():
+    # The list UI depends on ``running`` / ``runtime`` — they must survive
+    # the slim projection.
+    assert "running" in VMCP_LIST_FIELDS
+    assert "runtime" in VMCP_LIST_FIELDS
+
+
+def test_vnfs_preset_keeps_runtime_status_fields():
+    assert "running" in VNFS_LIST_FIELDS
+    assert "export_path" in VNFS_LIST_FIELDS

--- a/src/skillberry_store/tests/services/test_field_selection.py
+++ b/src/skillberry_store/tests/services/test_field_selection.py
@@ -1,14 +1,14 @@
-"""Unit tests for the field-projection helpers used by list endpoints."""
+"""Unit tests for the field-selection helpers used by list endpoints."""
 
 import pytest
 
-from skillberry_store.services.list_projections import (
+from skillberry_store.services.field_selection import (
     SKILL_LIST_FIELDS,
     SNIPPET_LIST_FIELDS,
     TOOL_LIST_FIELDS,
     parse_fields_spec,
-    project_item,
-    project_items,
+    select_item_fields,
+    select_items_fields,
 )
 
 
@@ -48,39 +48,39 @@ def test_parse_csv_empty_string_falls_through_to_none():
     assert parse_fields_spec(",,,", "snippet") is None
 
 
-def test_project_item_none_returns_input_ref():
+def test_select_item_fields_none_returns_input_ref():
     item = {"uuid": "u1", "name": "n"}
-    assert project_item(item, None) is item
+    assert select_item_fields(item, None) is item
 
 
-def test_project_item_returns_fresh_dict_subset():
+def test_select_item_fields_returns_fresh_dict_subset():
     item = {"uuid": "u1", "name": "n", "content": "big"}
-    result = project_item(item, {"uuid", "name"})
+    result = select_item_fields(item, {"uuid", "name"})
     assert result == {"uuid": "u1", "name": "n"}
     assert result is not item
 
 
-def test_project_item_ignores_missing_fields():
+def test_select_item_fields_ignores_missing_fields():
     item = {"uuid": "u1"}
-    result = project_item(item, {"uuid", "modified_at"})
+    result = select_item_fields(item, {"uuid", "modified_at"})
     assert result == {"uuid": "u1"}
 
 
-def test_project_item_does_not_mutate_source():
+def test_select_item_fields_does_not_mutate_source():
     item = {"uuid": "u1", "name": "n", "content": "big"}
-    project_item(item, {"uuid"})
+    select_item_fields(item, {"uuid"})
     assert item == {"uuid": "u1", "name": "n", "content": "big"}
 
 
-def test_project_items_shape():
+def test_select_items_fields_shape():
     items = [{"uuid": "a", "content": "1"}, {"uuid": "b", "content": "2"}]
-    result = project_items(items, {"uuid"})
+    result = select_items_fields(items, {"uuid"})
     assert result == [{"uuid": "a"}, {"uuid": "b"}]
 
 
-def test_project_items_none_returns_new_list_with_same_refs():
+def test_select_items_fields_none_returns_new_list_with_same_refs():
     items = [{"uuid": "a"}, {"uuid": "b"}]
-    result = project_items(items, None)
+    result = select_items_fields(items, None)
     assert result == items
     assert result is not items
     assert result[0] is items[0]

--- a/src/skillberry_store/tests/services/test_field_selection.py
+++ b/src/skillberry_store/tests/services/test_field_selection.py
@@ -35,11 +35,15 @@ def test_parse_empty_returns_narrow_allowlist():
     )
 
 
-def test_parse_full_returns_none():
-    """``"full"`` is the explicit opt-out — resolves to the
-    no-filtering sentinel (``None``); all fields are returned and all
-    bundling mechanisms run."""
-    assert parse_fields_spec("full", "snippet") is None
+def test_parse_full_returns_full_allowlist():
+    """``"full"`` resolves through the FieldTags like any other preset:
+    the returned allowlist is exactly the fields tagged ``"full"`` for
+    that type — which by convention covers every declared field,
+    including the underscore-prefixed flag fields."""
+    result = parse_fields_spec("full", "snippet")
+    assert result == fs._fields_with_preset("snippet", "full")
+    assert "content" in result  # payload field
+    assert "modified_at" in result  # timestamp field
 
 
 def test_parse_none_unknown_type_raises():
@@ -130,13 +134,6 @@ def test_csv_can_include_flag_field():
 # ── should_run_mechanism ─────────────────────────────────────────────
 
 
-def test_should_run_mechanism_none_allow_runs():
-    """``None`` (the ``"full"`` opt-out sentinel) triggers every
-    mechanism."""
-    assert should_run_mechanism(None, "_populate") is True
-    assert should_run_mechanism(None, "_enhance") is True
-
-
 def test_should_run_mechanism_flag_in_allow():
     assert should_run_mechanism({"uuid", "_populate"}, "_populate") is True
     assert should_run_mechanism({"uuid", "_enhance"}, "_enhance") is True
@@ -145,6 +142,19 @@ def test_should_run_mechanism_flag_in_allow():
 def test_should_run_mechanism_flag_absent():
     assert should_run_mechanism({"uuid", "name"}, "_populate") is False
     assert should_run_mechanism({"uuid", "name"}, "_enhance") is False
+
+
+def test_full_preset_triggers_every_mechanism():
+    """``"full"`` tags every flag field for every type, so
+    :func:`should_run_mechanism` fires for each of them."""
+    for t in ALL_TYPES:
+        allow = parse_fields_spec("full", t)
+        tags = fs._FIELD_TAGS_BY_TYPE[t]
+        for name in tags:
+            if name.startswith("_"):
+                assert should_run_mechanism(allow, name) is True, (
+                    f"type '{t}' full does not trigger '{name}'"
+                )
 
 
 def test_narrow_skill_does_not_trigger_populate():
@@ -181,15 +191,19 @@ def test_wide_never_triggers_bundling_mechanisms():
 # ── select_item_fields ───────────────────────────────────────────────
 
 
-def test_select_item_fields_none_returns_input_ref():
-    item = {"uuid": "u1", "name": "n"}
-    assert select_item_fields(item, None) is item
-
-
 def test_select_item_fields_returns_fresh_dict_subset():
     item = {"uuid": "u1", "name": "n", "content": "big"}
     result = select_item_fields(item, {"uuid", "name"})
     assert result == {"uuid": "u1", "name": "n"}
+    assert result is not item
+
+
+def test_select_item_fields_full_allowlist_returns_fresh_copy():
+    """Even the full allowlist returns a fresh dict — callers can
+    freely mutate the result without affecting the source."""
+    item = {"uuid": "u1", "name": "n", "content": "big"}
+    result = select_item_fields(item, {"uuid", "name", "content"})
+    assert result == item
     assert result is not item
 
 
@@ -211,12 +225,14 @@ def test_select_items_fields_shape():
     assert result == [{"uuid": "a"}, {"uuid": "b"}]
 
 
-def test_select_items_fields_none_returns_new_list_with_same_refs():
+def test_select_items_fields_returns_fresh_dicts():
+    """Every returned dict is a fresh copy — mutating one must not
+    affect the source item."""
     items = [{"uuid": "a"}, {"uuid": "b"}]
-    result = select_items_fields(items, None)
+    result = select_items_fields(items, {"uuid"})
     assert result == items
-    assert result is not items
-    assert result[0] is items[0]
+    assert result[0] is not items[0]
+    assert result[1] is not items[1]
 
 
 # ── invariants on the preset registry ────────────────────────────────

--- a/src/skillberry_store/tests/services/test_field_selection.py
+++ b/src/skillberry_store/tests/services/test_field_selection.py
@@ -19,23 +19,37 @@ ALL_TYPES = ["snippet", "tool", "skill", "vmcp", "vnfs"]
 # ── parse_fields_spec: default / full ────────────────────────────────
 
 
-def test_parse_none_returns_none():
-    assert parse_fields_spec(None, "snippet") is None
+def test_parse_none_returns_narrow_allowlist():
+    """The default preset is ``narrow`` — a missing ``fields_spec``
+    resolves to the narrow allowlist for the type."""
+    assert parse_fields_spec(None, "snippet") == fs._fields_with_preset(
+        "snippet", "narrow"
+    )
 
 
-def test_parse_empty_returns_none():
-    assert parse_fields_spec("", "snippet") is None
+def test_parse_empty_returns_narrow_allowlist():
+    """An empty query-string value is treated the same as omitted:
+    resolves to the narrow allowlist."""
+    assert parse_fields_spec("", "snippet") == fs._fields_with_preset(
+        "snippet", "narrow"
+    )
 
 
 def test_parse_full_returns_none():
-    """``"full"`` resolves to the no-filtering sentinel (``None``) — all
-    fields are returned and all bundling mechanisms run."""
+    """``"full"`` is the explicit opt-out — resolves to the
+    no-filtering sentinel (``None``); all fields are returned and all
+    bundling mechanisms run."""
     assert parse_fields_spec("full", "snippet") is None
 
 
 def test_parse_none_unknown_type_raises():
     with pytest.raises(ValueError, match="No field tags registered"):
         parse_fields_spec(None, "unknown")
+
+
+def test_parse_full_unknown_type_raises():
+    with pytest.raises(ValueError, match="No field tags registered"):
+        parse_fields_spec("full", "unknown")
 
 
 # ── parse_fields_spec: narrow / wide ─────────────────────────────────
@@ -87,9 +101,12 @@ def test_parse_csv_strips_whitespace_and_empty():
     assert parse_fields_spec(" uuid , name , ", "snippet") == {"uuid", "name"}
 
 
-def test_parse_csv_all_commas_falls_through_to_none():
-    """No tokens → treated as default (full)."""
-    assert parse_fields_spec(",,,", "snippet") is None
+def test_parse_csv_all_commas_falls_through_to_narrow():
+    """A CSV with no non-empty tokens is treated as an omitted spec —
+    resolves to the narrow default."""
+    assert parse_fields_spec(",,,", "snippet") == fs._fields_with_preset(
+        "snippet", "narrow"
+    )
 
 
 def test_registered_preset_name_never_falls_through_to_csv(monkeypatch):
@@ -114,7 +131,8 @@ def test_csv_can_include_flag_field():
 
 
 def test_should_run_mechanism_none_allow_runs():
-    """``None`` (full/default) triggers every mechanism."""
+    """``None`` (the ``"full"`` opt-out sentinel) triggers every
+    mechanism."""
     assert should_run_mechanism(None, "_populate") is True
     assert should_run_mechanism(None, "_enhance") is True
 

--- a/src/skillberry_store/tests/services/test_field_selection.py
+++ b/src/skillberry_store/tests/services/test_field_selection.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from skillberry_store.services import field_selection as fs
 from skillberry_store.services.field_selection import (
     SKILL_LIST_FIELDS,
     SNIPPET_LIST_FIELDS,
@@ -39,7 +40,7 @@ def test_parse_list_per_type():
 
 
 def test_parse_list_unknown_type_raises():
-    with pytest.raises(ValueError, match="No list preset"):
+    with pytest.raises(ValueError, match="No field tags registered"):
         parse_fields_spec("list", "unknown")
 
 
@@ -116,3 +117,83 @@ def test_vmcp_preset_keeps_runtime_status_fields():
 def test_vnfs_preset_keeps_runtime_status_fields():
     assert "running" in VNFS_LIST_FIELDS
     assert "export_path" in VNFS_LIST_FIELDS
+
+
+# ── tag-based preset registry ─────────────────────────────────────────
+
+
+def test_list_constants_match_tagged_fields_per_type():
+    """The public ``*_LIST_FIELDS`` constants are computed views over the
+    ``"list"`` tag of each type's field-tag table. Any drift (a field
+    tagged ``"list"`` but missing from the constant, or vice-versa) is a
+    bug in the registry."""
+    assert SNIPPET_LIST_FIELDS == fs._fields_with_preset("snippet", "list")
+    assert TOOL_LIST_FIELDS == fs._fields_with_preset("tool", "list")
+    assert SKILL_LIST_FIELDS == fs._fields_with_preset("skill", "list")
+    assert VMCP_LIST_FIELDS == fs._fields_with_preset("vmcp", "list")
+    assert VNFS_LIST_FIELDS == fs._fields_with_preset("vnfs", "list")
+
+
+def test_all_known_presets_currently_only_list():
+    """Today the registry only declares the ``"list"`` preset. This test
+    documents that invariant; adding a new preset should require an
+    intentional update here."""
+    assert fs._all_known_presets() == {"list"}
+
+
+def test_field_can_carry_multiple_presets(monkeypatch):
+    """Tagging a single field with more than one preset must resolve
+    correctly for each preset independently — the core new-model
+    invariant."""
+    monkeypatch.setitem(
+        fs._FIELD_TAGS_BY_TYPE,
+        "snippet",
+        {
+            "uuid": {"list", "summary"},
+            "name": {"list", "summary"},
+            "description": {"list"},
+            "content": set(),
+        },
+    )
+    assert parse_fields_spec("list", "snippet") == {"uuid", "name", "description"}
+    assert parse_fields_spec("summary", "snippet") == {"uuid", "name"}
+
+
+def test_known_preset_undeclared_for_type_raises(monkeypatch):
+    """If a preset name is declared for *some* type but no field of the
+    target type carries it, requesting it must raise — no silent CSV
+    fallback that would return ``{}`` per item."""
+    # ``"summary"`` is declared for snippet but not for tool.
+    monkeypatch.setitem(
+        fs._FIELD_TAGS_BY_TYPE,
+        "snippet",
+        {"uuid": {"list", "summary"}, "name": {"list"}},
+    )
+    monkeypatch.setitem(
+        fs._FIELD_TAGS_BY_TYPE,
+        "tool",
+        {"uuid": {"list"}, "name": {"list"}},
+    )
+    assert parse_fields_spec("summary", "snippet") == {"uuid"}
+    with pytest.raises(ValueError, match="No 'summary' preset"):
+        parse_fields_spec("summary", "tool")
+
+
+def test_csv_still_supported_for_arbitrary_allowlist():
+    """A caller-defined CSV must still resolve to the literal token set —
+    the "unknown-preset-name" branch only triggers when the token is a
+    registered preset name for some type."""
+    assert parse_fields_spec("uuid,name,port", "vmcp") == {"uuid", "name", "port"}
+
+
+def test_registered_preset_name_never_falls_through_to_csv(monkeypatch):
+    """Backstop: a bare token that happens to be a known preset name must
+    always take the preset path, never the CSV path — regardless of the
+    caller's intent."""
+    monkeypatch.setitem(
+        fs._FIELD_TAGS_BY_TYPE,
+        "snippet",
+        {"uuid": {"list"}, "detail": {"list"}},
+    )
+    # ``"list"`` is a known preset — this must NOT parse as ``{"list"}``.
+    assert parse_fields_spec("list", "snippet") == {"uuid", "detail"}

--- a/src/skillberry_store/tests/services/test_list_projections.py
+++ b/src/skillberry_store/tests/services/test_list_projections.py
@@ -1,0 +1,102 @@
+"""Unit tests for the field-projection helpers used by list endpoints."""
+
+import pytest
+
+from skillberry_store.services.list_projections import (
+    SKILL_LIST_FIELDS,
+    SNIPPET_LIST_FIELDS,
+    TOOL_LIST_FIELDS,
+    parse_fields_spec,
+    project_item,
+    project_items,
+)
+
+
+def test_parse_none_returns_none():
+    assert parse_fields_spec(None, "snippet") is None
+    assert parse_fields_spec("", "snippet") is None
+
+
+def test_parse_full_returns_none():
+    assert parse_fields_spec("full", "snippet") is None
+
+
+def test_parse_list_returns_preset_copy():
+    result = parse_fields_spec("list", "snippet")
+    assert result == SNIPPET_LIST_FIELDS
+    result.add("_scratch")
+    assert "_scratch" not in SNIPPET_LIST_FIELDS
+
+
+def test_parse_list_per_type():
+    assert parse_fields_spec("list", "snippet") == SNIPPET_LIST_FIELDS
+    assert parse_fields_spec("list", "tool") == TOOL_LIST_FIELDS
+    assert parse_fields_spec("list", "skill") == SKILL_LIST_FIELDS
+
+
+def test_parse_list_unknown_type_raises():
+    with pytest.raises(ValueError, match="No list preset"):
+        parse_fields_spec("list", "unknown")
+
+
+def test_parse_csv_allowlist():
+    assert parse_fields_spec("uuid,name", "snippet") == {"uuid", "name"}
+    assert parse_fields_spec(" uuid , name , ", "snippet") == {"uuid", "name"}
+
+
+def test_parse_csv_empty_string_falls_through_to_none():
+    assert parse_fields_spec(",,,", "snippet") is None
+
+
+def test_project_item_none_returns_input_ref():
+    item = {"uuid": "u1", "name": "n"}
+    assert project_item(item, None) is item
+
+
+def test_project_item_returns_fresh_dict_subset():
+    item = {"uuid": "u1", "name": "n", "content": "big"}
+    result = project_item(item, {"uuid", "name"})
+    assert result == {"uuid": "u1", "name": "n"}
+    assert result is not item
+
+
+def test_project_item_ignores_missing_fields():
+    item = {"uuid": "u1"}
+    result = project_item(item, {"uuid", "modified_at"})
+    assert result == {"uuid": "u1"}
+
+
+def test_project_item_does_not_mutate_source():
+    item = {"uuid": "u1", "name": "n", "content": "big"}
+    project_item(item, {"uuid"})
+    assert item == {"uuid": "u1", "name": "n", "content": "big"}
+
+
+def test_project_items_shape():
+    items = [{"uuid": "a", "content": "1"}, {"uuid": "b", "content": "2"}]
+    result = project_items(items, {"uuid"})
+    assert result == [{"uuid": "a"}, {"uuid": "b"}]
+
+
+def test_project_items_none_returns_new_list_with_same_refs():
+    items = [{"uuid": "a"}, {"uuid": "b"}]
+    result = project_items(items, None)
+    assert result == items
+    assert result is not items
+    assert result[0] is items[0]
+
+
+def test_snippet_preset_omits_content():
+    assert "content" not in SNIPPET_LIST_FIELDS
+
+
+def test_tool_preset_omits_heavy_fields():
+    for k in ("params", "returns", "dependencies", "packaging_params"):
+        assert k not in TOOL_LIST_FIELDS
+
+
+def test_skill_preset_omits_populated_arrays():
+    assert "tools" not in SKILL_LIST_FIELDS
+    assert "snippets" not in SKILL_LIST_FIELDS
+    assert "tool_uuids" in SKILL_LIST_FIELDS
+    assert "snippet_uuids" in SKILL_LIST_FIELDS

--- a/src/skillberry_store/tests/services/test_skills_service.py
+++ b/src/skillberry_store/tests/services/test_skills_service.py
@@ -71,6 +71,70 @@ def test_list_all_tolerates_skill_with_missing_tool():
     assert broken["snippets"] == []
 
 
+def test_list_all_default_populates_but_does_not_mutate_cache_entry(monkeypatch):
+    import skillberry_store.services.registry as registry
+    tools_svc = MagicMock()
+    tools_svc.get.return_value = {"uuid": "t1", "name": "tool1"}
+    snippets_svc = MagicMock()
+    snippets_svc.get.return_value = {"uuid": "s1", "name": "snip1"}
+    monkeypatch.setattr(registry, "_initialized", True)
+    monkeypatch.setattr(
+        registry, "_services", {"tool": tools_svc, "snippet": snippets_svc}
+    )
+    h = _handler()
+    original = {
+        "uuid": "sk1",
+        "name": "sk1",
+        "tool_uuids": ["t1"],
+        "snippet_uuids": ["s1"],
+        "modified_at": "2024-02-01",
+    }
+    h.list_all_dicts.return_value = [original]
+    svc = SkillsService(h)
+    result = svc.list_all()
+    assert result[0]["tools"] == [{"uuid": "t1", "name": "tool1"}]
+    assert result[0]["snippets"] == [{"uuid": "s1", "name": "snip1"}]
+    # Regression: the cached dict must not have grown 'tools' / 'snippets'.
+    assert "tools" not in original
+    assert "snippets" not in original
+
+
+def test_list_all_list_preset_skips_populate_and_keeps_uuid_arrays():
+    h = _handler()
+    h.list_all_dicts.return_value = [
+        {
+            "uuid": "sk1",
+            "name": "sk1",
+            "tool_uuids": ["t1", "t2"],
+            "snippet_uuids": ["s1"],
+            "modified_at": "2024-02-01",
+        },
+    ]
+    svc = SkillsService(h)
+    # No registry patching — a bug that reaches populate_objects would raise.
+    result = svc.list_all(fields="list")
+    assert result[0]["tool_uuids"] == ["t1", "t2"]
+    assert result[0]["snippet_uuids"] == ["s1"]
+    assert "tools" not in result[0]
+    assert "snippets" not in result[0]
+
+
+def test_list_all_custom_allowlist():
+    h = _handler()
+    h.list_all_dicts.return_value = [
+        {
+            "uuid": "sk1",
+            "name": "sk1",
+            "tool_uuids": ["t1"],
+            "snippet_uuids": [],
+            "modified_at": "2024-02-01",
+        },
+    ]
+    svc = SkillsService(h)
+    result = svc.list_all(fields="uuid,name")
+    assert result == [{"uuid": "sk1", "name": "sk1"}]
+
+
 def test_delete_updates_cache_then_deletes():
     h = _handler()
     mock_svc = MagicMock()

--- a/src/skillberry_store/tests/services/test_skills_service.py
+++ b/src/skillberry_store/tests/services/test_skills_service.py
@@ -99,7 +99,9 @@ def test_list_all_default_populates_but_does_not_mutate_cache_entry(monkeypatch)
     assert "snippets" not in original
 
 
-def test_list_all_list_preset_skips_populate_and_keeps_uuid_arrays():
+def test_list_all_narrow_preset_skips_populate_and_keeps_uuid_arrays():
+    """``narrow`` does not tag ``_populate``, so ``populate_objects`` must
+    not run — callers read counts from ``tool_uuids`` / ``snippet_uuids``."""
     h = _handler()
     h.list_all_dicts.return_value = [
         {
@@ -112,11 +114,59 @@ def test_list_all_list_preset_skips_populate_and_keeps_uuid_arrays():
     ]
     svc = SkillsService(h)
     # No registry patching — a bug that reaches populate_objects would raise.
-    result = svc.list_all(fields="list")
+    result = svc.list_all(fields="narrow")
     assert result[0]["tool_uuids"] == ["t1", "t2"]
     assert result[0]["snippet_uuids"] == ["s1"]
     assert "tools" not in result[0]
     assert "snippets" not in result[0]
+
+
+def test_list_all_wide_preset_skips_populate():
+    """``wide`` is manifest data only — no flag fields, no bundling."""
+    h = _handler()
+    h.list_all_dicts.return_value = [
+        {
+            "uuid": "sk1",
+            "name": "sk1",
+            "tool_uuids": ["t1"],
+            "snippet_uuids": ["s1"],
+            "modified_at": "2024-02-01",
+        },
+    ]
+    svc = SkillsService(h)
+    result = svc.list_all(fields="wide")
+    assert result[0]["tool_uuids"] == ["t1"]
+    assert "tools" not in result[0]
+    assert "snippets" not in result[0]
+
+
+def test_list_all_populate_flag_in_csv_triggers_populate(monkeypatch):
+    """Explicit CSV allowlist containing ``_populate`` must run the
+    populate mechanism."""
+    from skillberry_store.services import registry
+
+    tools_svc = MagicMock()
+    tools_svc.get.side_effect = lambda u: {"uuid": u, "name": f"tool-{u}"}
+    snippets_svc = MagicMock()
+    snippets_svc.get.side_effect = lambda u: {"uuid": u, "name": f"snip-{u}"}
+    monkeypatch.setattr(registry, "_initialized", True)
+    monkeypatch.setattr(
+        registry, "_services", {"tool": tools_svc, "snippet": snippets_svc}
+    )
+    h = _handler()
+    h.list_all_dicts.return_value = [
+        {
+            "uuid": "sk1",
+            "name": "sk1",
+            "tool_uuids": ["t1"],
+            "snippet_uuids": ["s1"],
+            "modified_at": "2024-02-01",
+        },
+    ]
+    svc = SkillsService(h)
+    result = svc.list_all(fields="uuid,tools,snippets,_populate")
+    assert result[0]["tools"] == [{"uuid": "t1", "name": "tool-t1"}]
+    assert result[0]["snippets"] == [{"uuid": "s1", "name": "snip-s1"}]
 
 
 def test_list_all_custom_allowlist():
@@ -157,21 +207,41 @@ def _search_handler_skills(cached_skill):
     return h
 
 
-def test_search_default_returns_legacy_shape():
+def test_search_default_runs_populate_and_returns_full_object(monkeypatch):
+    """Default ``fields=None`` resolves to ``full`` — ``_populate`` runs
+    and the response includes inlined ``tools`` / ``snippets``."""
+    from skillberry_store.services import registry
+
+    tools_svc = MagicMock()
+    tools_svc.get.side_effect = lambda u: {"uuid": u, "name": f"tool-{u}"}
+    snippets_svc = MagicMock()
+    snippets_svc.get.side_effect = lambda u: {"uuid": u, "name": f"snip-{u}"}
+    monkeypatch.setattr(registry, "_initialized", True)
+    monkeypatch.setattr(
+        registry, "_services", {"tool": tools_svc, "snippet": snippets_svc}
+    )
     cached = {
         "uuid": "sk1",
         "name": "sk1",
         "state": "approved",
         "tool_uuids": ["t1"],
-        "snippet_uuids": [],
+        "snippet_uuids": ["s1"],
         "modified_at": "2024-02-01",
     }
     svc = SkillsService(_search_handler_skills(cached))
     result = svc.search("q")
-    assert result == [{"filename": "sk1", "similarity_score": 0.4}]
+    assert len(result) == 1
+    r = result[0]
+    assert r["name"] == "sk1"
+    assert r["tools"] == [{"uuid": "t1", "name": "tool-t1"}]
+    assert r["snippets"] == [{"uuid": "s1", "name": "snip-s1"}]
+    assert r["similarity_score"] == 0.4
 
 
 def test_search_does_not_mutate_cache_entry():
+    """Search must not attach ``similarity_score`` (or bundled outputs)
+    onto the shared cache dict — the field is only merged into the
+    per-match projected copy."""
     cached = {
         "uuid": "sk1",
         "name": "sk1",
@@ -181,11 +251,13 @@ def test_search_does_not_mutate_cache_entry():
         "modified_at": "2024-02-01",
     }
     svc = SkillsService(_search_handler_skills(cached))
-    svc.search("q")
+    svc.search("q", fields="narrow")
     assert "similarity_score" not in cached
+    assert "tools" not in cached
+    assert "snippets" not in cached
 
 
-def test_search_with_fields_list_skips_populate_and_keeps_uuid_arrays():
+def test_search_with_fields_narrow_skips_populate_and_keeps_uuid_arrays():
     cached = {
         "uuid": "sk1",
         "name": "sk1",
@@ -196,7 +268,7 @@ def test_search_with_fields_list_skips_populate_and_keeps_uuid_arrays():
     }
     svc = SkillsService(_search_handler_skills(cached))
     # No registry patching — reaching populate_objects would raise.
-    result = svc.search("q", fields="list")
+    result = svc.search("q", fields="narrow")
     r = result[0]
     assert r["tool_uuids"] == ["t1", "t2"]
     assert r["snippet_uuids"] == ["s1"]

--- a/src/skillberry_store/tests/services/test_skills_service.py
+++ b/src/skillberry_store/tests/services/test_skills_service.py
@@ -57,21 +57,50 @@ def test_list_all_returns_sorted_and_populated():
     assert len(result) == 1
 
 
-def test_list_all_tolerates_skill_with_missing_tool():
+def test_list_all_full_tolerates_skill_with_missing_tool():
+    """``fields="full"`` triggers ``_populate`` — a missing tool UUID
+    resolves to an empty populated list rather than raising."""
     h = _handler()
     h.list_all_dicts.return_value = [
         {"name": "get_time", "modified_at": "2024-02-01", "tool_uuids": ["missing-uuid"], "snippet_uuids": []},
         {"name": "other", "modified_at": "2024-01-01", "tool_uuids": [], "snippet_uuids": []},
     ]
     svc = SkillsService(h)
-    result = svc.list_all()
+    result = svc.list_all(fields="full")
     assert len(result) == 2
     broken = next(r for r in result if r["name"] == "get_time")
     assert broken["tools"] == []
     assert broken["snippets"] == []
 
 
-def test_list_all_default_populates_but_does_not_mutate_cache_entry(monkeypatch):
+def test_list_all_default_is_narrow_skips_populate():
+    """Default (no ``fields``) is ``narrow``; the ``_populate`` mechanism
+    does NOT run — no ``tools`` / ``snippets`` inlining. Callers read
+    counts from ``tool_uuids`` / ``snippet_uuids``. This runs without a
+    registry: a bug that reaches ``populate_objects`` would raise."""
+    h = _handler()
+    original = {
+        "uuid": "sk1",
+        "name": "sk1",
+        "tool_uuids": ["t1"],
+        "snippet_uuids": ["s1"],
+        "modified_at": "2024-02-01",
+    }
+    h.list_all_dicts.return_value = [original]
+    svc = SkillsService(h)
+    result = svc.list_all()
+    assert result[0]["tool_uuids"] == ["t1"]
+    assert result[0]["snippet_uuids"] == ["s1"]
+    assert "tools" not in result[0]
+    assert "snippets" not in result[0]
+    # Regression: the cached dict must not have grown 'tools' / 'snippets'.
+    assert "tools" not in original
+    assert "snippets" not in original
+
+
+def test_list_all_fields_full_populates_but_does_not_mutate_cache_entry(monkeypatch):
+    """``fields="full"`` triggers ``_populate``: ``tools`` / ``snippets``
+    are inlined on the result but not written back to the cache."""
     import skillberry_store.services.registry as registry
     tools_svc = MagicMock()
     tools_svc.get.return_value = {"uuid": "t1", "name": "tool1"}
@@ -91,7 +120,7 @@ def test_list_all_default_populates_but_does_not_mutate_cache_entry(monkeypatch)
     }
     h.list_all_dicts.return_value = [original]
     svc = SkillsService(h)
-    result = svc.list_all()
+    result = svc.list_all(fields="full")
     assert result[0]["tools"] == [{"uuid": "t1", "name": "tool1"}]
     assert result[0]["snippets"] == [{"uuid": "s1", "name": "snip1"}]
     # Regression: the cached dict must not have grown 'tools' / 'snippets'.
@@ -207,9 +236,35 @@ def _search_handler_skills(cached_skill):
     return h
 
 
-def test_search_default_runs_populate_and_returns_full_object(monkeypatch):
-    """Default ``fields=None`` resolves to ``full`` — ``_populate`` runs
-    and the response includes inlined ``tools`` / ``snippets``."""
+def test_search_default_is_narrow_skips_populate():
+    """Default ``fields=None`` resolves to ``narrow`` — ``_populate``
+    does NOT run and the response omits the inlined ``tools`` /
+    ``snippets`` (callers use ``tool_uuids`` / ``snippet_uuids``). This
+    runs without a registry: a bug reaching ``populate_objects`` would
+    raise."""
+    cached = {
+        "uuid": "sk1",
+        "name": "sk1",
+        "state": "approved",
+        "tool_uuids": ["t1"],
+        "snippet_uuids": ["s1"],
+        "modified_at": "2024-02-01",
+    }
+    svc = SkillsService(_search_handler_skills(cached))
+    result = svc.search("q")
+    assert len(result) == 1
+    r = result[0]
+    assert r["name"] == "sk1"
+    assert r["tool_uuids"] == ["t1"]
+    assert r["snippet_uuids"] == ["s1"]
+    assert "tools" not in r
+    assert "snippets" not in r
+    assert r["similarity_score"] == 0.4
+
+
+def test_search_fields_full_runs_populate_and_returns_full_object(monkeypatch):
+    """Explicit ``fields="full"`` triggers ``_populate`` — the response
+    includes inlined ``tools`` / ``snippets``."""
     from skillberry_store.services import registry
 
     tools_svc = MagicMock()
@@ -229,7 +284,7 @@ def test_search_default_runs_populate_and_returns_full_object(monkeypatch):
         "modified_at": "2024-02-01",
     }
     svc = SkillsService(_search_handler_skills(cached))
-    result = svc.search("q")
+    result = svc.search("q", fields="full")
     assert len(result) == 1
     r = result[0]
     assert r["name"] == "sk1"

--- a/src/skillberry_store/tests/services/test_skills_service.py
+++ b/src/skillberry_store/tests/services/test_skills_service.py
@@ -144,3 +144,62 @@ def test_delete_updates_cache_then_deletes():
     calls = [str(c) for c in h.mock_calls]
     assert any("update_cache" in c for c in calls)
     assert any("delete_object" in c for c in calls)
+
+
+def _search_handler_skills(cached_skill):
+    """Search relies on ``handler.read_dict(uuid)`` directly (unlike snippets/tools)."""
+    h = _handler()
+    h.read_dict.return_value = cached_skill
+    h.descriptions = MagicMock()
+    h.descriptions.search_description.return_value = [
+        {"filename": cached_skill["uuid"], "similarity_score": 0.4}
+    ]
+    return h
+
+
+def test_search_default_returns_legacy_shape():
+    cached = {
+        "uuid": "sk1",
+        "name": "sk1",
+        "state": "approved",
+        "tool_uuids": ["t1"],
+        "snippet_uuids": [],
+        "modified_at": "2024-02-01",
+    }
+    svc = SkillsService(_search_handler_skills(cached))
+    result = svc.search("q")
+    assert result == [{"filename": "sk1", "similarity_score": 0.4}]
+
+
+def test_search_does_not_mutate_cache_entry():
+    cached = {
+        "uuid": "sk1",
+        "name": "sk1",
+        "state": "approved",
+        "tool_uuids": ["t1"],
+        "snippet_uuids": [],
+        "modified_at": "2024-02-01",
+    }
+    svc = SkillsService(_search_handler_skills(cached))
+    svc.search("q")
+    assert "similarity_score" not in cached
+
+
+def test_search_with_fields_list_skips_populate_and_keeps_uuid_arrays():
+    cached = {
+        "uuid": "sk1",
+        "name": "sk1",
+        "state": "approved",
+        "tool_uuids": ["t1", "t2"],
+        "snippet_uuids": ["s1"],
+        "modified_at": "2024-02-01",
+    }
+    svc = SkillsService(_search_handler_skills(cached))
+    # No registry patching — reaching populate_objects would raise.
+    result = svc.search("q", fields="list")
+    r = result[0]
+    assert r["tool_uuids"] == ["t1", "t2"]
+    assert r["snippet_uuids"] == ["s1"]
+    assert r["similarity_score"] == 0.4
+    assert "tools" not in r
+    assert "snippets" not in r

--- a/src/skillberry_store/tests/services/test_snippets_service.py
+++ b/src/skillberry_store/tests/services/test_snippets_service.py
@@ -73,13 +73,27 @@ def test_list_all_returns_sorted():
     assert result[0]["name"] == "a"  # most recent first
 
 
-def test_list_all_default_shape_is_unchanged():
+def test_list_all_default_is_narrow():
+    """Default (no ``fields`` argument) is the ``narrow`` preset — heavy
+    fields like ``content`` are dropped."""
     h = _handler()
     h.list_all_dicts.return_value = [
         {"uuid": "u1", "name": "a", "content": "body", "modified_at": "2024-02-01"},
     ]
     svc = SnippetsService(h)
     result = svc.list_all()
+    assert "content" not in result[0]
+    assert result[0]["uuid"] == "u1"
+
+
+def test_list_all_fields_full_keeps_content():
+    """Explicit ``fields="full"`` opts back into the complete object."""
+    h = _handler()
+    h.list_all_dicts.return_value = [
+        {"uuid": "u1", "name": "a", "content": "body", "modified_at": "2024-02-01"},
+    ]
+    svc = SnippetsService(h)
+    result = svc.list_all(fields="full")
     assert result[0].get("content") == "body"
 
 
@@ -174,14 +188,17 @@ def _search_handler(cached_snippet):
     return h
 
 
-def test_search_default_returns_full_object_with_score():
-    """Default ``fields=None`` resolves to ``full`` — each match is the
-    complete snippet dict with ``similarity_score`` merged in."""
+def test_search_default_returns_narrow_object_with_score():
+    """Default ``fields=None`` resolves to ``narrow`` — each match is a
+    slim snippet dict with ``similarity_score`` merged in (no
+    ``content``)."""
     cached = {
         "uuid": "u1",
         "name": "s1",
+        "description": "d",
         "content": "big body",
         "state": "approved",
+        "tags": ["a"],
         "modified_at": "2024-02-01",
     }
     svc = SnippetsService(_search_handler(cached))
@@ -190,6 +207,24 @@ def test_search_default_returns_full_object_with_score():
     r = result[0]
     assert r["uuid"] == "u1"
     assert r["name"] == "s1"
+    assert "content" not in r
+    assert r["similarity_score"] == 0.2
+
+
+def test_search_fields_full_returns_full_object_with_score():
+    """Explicit ``fields="full"`` returns the complete snippet dict
+    with ``similarity_score`` merged in."""
+    cached = {
+        "uuid": "u1",
+        "name": "s1",
+        "content": "big body",
+        "state": "approved",
+        "modified_at": "2024-02-01",
+    }
+    svc = SnippetsService(_search_handler(cached))
+    result = svc.search("q", fields="full")
+    assert len(result) == 1
+    r = result[0]
     assert r["content"] == "big body"
     assert r["similarity_score"] == 0.2
 

--- a/src/skillberry_store/tests/services/test_snippets_service.py
+++ b/src/skillberry_store/tests/services/test_snippets_service.py
@@ -73,6 +73,56 @@ def test_list_all_returns_sorted():
     assert result[0]["name"] == "a"  # most recent first
 
 
+def test_list_all_default_shape_is_unchanged():
+    h = _handler()
+    h.list_all_dicts.return_value = [
+        {"uuid": "u1", "name": "a", "content": "body", "modified_at": "2024-02-01"},
+    ]
+    svc = SnippetsService(h)
+    result = svc.list_all()
+    assert result[0].get("content") == "body"
+
+
+def test_list_all_list_preset_drops_content():
+    h = _handler()
+    h.list_all_dicts.return_value = [
+        {"uuid": "u1", "name": "a", "content": "body", "modified_at": "2024-02-01"},
+        {"uuid": "u2", "name": "b", "content": "big", "modified_at": "2024-01-01"},
+    ]
+    svc = SnippetsService(h)
+    result = svc.list_all(fields="list")
+    assert [r["name"] for r in result] == ["a", "b"]
+    assert all("content" not in r for r in result)
+    assert all("uuid" in r for r in result)
+
+
+def test_list_all_custom_allowlist():
+    h = _handler()
+    h.list_all_dicts.return_value = [
+        {"uuid": "u1", "name": "a", "content": "body", "modified_at": "2024-02-01"},
+    ]
+    svc = SnippetsService(h)
+    result = svc.list_all(fields="uuid,name")
+    assert result == [{"uuid": "u1", "name": "a"}]
+
+
+def test_list_all_projection_does_not_mutate_cache_entries():
+    original = {"uuid": "u1", "name": "a", "content": "body", "modified_at": "2024-02-01"}
+    h = _handler()
+    h.list_all_dicts.return_value = [original]
+    svc = SnippetsService(h)
+    svc.list_all(fields="list")
+    assert "content" in original
+    assert original == {
+        "uuid": "u1",
+        "name": "a",
+        "content": "body",
+        "modified_at": "2024-02-01",
+    }
+
+
+
+
 def test_update_merges_and_preserves_created_at():
     h = _handler()
     svc = SnippetsService(h)

--- a/src/skillberry_store/tests/services/test_snippets_service.py
+++ b/src/skillberry_store/tests/services/test_snippets_service.py
@@ -148,3 +148,76 @@ def test_delete_cleans_up_description():
     svc = SnippetsService(h)
     svc.delete("s1")
     h.descriptions.delete_description.assert_called_once_with("aaaa-1111")
+
+
+def _search_handler(cached_snippet):
+    """Handler mock wired for search tests. Returns ``cached_snippet`` from
+    ``read_dict`` and drives one vector match for ``search_term`` == 's1'."""
+    h = _handler()
+    h.read_dict.return_value = cached_snippet
+    h.resolve_to_uuid_or_error.return_value = cached_snippet["uuid"]
+    h.descriptions = MagicMock()
+    h.descriptions.search_description.return_value = [
+        {"filename": cached_snippet["name"], "similarity_score": 0.2}
+    ]
+    return h
+
+
+def test_search_default_returns_legacy_shape():
+    cached = {
+        "uuid": "u1",
+        "name": "s1",
+        "content": "big body",
+        "state": "approved",
+        "modified_at": "2024-02-01",
+    }
+    svc = SnippetsService(_search_handler(cached))
+    result = svc.search("q")
+    assert result == [{"filename": "s1", "similarity_score": 0.2}]
+
+
+def test_search_does_not_mutate_cache_entry():
+    """Regression: previously the service assigned similarity_score onto
+    the dereferenced dict, polluting the DictCache."""
+    cached = {
+        "uuid": "u1",
+        "name": "s1",
+        "content": "body",
+        "state": "approved",
+        "modified_at": "2024-02-01",
+    }
+    svc = SnippetsService(_search_handler(cached))
+    svc.search("q")
+    assert "similarity_score" not in cached
+
+
+def test_search_with_fields_list_returns_projected_plus_score():
+    cached = {
+        "uuid": "u1",
+        "name": "s1",
+        "description": "d",
+        "content": "big body",
+        "state": "approved",
+        "tags": ["a"],
+        "modified_at": "2024-02-01",
+    }
+    svc = SnippetsService(_search_handler(cached))
+    result = svc.search("q", fields="list")
+    assert len(result) == 1
+    r = result[0]
+    assert r["name"] == "s1"
+    assert r["similarity_score"] == 0.2
+    assert "content" not in r
+
+
+def test_search_with_custom_fields_allowlist():
+    cached = {
+        "uuid": "u1",
+        "name": "s1",
+        "content": "body",
+        "state": "approved",
+        "modified_at": "2024-02-01",
+    }
+    svc = SnippetsService(_search_handler(cached))
+    result = svc.search("q", fields="uuid,name")
+    assert result == [{"uuid": "u1", "name": "s1", "similarity_score": 0.2}]

--- a/src/skillberry_store/tests/services/test_snippets_service.py
+++ b/src/skillberry_store/tests/services/test_snippets_service.py
@@ -83,17 +83,28 @@ def test_list_all_default_shape_is_unchanged():
     assert result[0].get("content") == "body"
 
 
-def test_list_all_list_preset_drops_content():
+def test_list_all_narrow_preset_drops_content():
     h = _handler()
     h.list_all_dicts.return_value = [
         {"uuid": "u1", "name": "a", "content": "body", "modified_at": "2024-02-01"},
         {"uuid": "u2", "name": "b", "content": "big", "modified_at": "2024-01-01"},
     ]
     svc = SnippetsService(h)
-    result = svc.list_all(fields="list")
+    result = svc.list_all(fields="narrow")
     assert [r["name"] for r in result] == ["a", "b"]
     assert all("content" not in r for r in result)
     assert all("uuid" in r for r in result)
+
+
+def test_list_all_wide_preset_keeps_content():
+    """``wide`` is every persisted manifest field — including ``content``."""
+    h = _handler()
+    h.list_all_dicts.return_value = [
+        {"uuid": "u1", "name": "a", "content": "body", "modified_at": "2024-02-01"},
+    ]
+    svc = SnippetsService(h)
+    result = svc.list_all(fields="wide")
+    assert result[0]["content"] == "body"
 
 
 def test_list_all_custom_allowlist():
@@ -111,7 +122,7 @@ def test_list_all_field_selection_does_not_mutate_cache_entries():
     h = _handler()
     h.list_all_dicts.return_value = [original]
     svc = SnippetsService(h)
-    svc.list_all(fields="list")
+    svc.list_all(fields="narrow")
     assert "content" in original
     assert original == {
         "uuid": "u1",
@@ -163,7 +174,9 @@ def _search_handler(cached_snippet):
     return h
 
 
-def test_search_default_returns_legacy_shape():
+def test_search_default_returns_full_object_with_score():
+    """Default ``fields=None`` resolves to ``full`` — each match is the
+    complete snippet dict with ``similarity_score`` merged in."""
     cached = {
         "uuid": "u1",
         "name": "s1",
@@ -173,7 +186,12 @@ def test_search_default_returns_legacy_shape():
     }
     svc = SnippetsService(_search_handler(cached))
     result = svc.search("q")
-    assert result == [{"filename": "s1", "similarity_score": 0.2}]
+    assert len(result) == 1
+    r = result[0]
+    assert r["uuid"] == "u1"
+    assert r["name"] == "s1"
+    assert r["content"] == "big body"
+    assert r["similarity_score"] == 0.2
 
 
 def test_search_does_not_mutate_cache_entry():
@@ -191,7 +209,7 @@ def test_search_does_not_mutate_cache_entry():
     assert "similarity_score" not in cached
 
 
-def test_search_with_fields_list_returns_projected_plus_score():
+def test_search_with_fields_narrow_returns_projected_plus_score():
     cached = {
         "uuid": "u1",
         "name": "s1",
@@ -202,7 +220,7 @@ def test_search_with_fields_list_returns_projected_plus_score():
         "modified_at": "2024-02-01",
     }
     svc = SnippetsService(_search_handler(cached))
-    result = svc.search("q", fields="list")
+    result = svc.search("q", fields="narrow")
     assert len(result) == 1
     r = result[0]
     assert r["name"] == "s1"

--- a/src/skillberry_store/tests/services/test_snippets_service.py
+++ b/src/skillberry_store/tests/services/test_snippets_service.py
@@ -106,7 +106,7 @@ def test_list_all_custom_allowlist():
     assert result == [{"uuid": "u1", "name": "a"}]
 
 
-def test_list_all_projection_does_not_mutate_cache_entries():
+def test_list_all_field_selection_does_not_mutate_cache_entries():
     original = {"uuid": "u1", "name": "a", "content": "body", "modified_at": "2024-02-01"}
     h = _handler()
     h.list_all_dicts.return_value = [original]

--- a/src/skillberry_store/tests/services/test_tools_service.py
+++ b/src/skillberry_store/tests/services/test_tools_service.py
@@ -56,6 +56,77 @@ def test_list_all_sorted():
     assert len(result) == 1
 
 
+def test_list_all_default_shape_is_unchanged():
+    h = _handler()
+    heavy = {
+        "type": "object",
+        "properties": {"x": {"type": "int"}},
+        "required": [],
+        "optional": [],
+    }
+    h.list_all_dicts.return_value = [
+        {
+            "uuid": "u1",
+            "name": "a",
+            "modified_at": "2024-02-01",
+            "params": heavy,
+            "returns": {"type": "int"},
+            "dependencies": ["dep1"],
+            "packaging_params": {"foo": "bar"},
+        },
+    ]
+    svc = ToolsService(h)
+    result = svc.list_all()
+    assert result[0]["params"] == heavy
+    assert result[0]["dependencies"] == ["dep1"]
+
+
+def test_list_all_list_preset_drops_heavy_fields():
+    h = _handler()
+    h.list_all_dicts.return_value = [
+        {
+            "uuid": "u1",
+            "name": "a",
+            "modified_at": "2024-02-01",
+            "params": {"type": "object"},
+            "returns": {"type": "int"},
+            "dependencies": ["dep1"],
+            "packaging_params": {"foo": "bar"},
+            "module_name": "a.py",
+        },
+    ]
+    svc = ToolsService(h)
+    result = svc.list_all(fields="list")
+    assert result[0]["name"] == "a"
+    assert result[0]["module_name"] == "a.py"
+    for k in ("params", "returns", "dependencies", "packaging_params"):
+        assert k not in result[0]
+
+
+def test_list_all_custom_allowlist():
+    h = _handler()
+    h.list_all_dicts.return_value = [
+        {"uuid": "u1", "name": "a", "modified_at": "2024-02-01", "params": {}},
+    ]
+    svc = ToolsService(h)
+    result = svc.list_all(fields="uuid,name")
+    assert result == [{"uuid": "u1", "name": "a"}]
+
+
+def test_list_all_projection_does_not_mutate_cache_entries():
+    original = {
+        "uuid": "u1",
+        "name": "a",
+        "modified_at": "2024-02-01",
+        "params": {"type": "object"},
+    }
+    h = _handler()
+    h.list_all_dicts.return_value = [original]
+    svc = ToolsService(h)
+    svc.list_all(fields="list")
+    assert original["params"] == {"type": "object"}
+
+
 def test_get_module_returns_file_content():
     svc = ToolsService(_handler())
     content = svc.get_module("t1")

--- a/src/skillberry_store/tests/services/test_tools_service.py
+++ b/src/skillberry_store/tests/services/test_tools_service.py
@@ -133,6 +133,65 @@ def test_get_module_returns_file_content():
     assert "def hello" in content
 
 
+def _search_handler_tools(cached_tool):
+    h = _handler()
+    h.read_dict.return_value = cached_tool
+    h.resolve_to_uuid_or_error.return_value = cached_tool["uuid"]
+    h.descriptions = MagicMock()
+    h.descriptions.search_description.return_value = [
+        {"filename": cached_tool["name"], "similarity_score": 0.3}
+    ]
+    return h
+
+
+def test_search_default_returns_legacy_shape():
+    cached = {
+        "uuid": "u1",
+        "name": "t1",
+        "state": "approved",
+        "params": {"type": "object"},
+        "modified_at": "2024-02-01",
+    }
+    svc = ToolsService(_search_handler_tools(cached))
+    result = svc.search("q")
+    assert result == [{"filename": "t1", "similarity_score": 0.3}]
+
+
+def test_search_does_not_mutate_cache_entry():
+    cached = {
+        "uuid": "u1",
+        "name": "t1",
+        "state": "approved",
+        "params": {"type": "object"},
+        "modified_at": "2024-02-01",
+    }
+    svc = ToolsService(_search_handler_tools(cached))
+    svc.search("q")
+    assert "similarity_score" not in cached
+
+
+def test_search_with_fields_list_drops_heavy_fields():
+    cached = {
+        "uuid": "u1",
+        "name": "t1",
+        "state": "approved",
+        "params": {"type": "object"},
+        "returns": {"type": "int"},
+        "dependencies": ["d1"],
+        "packaging_params": {"foo": "bar"},
+        "module_name": "t1.py",
+        "modified_at": "2024-02-01",
+    }
+    svc = ToolsService(_search_handler_tools(cached))
+    result = svc.search("q", fields="list")
+    r = result[0]
+    assert r["name"] == "t1"
+    assert r["module_name"] == "t1.py"
+    assert r["similarity_score"] == 0.3
+    for k in ("params", "returns", "dependencies", "packaging_params"):
+        assert k not in r
+
+
 def test_delete_updates_cache_then_deletes():
     h = _handler()
     svc = ToolsService(h)

--- a/src/skillberry_store/tests/services/test_tools_service.py
+++ b/src/skillberry_store/tests/services/test_tools_service.py
@@ -113,7 +113,7 @@ def test_list_all_custom_allowlist():
     assert result == [{"uuid": "u1", "name": "a"}]
 
 
-def test_list_all_projection_does_not_mutate_cache_entries():
+def test_list_all_field_selection_does_not_mutate_cache_entries():
     original = {
         "uuid": "u1",
         "name": "a",

--- a/src/skillberry_store/tests/services/test_tools_service.py
+++ b/src/skillberry_store/tests/services/test_tools_service.py
@@ -56,7 +56,37 @@ def test_list_all_sorted():
     assert len(result) == 1
 
 
-def test_list_all_default_shape_is_unchanged():
+def test_list_all_default_is_narrow():
+    """Default (no ``fields``) is the ``narrow`` preset — the heavy
+    tool fields (params/returns/deps/packaging_*) are dropped."""
+    h = _handler()
+    heavy = {
+        "type": "object",
+        "properties": {"x": {"type": "int"}},
+        "required": [],
+        "optional": [],
+    }
+    h.list_all_dicts.return_value = [
+        {
+            "uuid": "u1",
+            "name": "a",
+            "modified_at": "2024-02-01",
+            "module_name": "a.py",
+            "params": heavy,
+            "returns": {"type": "int"},
+            "dependencies": ["dep1"],
+            "packaging_params": {"foo": "bar"},
+        },
+    ]
+    svc = ToolsService(h)
+    result = svc.list_all()
+    assert result[0]["module_name"] == "a.py"
+    for k in ("params", "returns", "dependencies", "packaging_params"):
+        assert k not in result[0]
+
+
+def test_list_all_fields_full_keeps_heavy_fields():
+    """Explicit ``fields="full"`` opts into the complete tool dict."""
     h = _handler()
     heavy = {
         "type": "object",
@@ -76,7 +106,7 @@ def test_list_all_default_shape_is_unchanged():
         },
     ]
     svc = ToolsService(h)
-    result = svc.list_all()
+    result = svc.list_all(fields="full")
     assert result[0]["params"] == heavy
     assert result[0]["dependencies"] == ["dep1"]
 
@@ -178,13 +208,14 @@ def _search_handler_tools(cached_tool):
     return h
 
 
-def test_search_default_returns_full_object_with_score():
-    """Default ``fields=None`` resolves to ``full`` — the whole tool
-    dict is returned with ``similarity_score`` merged in."""
+def test_search_default_returns_narrow_object_with_score():
+    """Default ``fields=None`` resolves to ``narrow`` — a slim tool
+    dict with ``similarity_score`` merged in (no ``params``)."""
     cached = {
         "uuid": "u1",
         "name": "t1",
         "state": "approved",
+        "module_name": "t1.py",
         "params": {"type": "object"},
         "modified_at": "2024-02-01",
     }
@@ -193,6 +224,24 @@ def test_search_default_returns_full_object_with_score():
     assert len(result) == 1
     r = result[0]
     assert r["name"] == "t1"
+    assert r["module_name"] == "t1.py"
+    assert "params" not in r
+    assert r["similarity_score"] == 0.3
+
+
+def test_search_fields_full_returns_full_object_with_score():
+    """Explicit ``fields="full"`` returns the complete tool dict."""
+    cached = {
+        "uuid": "u1",
+        "name": "t1",
+        "state": "approved",
+        "params": {"type": "object"},
+        "modified_at": "2024-02-01",
+    }
+    svc = ToolsService(_search_handler_tools(cached))
+    result = svc.search("q", fields="full")
+    assert len(result) == 1
+    r = result[0]
     assert r["params"] == {"type": "object"}
     assert r["similarity_score"] == 0.3
 

--- a/src/skillberry_store/tests/services/test_tools_service.py
+++ b/src/skillberry_store/tests/services/test_tools_service.py
@@ -81,7 +81,7 @@ def test_list_all_default_shape_is_unchanged():
     assert result[0]["dependencies"] == ["dep1"]
 
 
-def test_list_all_list_preset_drops_heavy_fields():
+def test_list_all_narrow_preset_drops_heavy_fields():
     h = _handler()
     h.list_all_dicts.return_value = [
         {
@@ -92,15 +92,49 @@ def test_list_all_list_preset_drops_heavy_fields():
             "returns": {"type": "int"},
             "dependencies": ["dep1"],
             "packaging_params": {"foo": "bar"},
+            "programming_language": "python",
+            "packaging_format": "code",
             "module_name": "a.py",
         },
     ]
     svc = ToolsService(h)
-    result = svc.list_all(fields="list")
+    result = svc.list_all(fields="narrow")
     assert result[0]["name"] == "a"
     assert result[0]["module_name"] == "a.py"
-    for k in ("params", "returns", "dependencies", "packaging_params"):
-        assert k not in result[0]
+    for k in (
+        "params",
+        "returns",
+        "dependencies",
+        "packaging_params",
+        "programming_language",
+        "packaging_format",
+    ):
+        assert k not in result[0], f"narrow unexpectedly contains {k}"
+
+
+def test_list_all_wide_preset_keeps_persisted_fields():
+    """``wide`` returns every persisted manifest field — the heavy ones
+    that ``narrow`` drops (params/returns/deps/etc) come back."""
+    h = _handler()
+    h.list_all_dicts.return_value = [
+        {
+            "uuid": "u1",
+            "name": "a",
+            "modified_at": "2024-02-01",
+            "params": {"type": "object"},
+            "returns": {"type": "int"},
+            "dependencies": ["dep1"],
+            "packaging_params": {"foo": "bar"},
+            "programming_language": "python",
+            "module_name": "a.py",
+        },
+    ]
+    svc = ToolsService(h)
+    result = svc.list_all(fields="wide")
+    r = result[0]
+    assert r["params"] == {"type": "object"}
+    assert r["dependencies"] == ["dep1"]
+    assert r["programming_language"] == "python"
 
 
 def test_list_all_custom_allowlist():
@@ -123,7 +157,7 @@ def test_list_all_field_selection_does_not_mutate_cache_entries():
     h = _handler()
     h.list_all_dicts.return_value = [original]
     svc = ToolsService(h)
-    svc.list_all(fields="list")
+    svc.list_all(fields="narrow")
     assert original["params"] == {"type": "object"}
 
 
@@ -144,7 +178,9 @@ def _search_handler_tools(cached_tool):
     return h
 
 
-def test_search_default_returns_legacy_shape():
+def test_search_default_returns_full_object_with_score():
+    """Default ``fields=None`` resolves to ``full`` — the whole tool
+    dict is returned with ``similarity_score`` merged in."""
     cached = {
         "uuid": "u1",
         "name": "t1",
@@ -154,7 +190,11 @@ def test_search_default_returns_legacy_shape():
     }
     svc = ToolsService(_search_handler_tools(cached))
     result = svc.search("q")
-    assert result == [{"filename": "t1", "similarity_score": 0.3}]
+    assert len(result) == 1
+    r = result[0]
+    assert r["name"] == "t1"
+    assert r["params"] == {"type": "object"}
+    assert r["similarity_score"] == 0.3
 
 
 def test_search_does_not_mutate_cache_entry():
@@ -170,7 +210,7 @@ def test_search_does_not_mutate_cache_entry():
     assert "similarity_score" not in cached
 
 
-def test_search_with_fields_list_drops_heavy_fields():
+def test_search_with_fields_narrow_drops_heavy_fields():
     cached = {
         "uuid": "u1",
         "name": "t1",
@@ -183,7 +223,7 @@ def test_search_with_fields_list_drops_heavy_fields():
         "modified_at": "2024-02-01",
     }
     svc = ToolsService(_search_handler_tools(cached))
-    result = svc.search("q", fields="list")
+    result = svc.search("q", fields="narrow")
     r = result[0]
     assert r["name"] == "t1"
     assert r["module_name"] == "t1.py"

--- a/src/skillberry_store/tests/services/test_vmcp_service.py
+++ b/src/skillberry_store/tests/services/test_vmcp_service.py
@@ -47,7 +47,9 @@ def test_create_raises_on_duplicate():
 def test_list_includes_running_status():
     svc = VmcpService(_handler(), _manager())
     result = svc.list_all()
-    assert "virtual_mcp_servers" in result
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["running"] is True
 
 
 def test_delete_stops_runtime_and_removes_persistent():

--- a/src/skillberry_store/tests/services/test_vmcp_service.py
+++ b/src/skillberry_store/tests/services/test_vmcp_service.py
@@ -60,3 +60,114 @@ def test_delete_stops_runtime_and_removes_persistent():
         svc.delete("vm1")
     mgr.remove_server.assert_called_once()
     h.delete_object.assert_called_once()
+
+
+# ── field selection (?fields) ──────────────────────────────────────────
+
+
+def test_list_all_fields_none_returns_full_enriched_shape():
+    svc = VmcpService(_handler(), _manager())
+    result = svc.list_all()
+    assert result[0]["running"] is True
+    assert result[0]["runtime"] is not None
+    assert "port" in result[0]
+
+
+def test_list_all_fields_list_preset_keeps_runtime_status():
+    svc = VmcpService(_handler(), _manager())
+    result = svc.list_all(fields="list")
+    # Preset keeps the runtime-status fields the list UI depends on.
+    assert result[0]["running"] is True
+    assert "runtime" in result[0]
+    assert result[0]["name"] == "vm1"
+
+
+def test_list_all_fields_csv_allowlist_narrows_output():
+    svc = VmcpService(_handler(), _manager())
+    result = svc.list_all(fields="uuid,name")
+    assert result == [{"uuid": "eeee-5555", "name": "vm1"}]
+
+
+def test_list_all_fields_full_returns_all_fields():
+    svc = VmcpService(_handler(), _manager())
+    result = svc.list_all(fields="full")
+    assert "running" in result[0]
+    assert "runtime" in result[0]
+
+
+def test_list_all_fields_invalid_object_type_raises_via_bad_preset():
+    # Purely covers the preset registration: parse_fields_spec is validated
+    # by its own tests. Here we just guarantee our service passes "vmcp"
+    # through so a caller-defined allowlist works end-to-end.
+    svc = VmcpService(_handler(), _manager())
+    result = svc.list_all(fields="running")
+    assert result == [{"running": True}]
+
+
+def _search_handler_vmcp(cached_vmcp):
+    """Build a handler mock wired for ``VmcpService.search``."""
+    h = _handler()
+    h.read_dict.return_value = cached_vmcp
+    h.descriptions = MagicMock()
+    h.descriptions.search_description.return_value = [
+        {"filename": cached_vmcp["uuid"], "similarity_score": 0.4}
+    ]
+    return h
+
+
+def test_search_default_returns_legacy_shape():
+    cached = {
+        "uuid": "vm1",
+        "name": "vm1",
+        "state": "approved",
+        "modified_at": "2024-02-01",
+    }
+    svc = VmcpService(_search_handler_vmcp(cached), _manager())
+    result = svc.search("q")
+    assert result == [{"filename": "vm1", "similarity_score": 0.4}]
+
+
+def test_search_does_not_mutate_cache_entry():
+    cached = {
+        "uuid": "vm1",
+        "name": "vm1",
+        "state": "approved",
+        "modified_at": "2024-02-01",
+    }
+    svc = VmcpService(_search_handler_vmcp(cached), _manager())
+    svc.search("q")
+    # The cached dict must stay clean — ``similarity_score`` is added to a
+    # fresh copy inside search().
+    assert "similarity_score" not in cached
+
+
+def test_search_with_fields_full_returns_dict_plus_score():
+    cached = {
+        "uuid": "vm1",
+        "name": "vm1",
+        "state": "approved",
+        "port": 8100,
+        "modified_at": "2024-02-01",
+    }
+    svc = VmcpService(_search_handler_vmcp(cached), _manager())
+    result = svc.search("q", fields="full")
+    r = result[0]
+    assert r["uuid"] == "vm1"
+    assert r["port"] == 8100
+    assert r["similarity_score"] == 0.4
+
+
+def test_search_with_fields_csv_narrows_output_and_keeps_score():
+    cached = {
+        "uuid": "vm1",
+        "name": "vm1",
+        "state": "approved",
+        "port": 8100,
+        "description": "hidden",
+        "modified_at": "2024-02-01",
+    }
+    svc = VmcpService(_search_handler_vmcp(cached), _manager())
+    result = svc.search("q", fields="uuid,name")
+    assert result == [
+        {"uuid": "vm1", "name": "vm1", "similarity_score": 0.4}
+    ]

--- a/src/skillberry_store/tests/services/test_vmcp_service.py
+++ b/src/skillberry_store/tests/services/test_vmcp_service.py
@@ -65,7 +65,10 @@ def test_delete_stops_runtime_and_removes_persistent():
 # ── field selection (?fields) ──────────────────────────────────────────
 
 
-def test_list_all_fields_none_returns_full_enriched_shape():
+def test_list_all_fields_none_returns_narrow_enriched_shape():
+    """Default (no ``fields``) is ``narrow``. For vMCP, narrow includes
+    ``_enhance`` so enhancement still runs and ``running`` / ``runtime``
+    are merged in."""
     svc = VmcpService(_handler(), _manager())
     result = svc.list_all()
     assert result[0]["running"] is True
@@ -137,9 +140,10 @@ def _search_handler_vmcp(cached_vmcp):
     return h
 
 
-def test_search_default_returns_full_enhanced_object_with_score():
-    """Default ``fields=None`` resolves to ``full`` — enhancement runs
-    and the response is the full object with ``similarity_score``."""
+def test_search_default_returns_narrow_enhanced_object_with_score():
+    """Default ``fields=None`` resolves to ``narrow``. For vMCP,
+    narrow tags ``_enhance``, so enhancement runs and the response
+    carries ``running`` / ``runtime`` alongside ``similarity_score``."""
     cached = {
         "uuid": "vm1",
         "name": "vm1",

--- a/src/skillberry_store/tests/services/test_vmcp_service.py
+++ b/src/skillberry_store/tests/services/test_vmcp_service.py
@@ -73,19 +73,40 @@ def test_list_all_fields_none_returns_full_enriched_shape():
     assert "port" in result[0]
 
 
-def test_list_all_fields_list_preset_keeps_runtime_status():
+def test_list_all_fields_narrow_preset_runs_enhance():
+    """``narrow`` includes ``_enhance``, so the enhancement mechanism
+    runs and ``running`` / ``runtime`` are merged in."""
     svc = VmcpService(_handler(), _manager())
-    result = svc.list_all(fields="list")
-    # Preset keeps the runtime-status fields the list UI depends on.
+    result = svc.list_all(fields="narrow")
     assert result[0]["running"] is True
     assert "runtime" in result[0]
     assert result[0]["name"] == "vm1"
 
 
+def test_list_all_fields_wide_preset_skips_enhance():
+    """``wide`` is manifest data only — enhancement does NOT run, so
+    ``running`` and ``runtime`` are absent."""
+    svc = VmcpService(_handler(), _manager())
+    result = svc.list_all(fields="wide")
+    assert "running" not in result[0]
+    assert "runtime" not in result[0]
+    assert result[0]["name"] == "vm1"
+    assert result[0]["port"] is not None or "port" in result[0]
+
+
 def test_list_all_fields_csv_allowlist_narrows_output():
+    """A CSV allowlist without ``_enhance`` does not activate enhancement."""
     svc = VmcpService(_handler(), _manager())
     result = svc.list_all(fields="uuid,name")
     assert result == [{"uuid": "eeee-5555", "name": "vm1"}]
+
+
+def test_list_all_fields_csv_with_enhance_flag_runs_enhance():
+    """Explicit CSV allowlist naming ``_enhance`` runs the mechanism."""
+    svc = VmcpService(_handler(), _manager())
+    result = svc.list_all(fields="uuid,name,running,_enhance")
+    assert result[0]["running"] is True
+    assert result[0]["uuid"] == "eeee-5555"
 
 
 def test_list_all_fields_full_returns_all_fields():
@@ -95,13 +116,14 @@ def test_list_all_fields_full_returns_all_fields():
     assert "runtime" in result[0]
 
 
-def test_list_all_fields_invalid_object_type_raises_via_bad_preset():
-    # Purely covers the preset registration: parse_fields_spec is validated
-    # by its own tests. Here we just guarantee our service passes "vmcp"
-    # through so a caller-defined allowlist works end-to-end.
+def test_list_all_running_only_csv_needs_enhance_flag_to_populate():
+    """A CSV allowlist naming ``running`` alone won't populate the
+    field — enhancement is gated on ``_enhance``, not on ``running``."""
     svc = VmcpService(_handler(), _manager())
     result = svc.list_all(fields="running")
-    assert result == [{"running": True}]
+    # Enhancement did not run → 'running' was never set, so the
+    # projection drops it.
+    assert result == [{}]
 
 
 def _search_handler_vmcp(cached_vmcp):
@@ -115,7 +137,9 @@ def _search_handler_vmcp(cached_vmcp):
     return h
 
 
-def test_search_default_returns_legacy_shape():
+def test_search_default_returns_full_enhanced_object_with_score():
+    """Default ``fields=None`` resolves to ``full`` — enhancement runs
+    and the response is the full object with ``similarity_score``."""
     cached = {
         "uuid": "vm1",
         "name": "vm1",
@@ -124,7 +148,12 @@ def test_search_default_returns_legacy_shape():
     }
     svc = VmcpService(_search_handler_vmcp(cached), _manager())
     result = svc.search("q")
-    assert result == [{"filename": "vm1", "similarity_score": 0.4}]
+    assert len(result) == 1
+    r = result[0]
+    assert r["name"] == "vm1"
+    assert r["running"] is True
+    assert "runtime" in r
+    assert r["similarity_score"] == 0.4
 
 
 def test_search_does_not_mutate_cache_entry():

--- a/src/skillberry_store/tests/services/test_vnfs_service.py
+++ b/src/skillberry_store/tests/services/test_vnfs_service.py
@@ -44,7 +44,9 @@ def test_create_raises_on_duplicate():
 def test_list_includes_running_status():
     svc = VnfsService(_handler(), _manager())
     result = svc.list_all()
-    assert "virtual_nfs_servers" in result
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["running"] is True
 
 
 def test_delete_stops_runtime_then_removes_persistent():

--- a/src/skillberry_store/tests/services/test_vnfs_service.py
+++ b/src/skillberry_store/tests/services/test_vnfs_service.py
@@ -70,19 +70,37 @@ def test_list_all_fields_none_returns_full_enriched_shape():
     assert "port" in result[0]
 
 
-def test_list_all_fields_list_preset_keeps_runtime_status():
+def test_list_all_fields_narrow_preset_runs_enhance():
+    """``narrow`` includes ``_enhance``, so enhancement runs and
+    ``running`` / ``export_path`` are merged in."""
     svc = VnfsService(_handler(), _manager())
-    result = svc.list_all(fields="list")
-    # Preset keeps the runtime-status fields the list UI depends on.
+    result = svc.list_all(fields="narrow")
     assert result[0]["running"] is True
     assert result[0]["export_path"] == "/tmp/export"
     assert result[0]["name"] == "v1"
 
 
+def test_list_all_fields_wide_preset_skips_enhance():
+    """``wide`` is manifest data only — enhancement does NOT run."""
+    svc = VnfsService(_handler(), _manager())
+    result = svc.list_all(fields="wide")
+    assert "running" not in result[0]
+    assert "export_path" not in result[0]
+    assert result[0]["name"] == "v1"
+
+
 def test_list_all_fields_csv_allowlist_narrows_output():
+    """A CSV allowlist without ``_enhance`` does not activate enhancement."""
     svc = VnfsService(_handler(), _manager())
     result = svc.list_all(fields="uuid,name")
     assert result == [{"uuid": "dddd-4444", "name": "v1"}]
+
+
+def test_list_all_fields_csv_with_enhance_flag_runs_enhance():
+    svc = VnfsService(_handler(), _manager())
+    result = svc.list_all(fields="uuid,name,running,_enhance")
+    assert result[0]["running"] is True
+    assert result[0]["uuid"] == "dddd-4444"
 
 
 def test_list_all_fields_full_returns_all_fields():
@@ -103,7 +121,9 @@ def _search_handler_vnfs(cached_vnfs):
     return h
 
 
-def test_search_default_returns_legacy_shape():
+def test_search_default_returns_full_enhanced_object_with_score():
+    """Default ``fields=None`` resolves to ``full`` — enhancement runs
+    and the response is the full object with ``similarity_score``."""
     cached = {
         "uuid": "v1",
         "name": "v1",
@@ -112,7 +132,12 @@ def test_search_default_returns_legacy_shape():
     }
     svc = VnfsService(_search_handler_vnfs(cached), _manager())
     result = svc.search("q")
-    assert result == [{"filename": "v1", "similarity_score": 0.4}]
+    assert len(result) == 1
+    r = result[0]
+    assert r["name"] == "v1"
+    assert r["running"] is True
+    assert r["export_path"] == "/tmp/export"
+    assert r["similarity_score"] == 0.4
 
 
 def test_search_does_not_mutate_cache_entry():

--- a/src/skillberry_store/tests/services/test_vnfs_service.py
+++ b/src/skillberry_store/tests/services/test_vnfs_service.py
@@ -57,3 +57,103 @@ def test_delete_stops_runtime_then_removes_persistent():
         svc.delete("v1")
     mgr.remove_server.assert_called_once()
     h.delete_object.assert_called_once()
+
+
+# ── field selection (?fields) ──────────────────────────────────────────
+
+
+def test_list_all_fields_none_returns_full_enriched_shape():
+    svc = VnfsService(_handler(), _manager())
+    result = svc.list_all()
+    assert result[0]["running"] is True
+    assert result[0]["export_path"] == "/tmp/export"
+    assert "port" in result[0]
+
+
+def test_list_all_fields_list_preset_keeps_runtime_status():
+    svc = VnfsService(_handler(), _manager())
+    result = svc.list_all(fields="list")
+    # Preset keeps the runtime-status fields the list UI depends on.
+    assert result[0]["running"] is True
+    assert result[0]["export_path"] == "/tmp/export"
+    assert result[0]["name"] == "v1"
+
+
+def test_list_all_fields_csv_allowlist_narrows_output():
+    svc = VnfsService(_handler(), _manager())
+    result = svc.list_all(fields="uuid,name")
+    assert result == [{"uuid": "dddd-4444", "name": "v1"}]
+
+
+def test_list_all_fields_full_returns_all_fields():
+    svc = VnfsService(_handler(), _manager())
+    result = svc.list_all(fields="full")
+    assert "running" in result[0]
+    assert "export_path" in result[0]
+
+
+def _search_handler_vnfs(cached_vnfs):
+    """Build a handler mock wired for ``VnfsService.search``."""
+    h = _handler()
+    h.read_dict.return_value = cached_vnfs
+    h.descriptions = MagicMock()
+    h.descriptions.search_description.return_value = [
+        {"filename": cached_vnfs["uuid"], "similarity_score": 0.4}
+    ]
+    return h
+
+
+def test_search_default_returns_legacy_shape():
+    cached = {
+        "uuid": "v1",
+        "name": "v1",
+        "state": "approved",
+        "modified_at": "2024-02-01",
+    }
+    svc = VnfsService(_search_handler_vnfs(cached), _manager())
+    result = svc.search("q")
+    assert result == [{"filename": "v1", "similarity_score": 0.4}]
+
+
+def test_search_does_not_mutate_cache_entry():
+    cached = {
+        "uuid": "v1",
+        "name": "v1",
+        "state": "approved",
+        "modified_at": "2024-02-01",
+    }
+    svc = VnfsService(_search_handler_vnfs(cached), _manager())
+    svc.search("q")
+    assert "similarity_score" not in cached
+
+
+def test_search_with_fields_full_returns_dict_plus_score():
+    cached = {
+        "uuid": "v1",
+        "name": "v1",
+        "state": "approved",
+        "port": 9000,
+        "modified_at": "2024-02-01",
+    }
+    svc = VnfsService(_search_handler_vnfs(cached), _manager())
+    result = svc.search("q", fields="full")
+    r = result[0]
+    assert r["uuid"] == "v1"
+    assert r["port"] == 9000
+    assert r["similarity_score"] == 0.4
+
+
+def test_search_with_fields_csv_narrows_output_and_keeps_score():
+    cached = {
+        "uuid": "v1",
+        "name": "v1",
+        "state": "approved",
+        "port": 9000,
+        "description": "hidden",
+        "modified_at": "2024-02-01",
+    }
+    svc = VnfsService(_search_handler_vnfs(cached), _manager())
+    result = svc.search("q", fields="uuid,name")
+    assert result == [
+        {"uuid": "v1", "name": "v1", "similarity_score": 0.4}
+    ]

--- a/src/skillberry_store/tests/services/test_vnfs_service.py
+++ b/src/skillberry_store/tests/services/test_vnfs_service.py
@@ -62,7 +62,10 @@ def test_delete_stops_runtime_then_removes_persistent():
 # ── field selection (?fields) ──────────────────────────────────────────
 
 
-def test_list_all_fields_none_returns_full_enriched_shape():
+def test_list_all_fields_none_returns_narrow_enriched_shape():
+    """Default (no ``fields``) is ``narrow``. For vNFS, narrow includes
+    ``_enhance`` so enhancement still runs and ``running`` /
+    ``export_path`` are merged in."""
     svc = VnfsService(_handler(), _manager())
     result = svc.list_all()
     assert result[0]["running"] is True
@@ -121,9 +124,11 @@ def _search_handler_vnfs(cached_vnfs):
     return h
 
 
-def test_search_default_returns_full_enhanced_object_with_score():
-    """Default ``fields=None`` resolves to ``full`` — enhancement runs
-    and the response is the full object with ``similarity_score``."""
+def test_search_default_returns_narrow_enhanced_object_with_score():
+    """Default ``fields=None`` resolves to ``narrow``. For vNFS,
+    narrow tags ``_enhance``, so enhancement runs and the response
+    carries ``running`` / ``export_path`` alongside
+    ``similarity_score``."""
     cached = {
         "uuid": "v1",
         "name": "v1",

--- a/src/skillberry_store/tests/test_store_api_vmcp.py
+++ b/src/skillberry_store/tests/test_store_api_vmcp.py
@@ -7,7 +7,7 @@ def _store_with_vmcp():
     vmcp_service = MagicMock()
     vmcp_service.create.return_value = {"uuid": "v1", "port": 10001}
     vmcp_service.get.return_value = {"uuid": "v1", "port": 10001, "running": True}
-    vmcp_service.list_all.return_value = {"virtual_mcp_servers": {"v1": {"uuid": "v1"}}}
+    vmcp_service.list_all.return_value = [{"uuid": "v1"}]
     return StoreAPI({"vmcp": vmcp_service}), vmcp_service
 
 

--- a/src/skillberry_store/tests/test_vmcp_api_filter.py
+++ b/src/skillberry_store/tests/test_vmcp_api_filter.py
@@ -7,7 +7,7 @@ def _app(servers):
     app = FastAPI()
     svc = MagicMock()
 
-    def _list_all(skill_uuid=None):
+    def _list_all(skill_uuid=None, fields=None):
         matches = servers if skill_uuid is None else [
             s for s in servers if s.get("skill_uuid") == skill_uuid
         ]

--- a/src/skillberry_store/tests/test_vmcp_api_filter.py
+++ b/src/skillberry_store/tests/test_vmcp_api_filter.py
@@ -11,7 +11,7 @@ def _app(servers):
         matches = servers if skill_uuid is None else [
             s for s in servers if s.get("skill_uuid") == skill_uuid
         ]
-        return {"virtual_mcp_servers": {s["uuid"]: s for s in matches}}
+        return list(matches)
 
     svc.list_all.side_effect = _list_all
     register_vmcp_api(app, service=svc)
@@ -28,17 +28,20 @@ def test_list_vmcp_servers_no_filter_returns_all():
     client = _app(SERVERS)
     resp = client.get("/vmcp_servers/")
     assert resp.status_code == 200
-    assert len(resp.json()["virtual_mcp_servers"]) == 2
+    body = resp.json()
+    assert isinstance(body, list)
+    assert len(body) == 2
 
 def test_list_vmcp_servers_skill_uuid_filter():
     client = _app(SERVERS)
     resp = client.get("/vmcp_servers/?skill_uuid=sk1")
     assert resp.status_code == 200
-    uuids = list(resp.json()["virtual_mcp_servers"].keys())
+    body = resp.json()
+    uuids = [s["uuid"] for s in body]
     assert uuids == ["v1"]
 
 def test_list_vmcp_servers_skill_uuid_no_match_returns_empty():
     client = _app(SERVERS)
     resp = client.get("/vmcp_servers/?skill_uuid=unknown")
     assert resp.status_code == 200
-    assert resp.json()["virtual_mcp_servers"] == {}
+    assert resp.json() == []

--- a/src/skillberry_store/tests/test_vnfs_api_filter.py
+++ b/src/skillberry_store/tests/test_vnfs_api_filter.py
@@ -12,7 +12,7 @@ def _app(servers):
         matches = servers if skill_uuid is None else [
             s for s in servers if s.get("skill_uuid") == skill_uuid
         ]
-        return {"virtual_nfs_servers": {s["uuid"]: s for s in matches}}
+        return list(matches)
 
     svc.list_all.side_effect = _list_all
     register_vnfs_api(app, service=svc)
@@ -49,14 +49,17 @@ def test_list_vnfs_servers_no_filter_returns_all():
     client = _app(SERVERS)
     resp = client.get("/vnfs_servers/")
     assert resp.status_code == 200
-    assert len(resp.json()["virtual_nfs_servers"]) == 2
+    body = resp.json()
+    assert isinstance(body, list)
+    assert len(body) == 2
 
 
 def test_list_vnfs_servers_skill_uuid_filter():
     client = _app(SERVERS)
     resp = client.get("/vnfs_servers/?skill_uuid=sk1")
     assert resp.status_code == 200
-    uuids = list(resp.json()["virtual_nfs_servers"].keys())
+    body = resp.json()
+    uuids = [s["uuid"] for s in body]
     assert uuids == ["v1"]
 
 
@@ -64,4 +67,4 @@ def test_list_vnfs_servers_skill_uuid_no_match_returns_empty():
     client = _app(SERVERS)
     resp = client.get("/vnfs_servers/?skill_uuid=unknown")
     assert resp.status_code == 200
-    assert resp.json()["virtual_nfs_servers"] == {}
+    assert resp.json() == []

--- a/src/skillberry_store/tests/test_vnfs_api_filter.py
+++ b/src/skillberry_store/tests/test_vnfs_api_filter.py
@@ -8,7 +8,7 @@ def _app(servers):
     app = FastAPI()
     svc = MagicMock()
 
-    def _list_all(skill_uuid=None):
+    def _list_all(skill_uuid=None, fields=None):
         matches = servers if skill_uuid is None else [
             s for s in servers if s.get("skill_uuid") == skill_uuid
         ]

--- a/src/skillberry_store/ui/src/components/SkillCard.tsx
+++ b/src/skillberry_store/ui/src/components/SkillCard.tsx
@@ -111,11 +111,17 @@ export function SkillCard({ skill, isSelected, onSelect }: SkillCardProps) {
       }}>
         <span style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
           <WrenchIcon />
-          {skill.tools && skill.tools.length > 0 ? `${skill.tools.length} tools` : '—'}
+          {(() => {
+            const count = skill.tool_uuids?.length ?? skill.tools?.length ?? 0;
+            return count > 0 ? `${count} tools` : '—';
+          })()}
         </span>
         <span style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
           <FileCodeIcon />
-          {skill.snippets && skill.snippets.length > 0 ? `${skill.snippets.length} snippets` : '—'}
+          {(() => {
+            const count = skill.snippet_uuids?.length ?? skill.snippets?.length ?? 0;
+            return count > 0 ? `${count} snippets` : '—';
+          })()}
         </span>
         {skill.version && (
           <span style={{ marginLeft: 'auto', color: '#6a6e73' }}>{skill.version}</span>

--- a/src/skillberry_store/ui/src/components/SkillCard.tsx
+++ b/src/skillberry_store/ui/src/components/SkillCard.tsx
@@ -112,14 +112,14 @@ export function SkillCard({ skill, isSelected, onSelect }: SkillCardProps) {
         <span style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
           <WrenchIcon />
           {(() => {
-            const count = skill.tool_uuids?.length ?? skill.tools?.length ?? 0;
+            const count = skill.tool_uuids?.length ?? 0;
             return count > 0 ? `${count} tools` : '—';
           })()}
         </span>
         <span style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
           <FileCodeIcon />
           {(() => {
-            const count = skill.snippet_uuids?.length ?? skill.snippets?.length ?? 0;
+            const count = skill.snippet_uuids?.length ?? 0;
             return count > 0 ? `${count} snippets` : '—';
           })()}
         </span>

--- a/src/skillberry_store/ui/src/components/SkillListView.tsx
+++ b/src/skillberry_store/ui/src/components/SkillListView.tsx
@@ -88,7 +88,7 @@ export function SkillListView({
               style={{ cursor: 'pointer' }}
             >
               {(() => {
-                const count = skill.tool_uuids?.length ?? skill.tools?.length ?? 0;
+                const count = skill.tool_uuids?.length ?? 0;
                 return count > 0 ? count : '-';
               })()}
             </Td>
@@ -98,7 +98,7 @@ export function SkillListView({
               style={{ cursor: 'pointer' }}
             >
               {(() => {
-                const count = skill.snippet_uuids?.length ?? skill.snippets?.length ?? 0;
+                const count = skill.snippet_uuids?.length ?? 0;
                 return count > 0 ? count : '-';
               })()}
             </Td>

--- a/src/skillberry_store/ui/src/components/SkillListView.tsx
+++ b/src/skillberry_store/ui/src/components/SkillListView.tsx
@@ -87,14 +87,20 @@ export function SkillListView({
               onClick={() => navigate(`/skills/${skill.uuid}`)}
               style={{ cursor: 'pointer' }}
             >
-              {skill.tools && skill.tools.length > 0 ? skill.tools.length : '-'}
+              {(() => {
+                const count = skill.tool_uuids?.length ?? skill.tools?.length ?? 0;
+                return count > 0 ? count : '-';
+              })()}
             </Td>
             <Td
               dataLabel="Snippets"
               onClick={() => navigate(`/skills/${skill.uuid}`)}
               style={{ cursor: 'pointer' }}
             >
-              {skill.snippets && skill.snippets.length > 0 ? skill.snippets.length : '-'}
+              {(() => {
+                const count = skill.snippet_uuids?.length ?? skill.snippets?.length ?? 0;
+                return count > 0 ? count : '-';
+              })()}
             </Td>
             <Td
               dataLabel="Version"

--- a/src/skillberry_store/ui/src/pages/SkillDetailPage.tsx
+++ b/src/skillberry_store/ui/src/pages/SkillDetailPage.tsx
@@ -793,7 +793,7 @@ export function SkillDetailPage() {
                                   minHeight: '100%',
                                 }}
                               >
-                                {selectedSnippet.content}
+                                {selectedSnippet.content ?? ''}
                               </SyntaxHighlighter>
                             </div>
                           </div>

--- a/src/skillberry_store/ui/src/pages/SkillsPage.tsx
+++ b/src/skillberry_store/ui/src/pages/SkillsPage.tsx
@@ -290,8 +290,9 @@ export function SkillsPage() {
   const handleExport = async () => {
     const selectedSkillObjects = skills?.filter(s => selectedSkills.includes(s.name)) || [];
     
-    // Use helper function to export skills with UUIDs (matching backend format)
-    const skillsForExport = exportSkills(selectedSkillObjects);
+    // Re-fetch full manifests (list-page items use a narrow preset)
+    // and normalize to the backend export shape.
+    const skillsForExport = await exportSkills(selectedSkillObjects);
     
     // Generate filename based on selected skills
     let filename: string;

--- a/src/skillberry_store/ui/src/pages/SnippetDetailPage.tsx
+++ b/src/skillberry_store/ui/src/pages/SnippetDetailPage.tsx
@@ -106,7 +106,7 @@ export function SnippetDetailPage() {
         description: snippet.description,
         state: snippet.state || 'approved',
         tags: snippet.tags || [],
-        content: snippet.content,
+        content: snippet.content ?? '',
         content_type: snippet.content_type || 'text/plain',
         extra: snippet.extra || {},
       });
@@ -337,7 +337,7 @@ export function SnippetDetailPage() {
                   minHeight: '100%',
                 }}
               >
-                {snippet.content}
+                {snippet.content ?? ''}
               </SyntaxHighlighter>
             </div>
           </CardBody>

--- a/src/skillberry_store/ui/src/pages/SnippetsPage.tsx
+++ b/src/skillberry_store/ui/src/pages/SnippetsPage.tsx
@@ -172,12 +172,12 @@ export function SnippetsPage() {
     deleteMutation.mutate(selectedSnippets);
   };
 
-  const handleExport = () => {
+  const handleExport = async () => {
     const selectedSnippetObjects = snippets?.filter(s => selectedSnippets.includes(s.name)) || [];
-    
-    // Use helper function to export snippets
-    const snippetsForExport = exportSnippets(selectedSnippetObjects);
-    
+
+    // Re-fetch full manifests (list-page items use a narrow preset).
+    const snippetsForExport = await exportSnippets(selectedSnippetObjects);
+
     // Download as JSON file
     downloadJSON(snippetsForExport, `snippets-export-${new Date().toISOString().split('T')[0]}.json`);
   };

--- a/src/skillberry_store/ui/src/pages/VMCPServersPage.tsx
+++ b/src/skillberry_store/ui/src/pages/VMCPServersPage.tsx
@@ -221,12 +221,12 @@ export function VMCPServersPage() {
     deleteMutation.mutate(selectedServers);
   };
 
-  const handleExport = () => {
+  const handleExport = async () => {
     const selectedServerObjects = servers?.filter(s => selectedServers.includes(s.name)) || [];
-    
-    // Use helper function to export VMCP servers
-    const serversForExport = exportVMCPServers(selectedServerObjects);
-    
+
+    // Re-fetch full manifests (list-page items use a narrow preset).
+    const serversForExport = await exportVMCPServers(selectedServerObjects);
+
     // Download as JSON file
     downloadJSON(serversForExport, `vmcp-servers-export-${new Date().toISOString().split('T')[0]}.json`);
   };

--- a/src/skillberry_store/ui/src/pages/VNFSServersPage.tsx
+++ b/src/skillberry_store/ui/src/pages/VNFSServersPage.tsx
@@ -179,9 +179,10 @@ export function VNFSServersPage() {
     deleteMutation.mutate(selectedServers);
   };
 
-  const handleExport = () => {
+  const handleExport = async () => {
     const selected = servers?.filter(s => selectedServers.includes(s.name)) || [];
-    downloadJSON(exportVNFSServers(selected), `vnfs-servers-export-${new Date().toISOString().split('T')[0]}.json`);
+    const forExport = await exportVNFSServers(selected);
+    downloadJSON(forExport, `vnfs-servers-export-${new Date().toISOString().split('T')[0]}.json`);
   };
 
   const handleImport = async () => {

--- a/src/skillberry_store/ui/src/services/api.ts
+++ b/src/skillberry_store/ui/src/services/api.ts
@@ -44,7 +44,7 @@ async function handleResponse<T>(response: Response): Promise<T> {
 // Tools API
 export const toolsApi = {
   list: async (): Promise<Tool[]> => {
-    const response = await fetch(`${API_BASE}/tools/`);
+    const response = await fetch(`${API_BASE}/tools/?fields=list`);
     return handleResponse<Tool[]>(response);
   },
 
@@ -125,7 +125,7 @@ export const toolsApi = {
 // Skills API
 export const skillsApi = {
   list: async (): Promise<Skill[]> => {
-    const response = await fetch(`${API_BASE}/skills/`);
+    const response = await fetch(`${API_BASE}/skills/?fields=list`);
     return handleResponse<Skill[]>(response);
   },
 
@@ -184,7 +184,7 @@ export const skillsApi = {
 // Snippets API
 export const snippetsApi = {
   list: async (): Promise<Snippet[]> => {
-    const response = await fetch(`${API_BASE}/snippets/`);
+    const response = await fetch(`${API_BASE}/snippets/?fields=list`);
     return handleResponse<Snippet[]>(response);
   },
 
@@ -198,7 +198,7 @@ export const snippetsApi = {
     const params = new URLSearchParams({
       name: snippet.name,
       description: snippet.description,
-      content: snippet.content,
+      content: snippet.content ?? '',
       version: snippet.version || '1.0.0',
       content_type: snippet.content_type || 'text/plain',
       state: snippet.state || 'approved',

--- a/src/skillberry_store/ui/src/services/api.ts
+++ b/src/skillberry_store/ui/src/services/api.ts
@@ -44,7 +44,7 @@ async function handleResponse<T>(response: Response): Promise<T> {
 // Tools API
 export const toolsApi = {
   list: async (): Promise<Tool[]> => {
-    const response = await fetch(`${API_BASE}/tools/?fields=list`);
+    const response = await fetch(`${API_BASE}/tools/?fields=narrow`);
     return handleResponse<Tool[]>(response);
   },
 
@@ -125,7 +125,7 @@ export const toolsApi = {
 // Skills API
 export const skillsApi = {
   list: async (): Promise<Skill[]> => {
-    const response = await fetch(`${API_BASE}/skills/?fields=list`);
+    const response = await fetch(`${API_BASE}/skills/?fields=narrow`);
     return handleResponse<Skill[]>(response);
   },
 
@@ -184,7 +184,7 @@ export const skillsApi = {
 // Snippets API
 export const snippetsApi = {
   list: async (): Promise<Snippet[]> => {
-    const response = await fetch(`${API_BASE}/snippets/?fields=list`);
+    const response = await fetch(`${API_BASE}/snippets/?fields=narrow`);
     return handleResponse<Snippet[]>(response);
   },
 
@@ -257,7 +257,7 @@ export const snippetsApi = {
 // VMCP Servers API
 export const vmcpApi = {
   list: async (): Promise<VMCPServer[]> => {
-    const response = await fetch(`${API_BASE}/vmcp_servers/`);
+    const response = await fetch(`${API_BASE}/vmcp_servers/?fields=narrow`);
     return handleResponse<VMCPServer[]>(response);
   },
 
@@ -342,7 +342,7 @@ export const vmcpApi = {
 // vNFS Servers API
 export const vnfsApi = {
   list: async (): Promise<VNFSServer[]> => {
-    const response = await fetch(`${API_BASE}/vnfs_servers/`);
+    const response = await fetch(`${API_BASE}/vnfs_servers/?fields=narrow`);
     return handleResponse<VNFSServer[]>(response);
   },
 

--- a/src/skillberry_store/ui/src/services/api.ts
+++ b/src/skillberry_store/ui/src/services/api.ts
@@ -258,9 +258,7 @@ export const snippetsApi = {
 export const vmcpApi = {
   list: async (): Promise<VMCPServer[]> => {
     const response = await fetch(`${API_BASE}/vmcp_servers/`);
-    const data = await handleResponse<{ virtual_mcp_servers: Record<string, VMCPServer> }>(response);
-    // Convert the object to an array
-    return Object.values(data.virtual_mcp_servers);
+    return handleResponse<VMCPServer[]>(response);
   },
 
   get: async (uuid: string): Promise<VMCPServer> => {
@@ -345,8 +343,7 @@ export const vmcpApi = {
 export const vnfsApi = {
   list: async (): Promise<VNFSServer[]> => {
     const response = await fetch(`${API_BASE}/vnfs_servers/`);
-    const data = await handleResponse<{ virtual_nfs_servers: Record<string, VNFSServer> }>(response);
-    return Object.values(data.virtual_nfs_servers);
+    return handleResponse<VNFSServer[]>(response);
   },
 
   get: async (uuid: string): Promise<VNFSServer> => {

--- a/src/skillberry_store/ui/src/types/index.ts
+++ b/src/skillberry_store/ui/src/types/index.ts
@@ -35,6 +35,10 @@ export interface Skill {
   name: string;
   description: string;
   state?: ManifestState;
+  // Slim list-view responses expose tool_uuids/snippet_uuids only.
+  // Detail (GET /skills/{uuid}) additionally populates tools/snippets.
+  tool_uuids?: string[];
+  snippet_uuids?: string[];
   tools?: Tool[];
   snippets?: Snippet[];
   tags?: string[];
@@ -49,7 +53,9 @@ export interface Snippet {
   uuid: string;
   name: string;
   description: string;
-  content: string;
+  // `content` is absent on slim list-view responses (fields=list); the
+  // detail endpoint (GET /snippets/{uuid}) still returns it.
+  content?: string;
   state?: ManifestState;
   content_type?: string;
   tags?: string[];

--- a/src/skillberry_store/ui/src/utils/exportImportHelpers.ts
+++ b/src/skillberry_store/ui/src/utils/exportImportHelpers.ts
@@ -1,8 +1,8 @@
 // Copyright 2025 IBM Corp.
 // Licensed under the Apache License, Version 2.0
 
-import { toolsApi, snippetsApi, vmcpApi, vnfsApi } from '@/services/api';
-import type { Tool, Snippet, VMCPServer, VNFSServer } from '@/types';
+import { toolsApi, skillsApi, snippetsApi, vmcpApi, vnfsApi } from '@/services/api';
+import type { Tool, Skill, Snippet, VMCPServer, VNFSServer } from '@/types';
 import JSZip from 'jszip';
 
 export interface ImportResult {
@@ -11,17 +11,27 @@ export interface ImportResult {
 }
 
 /**
- * Export tools with their module content
+ * Export tools with their module content.
+ *
+ * The input list may have been fetched with a narrow field-selection
+ * preset, so the full manifest is re-fetched via ``toolsApi.get`` (which
+ * always returns every field) before the module content is attached.
  */
 export async function exportTools(tools: Tool[]): Promise<(Tool & { module_content?: string })[]> {
   return await Promise.all(
     tools.map(async (tool) => {
+      let full: Tool = tool;
       try {
-        const module = await toolsApi.getModule(tool.name);
-        return { ...tool, module_content: module };
+        full = await toolsApi.get(tool.uuid!);
       } catch (error) {
-        console.error(`Failed to fetch module for ${tool.name}:`, error);
-        return { ...tool, module_content: undefined };
+        console.error(`Failed to fetch full tool ${tool.name}:`, error);
+      }
+      try {
+        const module = await toolsApi.getModule(full.name);
+        return { ...full, module_content: module };
+      } catch (error) {
+        console.error(`Failed to fetch module for ${full.name}:`, error);
+        return { ...full, module_content: undefined };
       }
     })
   );
@@ -65,10 +75,21 @@ export async function importTools(tools: (Tool & { module_content?: string })[])
 }
 
 /**
- * Export snippets (they already contain content in the schema)
+ * Export snippets. The list-page items are fetched with a narrow preset
+ * (no ``content``), so each snippet is re-fetched via ``snippetsApi.get``
+ * to obtain the full manifest before export.
  */
-export function exportSnippets(snippets: Snippet[]): Snippet[] {
-  return snippets;
+export async function exportSnippets(snippets: Snippet[]): Promise<Snippet[]> {
+  return await Promise.all(
+    snippets.map(async (s) => {
+      try {
+        return await snippetsApi.get(s.uuid!);
+      } catch (error) {
+        console.error(`Failed to fetch full snippet ${s.name}:`, error);
+        return s;
+      }
+    })
+  );
 }
 
 /**
@@ -91,24 +112,29 @@ export async function importSnippets(snippets: Snippet[]): Promise<ImportResult>
 }
 
 /**
- * Export skills with tool and snippet UUIDs (matching backend format)
+ * Export skills with tool and snippet UUIDs (matching backend format).
+ * Each skill is fetched via ``skillsApi.get`` to obtain the full
+ * manifest (list-page items use a narrow preset).
  */
-export function exportSkills(skills: any[]): any[] {
-  return skills.map(skill => {
-    // If the skill already has tool_uuids and snippet_uuids (from backend), use them
-    // Otherwise, extract from the populated tools and snippets arrays
-    const tool_uuids = skill.tool_uuids || skill.tools?.map((t: any) => t.uuid) || [];
-    const snippet_uuids = skill.snippet_uuids || skill.snippets?.map((s: any) => s.uuid) || [];
-
-    return {
-      name: skill.name,
-      version: skill.version || '1.0.0',
-      description: skill.description,
-      tags: skill.tags || [],
-      tool_uuids,
-      snippet_uuids,
-    };
-  });
+export async function exportSkills(skills: Skill[]): Promise<any[]> {
+  const full = await Promise.all(
+    skills.map(async (skill) => {
+      try {
+        return await skillsApi.get(skill.uuid!);
+      } catch (error) {
+        console.error(`Failed to fetch full skill ${skill.name}:`, error);
+        return skill as any;
+      }
+    })
+  );
+  return full.map(skill => ({
+    name: skill.name,
+    version: skill.version || '1.0.0',
+    description: skill.description,
+    tags: skill.tags || [],
+    tool_uuids: skill.tool_uuids || [],
+    snippet_uuids: skill.snippet_uuids || [],
+  }));
 }
 
 /**
@@ -179,10 +205,20 @@ export async function importSkills(skills: any[]): Promise<ImportResult> {
 }
 
 /**
- * Export VMCP servers
+ * Export VMCP servers. Re-fetched via ``vmcpApi.get`` so the export
+ * contains every field (list-page items use a narrow preset).
  */
-export function exportVMCPServers(servers: VMCPServer[]): VMCPServer[] {
-  return servers;
+export async function exportVMCPServers(servers: VMCPServer[]): Promise<VMCPServer[]> {
+  return await Promise.all(
+    servers.map(async (s) => {
+      try {
+        return await vmcpApi.get(s.uuid!);
+      } catch (error) {
+        console.error(`Failed to fetch full vmcp server ${s.name}:`, error);
+        return s;
+      }
+    })
+  );
 }
 
 /**
@@ -220,10 +256,20 @@ export function downloadJSON(data: any, filename: string): void {
 }
 
 /**
- * Export vNFS servers
+ * Export vNFS servers. Re-fetched via ``vnfsApi.get`` so the export
+ * contains every field (list-page items use a narrow preset).
  */
-export function exportVNFSServers(servers: VNFSServer[]): VNFSServer[] {
-  return servers;
+export async function exportVNFSServers(servers: VNFSServer[]): Promise<VNFSServer[]> {
+  return await Promise.all(
+    servers.map(async (s) => {
+      try {
+        return await vnfsApi.get(s.uuid!);
+      } catch (error) {
+        console.error(`Failed to fetch full vnfs server ${s.name}:`, error);
+        return s;
+      }
+    })
+  );
 }
 
 /**


### PR DESCRIPTION
This PR continues PR #278
Field presets are defined as labels that are associated with fields for each object type (skill, tool, etc)
Created 3 basic presets: narrow, wide and full
Narrow is the basic preset
- **refactor: express field-selection presets as per-field tags**
- **refactor: three-preset field-selection model (narrow/wide/full) with flag-gated bundling**
- **change: default field-selection preset on list/search HTTP endpoints from full to narrow**
- **fix: make narrow the semantic default in parse_fields_spec, not just at HTTP layer**
- **refactor: govern "full" through FieldTags like every other preset**
