### PR TITLE
ci push fix

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,6 +17,12 @@ jobs:
       run: sudo apt-get install make
     - name: checkout
       uses: actions/checkout@v7.0.0
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v4
+      with:
+        platforms: arm64
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
     - name: create-venv
       run: |
           python -m venv .venv
@@ -26,3 +32,6 @@ jobs:
       run: |
           source .venv/bin/activate
           make ci-push
+
+
+

--- a/skillberry-common/.mk/ci.mk
+++ b/skillberry-common/.mk/ci.mk
@@ -18,9 +18,9 @@ ci-pull-request: ## Executed upon ci pull_request event
 
 .PHONY: ci-push
 ci-push: ci-pull-request ## Executed upon ci push event
-	@echo "|||====> Executing make docker-push (and build)"
-	VERSION=$(VERSION) make docker-push
-	@echo "|||====> docker-push Done."
+	@echo "|||====> Executing make docker-build (buildx multi-platform - also push)"
+	VERSION=$(VERSION) DBT=registry make docker-build
+	@echo "|||====> docker-build Done."
 	@echo ""
 	@echo "|||====> Executing make update-sdk"
 	VERSION=$(VERSION) make update-sdk

--- a/skillberry-common/.mk/dev.mk
+++ b/skillberry-common/.mk/dev.mk
@@ -35,13 +35,12 @@ CODE_FILES := $(CODE_FILES) pyproject.toml Makefile Dockerfile
 .stamps/code-scan: $(CODE_FILES)
 	@echo "Detected code changed in: $(CODE_SUBTREES)"
 	@if [ -f .stamps/code-scan ]; then \
-		for file in $(CODE_FILES); do \
-			if [ "$$file" -nt .stamps/code-scan ]; then \
-				echo "$$file"; \
-			fi; \
+		find $(CODE_SUBTREES) -type f $(CODE_FILTER) -newer .stamps/code-scan -print; \
+		for f in pyproject.toml Makefile Dockerfile; do \
+			[ -e "$$f" ] && [ "$$f" -nt .stamps/code-scan ] && echo "$$f"; \
 		done; \
 	fi
-	@touch .stamps/code-scan
+	@mkdir -p .stamps && touch .stamps/code-scan
 
 git-hooks-setup:
 	@if git rev-parse --is-inside-work-tree > /dev/null 2>&1; then \


### PR DESCRIPTION
- **Added standard setup for multi-platform buildx (QEMU + buildx)**
- **Replaced old docker-push target with docker-build, which also handles push with DBT=registry**
- **File change check updated to use find and avoid too big shell commands**