### PR TITLE
docs(readme): add status badges and a GitHub stars badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 <p>
   <a href="https://skillberry-ai.github.io/skillberry-store/"><img src="https://img.shields.io/badge/site-live-0066CC" alt="site"></a>
+  <a href="https://github.com/skillberry-ai/skillberry-store/actions/workflows/push.yml"><img src="https://github.com/skillberry-ai/skillberry-store/actions/workflows/push.yml/badge.svg?branch=main" alt="CI"></a>
   <a href="https://github.com/skillberry-ai/skillberry-store/stargazers"><img src="https://img.shields.io/github/stars/skillberry-ai/skillberry-store?style=flat&label=stars&color=0066CC" alt="GitHub stars"></a>
   <img src="https://img.shields.io/badge/status-beta%20(0.x)-orange" alt="status">
   <img src="https://img.shields.io/badge/python-3.11%2B-blue" alt="python">

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # Skillberry-store service (a.k.a., SBS)
 
+<p>
+  <a href="https://skillberry-ai.github.io/skillberry-store/"><img src="https://img.shields.io/badge/site-live-0066CC" alt="site"></a>
+  <a href="https://github.com/skillberry-ai/skillberry-store/stargazers"><img src="https://img.shields.io/github/stars/skillberry-ai/skillberry-store?style=flat&label=stars&color=0066CC" alt="GitHub stars"></a>
+  <img src="https://img.shields.io/badge/status-beta%20(0.x)-orange" alt="status">
+  <img src="https://img.shields.io/badge/python-3.11%2B-blue" alt="python">
+  <img src="https://img.shields.io/badge/license-Apache--2.0-informational" alt="license">
+  <a href="docs/plugins-installation.md"><img src="https://img.shields.io/badge/plugins-16-0066CC" alt="plugins"></a>
+</p>
+
 This service implements a smart skills repository for agentic workflows. Manage, execute, and organize your skills, tools and snippets with powerful search and lifecycle management.
 
 ![Skillberry Store demo](https://i.imgur.com/hpsGpnc.gif)


### PR DESCRIPTION
Closes #291.

## Summary
Adds a badge row under the README title, mirroring the badge style used in the [cap-evolve](https://github.com/skillberry-ai/cap-evolve) README, adapted to skillberry-store's facts and using the Skillberry blue accent (`#0066CC`):

- **site — live** → links to the GitHub Pages site
- **stars** → live GitHub stars count (dynamic shields.io badge, links to stargazers)
- **status — beta (0.x)** — reflects the current `0.1.0` version
- **python — 3.11+** — from `requires-python = ">=3.11"`
- **license — Apache-2.0**
- **plugins — 16** → links to the Plugin Installation Guide (16 packages under `plugins/`)

The cap-evolve "0 runtime deps" badge was intentionally omitted, since SBS has substantial runtime dependencies.

## Testing
Verified badge markup and counts against the repo (`plugins/` has 16 packages; `pyproject.toml` requires Python 3.11+, version 0.1.0). Badge image URLs are standard shields.io endpoints.

Signed-off-by: Eran Raichstein <eranra@il.ibm.com>