### PR TITLE
Build system: simplification, cleanup, minor bug fixes

### DIFF
--- a/.mk/dev.mk
+++ b/.mk/dev.mk
@@ -1,6 +1,6 @@
 ##@ Development
 
-lint: ## List the tools-service
+lint: ## Lint the codebase
 	@$(MAKE) install-requirements ODEPS=dev
 	black --check --diff --color src/skillberry_store/modules src/skillberry_store/tools src/skillberry_store/fast_api src/skillberry_store/utils || \
 		(echo "Lint Failed. Please run 'black src/skillberry_store/modules src/skillberry_store/tools src/skillberry_store/fast_api src/skillberry_store/utils' to fix the issues" && exit 1)

--- a/docs/design/build_concepts.md
+++ b/docs/design/build_concepts.md
@@ -1,0 +1,158 @@
+# Build System Concepts
+
+These concepts define how the Makefile system tracks repository state, decides when to
+reinstall Python dependencies, and decides when to rebuild the Docker image. They form
+a single "state → label → build" pipeline: repository state is fingerprinted into a
+**git version label**, and downstream artifacts (installed dependencies, docker images,
+version files) are invalidated only when that label — or a small set of well-defined
+inputs — changes.
+
+## 1. Git version label reflects repository state
+
+A "git version" label is computed to identify the current state of the repository. The
+label is a **pure function of state**, not of time or of environmental factors: the same
+state always produces the same label, and any real change to state produces a different
+label.
+
+"State" is defined as **anything that `git status --porcelain` would report** at the
+root of the working tree, together with the committed history reachable from `HEAD`.
+Concretely, the label must change when any of the following occur:
+
+- A new commit is made, amended, or checked out.
+- A tracked file is modified, added, or removed in the working tree (whether staged or
+  unstaged).
+- A file is added to or removed from tracking (`git add`, `git rm --cached`).
+- A new file appears in the working tree that is **not** matched by `.gitignore`.
+
+The label must **not** change for events that do not affect state, including:
+
+- Files that are matched by `.gitignore` (logs, build artifacts, virtual environments,
+  the `.stamps/` directory itself, etc.) being created, modified, or removed.
+- Remote refs being fetched, pruned, or otherwise updated without a corresponding local
+  checkout.
+- The passage of time between two invocations that observe the same state.
+
+Because different sets of uncommitted changes must produce different labels, a bare
+`-dirty` suffix is insufficient. When state is dirty, the label must incorporate a
+fingerprint of the dirty content (for example, a short hash derived from
+`git stash create`, or from the concatenation of `git diff HEAD` and the list of
+non-ignored untracked files).
+
+## 2. State manifest is content-idempotent and pivots the stamp graph
+
+The primary artifact recording repository state is the **git-state manifest**
+at `.stamps/git-version-manifest`. It is a canonical, byte-stable record of the
+working-tree state whose content is a function of that state alone: same state
+produces byte-identical manifest, and any real state change produces a
+different manifest.
+
+The manifest is content-idempotent: it is rewritten **only** when either:
+
+1. It does not yet exist, or
+2. Its new content differs from the content currently in the file.
+
+The purpose is to keep the file's modification time stable across invocations
+that do not change state. Anything downstream that depends on this file via
+Make's timestamp rules must not re-fire spuriously. The manifest is the
+**pivot of the stamp graph** — every downstream stamp that needs to know
+"did state change" depends on it (see concept 4).
+
+**Observability.** Because the manifest records per-file state, a rewrite is
+also the natural place to report *what* changed. Whenever the manifest is
+rewritten, an observability line is emitted:
+
+- If no prior manifest exists: `No prior BUILD_VERSION detected`.
+- Otherwise: `The following changes have been detected since previous BUILD_VERSION:` followed by the list of file paths responsible for the change, categorized (commit-delta `~`, newly-dirty `+`, no-longer-dirty `-`, still-dirty-with-different-content `!`).
+
+**Optional projection to `VERSION_LOCATION`.** A project may additionally
+declare `VERSION_LOCATION` — a path to an app-visible file (typically a
+generated Python module) that carries the label at runtime. When defined,
+this file is written with the *same* content-idempotence rule (rewritten only
+when the label content differs), as a side effect of the manifest rewrite.
+Projects that do not need runtime access to the label may leave
+`VERSION_LOCATION` undefined; the manifest remains the pivot regardless.
+
+This is a specific instance of a more general rule: **every generated file
+that gates downstream builds must be content-idempotent** — rewritten only
+when its content actually changes. The same discipline applies to any other
+generated file that participates in the stamp graph.
+
+## 3. Docker image presence is aligned with the git version label
+
+The invariant enforced is: **a Docker image tagged with the current git version label
+exists locally (or in the target registry, for registry builds)**. Build work is
+performed only when necessary to restore that invariant.
+
+A rebuild is performed when either:
+
+1. No stamp records that an image for the current label has been produced, **or**
+2. No local image with the current label tag actually exists (e.g., it was deleted
+   with `docker rmi`).
+
+An image obtained by pulling from a registry satisfies the invariant just as well as
+one produced by a local build; the concept is **image presence at the current label**,
+not "the build command was invoked." Stamp names should reflect the label so that
+different labels never share a stamp:
+`.stamps/docker-build-$(DBT)-$(BUILD_VERSION)` (or equivalent).
+
+Local builds (`DBT=local`) and registry builds (`DBT=registry`) produce different
+artifacts (a local image versus a pushed multi-arch manifest). They are tracked with
+separate stamps and neither satisfies the other.
+
+## 4. Change detection uses the state manifest, not a parallel scan
+
+Any Make target that needs to know "did anything relevant change" must
+consult the state manifest from concept 2 — directly, as a prerequisite. A
+parallel scan-based mechanism (for example, `find`-with-mtime over a
+hand-maintained list of subtrees) is **redundant** and must not be used,
+because:
+
+- It duplicates what git already tracks, and the two mechanisms will drift.
+- Hand-maintained path lists rot as the codebase evolves.
+- `mtime` is not preserved across `git checkout` and other git operations
+  that rewrite files without changing their content, producing both false
+  positives and false negatives.
+
+Every stamp target that previously depended on such a parallel scan must be
+migrated to depend on the state manifest.
+
+## 5. `install-requirements-$(ODEPS)` has minimal, precise dependencies
+
+The stamp for `install-requirements-$(ODEPS)` depends on exactly two things:
+
+1. `pyproject.toml` — the source of dependency declarations.
+2. The value of `ODEPS` — captured naturally by the per-value stamp name
+   (`.stamps/install-requirements-$(ODEPS)`), so different `ODEPS` values get
+   different stamps.
+
+No other prerequisites are permitted on this stamp. In particular, the virtual
+environment directory (`.venv`) must not be a prerequisite — its modification time is
+not a reliable signal, and its existence is a precondition that belongs in a separate
+`verify-venv` step that fails loudly if missing.
+
+**Note on lockfiles**: this project currently installs directly from `pyproject.toml`
+via `uv pip install -e .` without a lockfile. If a lockfile (`uv.lock`,
+`poetry.lock`, `requirements*.txt`, etc.) is ever adopted, it becomes the ground
+truth for what will actually be installed and must be added to the prerequisite list
+alongside `pyproject.toml`.
+
+## 6. Install stamp bookkeeping
+
+When `install-requirements-$(ODEPS)` actually performs an installation, it must
+enforce the following invariant on completion: **at most one non-empty-`ODEPS` stamp
+is valid at any moment, and the empty-`ODEPS` stamp is always valid when any install
+has occurred.**
+
+The rationale is that `uv pip install -e .[X]` replaces the previous set of extras;
+the environment reflects only the most recently installed extras, so any prior
+non-empty stamp would be a lie about the environment. The empty-`ODEPS` case is
+always implied because any `.[X]` install also installs the base package.
+
+Concretely, on a successful install, the recipe must:
+
+1. Remove **all** existing `.stamps/install-requirements-*` stamps.
+2. Touch `.stamps/install-requirements-` (the empty-`ODEPS` stamp) — always.
+3. If `ODEPS` is non-empty, additionally touch `.stamps/install-requirements-$(ODEPS)`.
+
+On a **failed** install, no stamps are touched, so retry is forced on the next
+invocation.

--- a/skillberry-common/.mk/dev.mk
+++ b/skillberry-common/.mk/dev.mk
@@ -19,28 +19,8 @@ OPEN_API_SPEC_URL ?= http://$(SERVICE_HOST):$(MAIN_SERVICE_PORT)
 
 export SERVICE_HAS_SDK ?= 0
 
-# List your subtree roots
-CODE_SUBTREES := src .mk $(SB_COMMON_PATH)/.mk $(SB_COMMON_PATH)/scripts
-
-# One common filter for all
-CODE_FILTER := \( -name '*.py' -o -name 'Makefile' -o -name '*.mk' -o -name '*.sh' \)
-
-# Expand to the union of files across all subtrees
-CODE_FILES := $(foreach T,$(CODE_SUBTREES), \
-  $(shell find $(T) -type f $(CODE_FILTER) -print))
-
-CODE_FILES := $(CODE_FILES) pyproject.toml Makefile Dockerfile
-
-# This stamp file checks for code changes
-.stamps/code-scan: $(CODE_FILES)
-	@echo "Detected code changed in: $(CODE_SUBTREES)"
-	@if [ -f .stamps/code-scan ]; then \
-		find $(CODE_SUBTREES) -type f $(CODE_FILTER) -newer .stamps/code-scan -print; \
-		for f in pyproject.toml Makefile Dockerfile; do \
-			[ -e "$$f" ] && [ "$$f" -nt .stamps/code-scan ] && echo "$$f" || true; \
-		done; \
-	fi
-	@mkdir -p .stamps && touch .stamps/code-scan
+# Change detection is driven off the BUILD_VERSION label (see globals.mk and
+# concept 4 of docs/design/build_concepts.md). No parallel file-scan is used.
 
 git-hooks-setup:
 	@if git rev-parse --is-inside-work-tree > /dev/null 2>&1; then \
@@ -79,7 +59,7 @@ check-git-main:
 	fi
 
 .PHONY: install-requirements verify-venv
-install-requirements: update-git-version git-hooks-setup verify-venv .stamps/install-requirements-$(ODEPS) ## Install dependencies. Opt: make install-requirements ODEPS=dev [SKIPOPT=1 to allow skip]
+install-requirements: git-hooks-setup verify-venv .stamps/git-version-manifest .stamps/install-requirements-$(ODEPS) ## Install dependencies. Opt: make install-requirements ODEPS=dev [SKIPOPT=1 to allow skip]
 	@true
 
 verify-venv:
@@ -87,47 +67,30 @@ verify-venv:
 	@python $(SB_COMMON_PATH)/scripts/ensure_pip.py || exit 1
 	@python -m pip install uv
 
-# Need to actually install only when pyproject.toml changes
-.stamps/install-requirements-$(ODEPS): pyproject.toml .venv
-	@ODEPS="$(ODEPS)"; \
-	SKIPOPT="$(SKIPOPT)"; \
-	if [ -z "$$ODEPS" ]; then \
-		uv pip install -e . || exit 1; \
-	else \
-		if uv pip install -e .[$$ODEPS]; then \
-			true; \
-		elif [ "$$SKIPOPT" = "1" ]; then \
-			echo "Optional dependency install failed for ODEPS=$$ODEPS; retrying without optional dependencies because SKIPOPT=1"; \
-			uv pip install -e . || exit 1; \
-		else \
-			exit 1; \
-		fi; \
-	fi
-	@touch .stamps/install-requirements-$(ODEPS)
+# Install stamp: prerequisite is exactly `pyproject.toml`. The per-ODEPS stamp
+# name captures the ODEPS variant (concept 5). Concept-6 stamp bookkeeping
+# (single valid non-empty stamp, always-valid empty stamp, no touch on
+# failure) is performed by the delegated script.
+.stamps/install-requirements-$(ODEPS): pyproject.toml
+	@$(SB_COMMON_PATH)/scripts/install-requirements.sh "$(ODEPS)" "$(SKIPOPT)"
 
 
-# Will actually modify the file in $(VERSIOIN_LOCATION) only if it does not exist or has different content
+# .stamps/git-version-manifest is the pivot of the build stamp graph — the
+# label-derived record that gates all downstream builds (concepts 2 & 4).
+#
+# The recipe runs whenever a make target that (transitively) depends on the
+# manifest is invoked (e.g. install-requirements, docker-build). It calls
+# scripts/git_state.py update, which is content-idempotent: the manifest
+# file is rewritten (and observability printed to stderr) only when
+# repository state has actually changed, keeping mtime stable so downstream
+# targets don't refire spuriously. Targets that don't need the label (make
+# help, make print_build_version, etc.) don't trigger this recipe.
+.stamps/git-version-manifest: FORCE
+	@python $(SB_COMMON_PATH)/scripts/git_state.py update \
+	    "$(BUILD_VERSION)" "$@" "$(VERSION_LOCATION)"
 
-.PHONY: update-git-version
-update-git-version:
-	@if git rev-parse --is-inside-work-tree > /dev/null 2>&1; then \
-	    NEW_CONTENT="__git_version__ = \"$(BUILD_VERSION)\""; \
-	    if [ ! -f "$(VERSION_LOCATION)" ]; then \
-	        echo "Creating git version file at $(VERSION_LOCATION)"; \
-	        echo "$$NEW_CONTENT" > $(VERSION_LOCATION); \
-	    else \
-	        CURRENT_CONTENT=$$(cat $(VERSION_LOCATION) 2>/dev/null || echo ""); \
-	        if [ "$$CURRENT_CONTENT" != "$$NEW_CONTENT" ]; then \
-				echo "Git version changed. Current content: $$CURRENT_CONTENT <==> New content: $$NEW_CONTENT"; \
-	            echo "Updating git version in $(VERSION_LOCATION)"; \
-	            echo "$$NEW_CONTENT" > $(VERSION_LOCATION); \
-	        else \
-	            echo "Git version in $(VERSION_LOCATION) is already up to date"; \
-	        fi; \
-	    fi; \
-	else \
-	    echo "Skipping update-git-version: not inside a Git repository."; \
-	fi
+.PHONY: FORCE
+FORCE:
 
 
 release: check-git-main check-git-clean install-requirements  ## Release a new version (REDO=1 to cleanup existing artifacts)
@@ -171,8 +134,8 @@ release: check-git-main check-git-clean install-requirements  ## Release a new v
 	@git push origin $(RELEASE_VERSION)
 
 	#
-	# Important: change to main so that later invocation of "update-git-version" properly works,
-	# Note: update-git-version is called on different contexts later in this flow
+	# Switch to main so the subsequent gh release notes command computes its
+	# commit range against main rather than the release branch.
 	#
 	@git checkout main
 

--- a/skillberry-common/.mk/dev.mk
+++ b/skillberry-common/.mk/dev.mk
@@ -124,6 +124,8 @@ release: check-git-main check-git-clean install-requirements  ## Release a new v
 		gh release delete $(RELEASE_VERSION) --yes 2>/dev/null || echo "GitHub release does not exist"; \
 		echo "===> REDO: Cleaning up existing Docker images"; \
 		$(DOCKER) rmi -f $(FULL_IMAGE_NAME):$(RELEASE_VERSION) 2>/dev/null || echo "Docker image with version tag does not exist"; \
+		echo "===> REDO: Cleaning up docker build/get stamps so the re-release forces a fresh build"; \
+		rm -f .stamps/docker-build-registry-* .stamps/docker-get-* 2>/dev/null || true; \
 		echo "===> REDO: Cleanup completed"; \
 	fi
 
@@ -131,7 +133,13 @@ release: check-git-main check-git-clean install-requirements  ## Release a new v
 	@git checkout -b branch-$(RELEASE_VERSION)
 	@echo "===> Generated release branch $(RELEASE_VERSION)"
 	@git tag -a $(RELEASE_VERSION) -m "Release $(RELEASE_VERSION)"
-	@git push origin $(RELEASE_VERSION)
+	# Push BOTH the tag and the release branch. The branch is required on
+	# origin so that git_state.py's _LATEST_RELEASE detection (which scans
+	# `git branch -r | grep 'branch-'`) picks up this release when the
+	# docker-build sub-make below recomputes BUILD_VERSION — otherwise the
+	# image is tagged with the previous-release-based label instead of
+	# $(RELEASE_VERSION).
+	@git push origin $(RELEASE_VERSION) branch-$(RELEASE_VERSION)
 
 	#
 	# Switch to main so the subsequent gh release notes command computes its

--- a/skillberry-common/.mk/docker.mk
+++ b/skillberry-common/.mk/docker.mk
@@ -88,9 +88,6 @@ else
 DOCKER_ARCH := unknown
 endif
 
-# Print the value of DOCKER
-@echo "Using Docker: $(DOCKER)"
-
 # Check whether docker is aliased to podman
 # It is assumed that the user is using zsh or bash and alias is defined in ~/.zshrc or ~/.bashrc
 # Check that either Docker or Podman is installed
@@ -120,15 +117,21 @@ else ifeq ($(DBT),registry)
 	DB_ARCH := $(SUPPORTED_ARCHS)
 	DB_ACTION := push
 else
-	@echo "Invalid DBT value: $(DBT). Supported values: local, registry"
-	@exit 1
+$(error Invalid DBT value: $(DBT). Supported values: local, registry)
 endif
 
-.PHONY: base-image-build 
-base-image-build: multiarch-check .stamps/base-image-build-$(DBT)	## Build skillberry base image (DBT=registry to build & push multi-arch)
+# Parse-time reconciler: if the local image at the current BUILD_VERSION label
+# has been removed (e.g., `docker rmi`), invalidate the stamps that claim it
+# exists so the next build/get restores the invariant (concept 3).
+_docker_reconcile := $(shell $(SB_COMMON_PATH)/scripts/docker-reconcile-stamp.sh \
+    $(DOCKER) $(FULL_IMAGE_NAME) $(BUILD_VERSION) $(DBT))
 
-# Build base multi-arch image if it does not exist
-.stamps/base-image-build-$(DBT): 
+.PHONY: base-image-build
+base-image-build: multiarch-check .stamps/base-image-build-$(DBT)-$(BASE_IMAGE_TAG)	## Build skillberry base image (DBT=registry to build & push multi-arch)
+
+# Build base multi-arch image if it does not exist. Stamp includes DBT and
+# BASE_IMAGE_TAG so different variants never share a stamp (concept 3).
+.stamps/base-image-build-$(DBT)-$(BASE_IMAGE_TAG):
 	@echo "Building Base Image using $(DOCKER) version: $(shell $(DOCKER) --version)"
 	@echo "Supported Architectures: $(DB_ARCH)"
 	@echo "Base Image Name: $(BASE_IMAGE_FULL_NAME):$(BASE_IMAGE_TAG)"
@@ -142,7 +145,7 @@ base-image-build: multiarch-check .stamps/base-image-build-$(DBT)	## Build skill
 		--$(DB_ACTION) \
 		. \
 		|| exit 1; \
-		touch .stamps/base-image-build-$(DBT); \
+		touch .stamps/base-image-build-$(DBT)-$(BASE_IMAGE_TAG); \
 	elif [ "$(DOCKER)" = "podman" ]; then \
 		if [ "$(DBT)" = "registry" ]; then \
 			$(DOCKER) build --no-cache=true \
@@ -161,7 +164,7 @@ base-image-build: multiarch-check .stamps/base-image-build-$(DBT)	## Build skill
 			-t $(BASE_IMAGE_FULL_NAME):$(BASE_IMAGE_TAG) \
 			. || exit 1; \
 		fi; \
-		touch .stamps/base-image-build-$(DBT); \
+		touch .stamps/base-image-build-$(DBT)-$(BASE_IMAGE_TAG); \
     else \
 		echo "Unsupported Docker version: $(DOCKER)"; \
 		echo "Please use Docker or Podman"; \
@@ -179,13 +182,16 @@ base-image-build: multiarch-check .stamps/base-image-build-$(DBT)	## Build skill
 base-image-rm: docker-check ## Remove the local base image
 	@echo "Removing BASE image: $(BASE_IMAGE_FULL_NAME):$(BASE_IMAGE_TAG)"
 	$(DOCKER) rmi -f $(BASE_IMAGE_FULL_NAME):$(BASE_IMAGE_TAG) > /dev/null 2>&1 || true
-	rm -f .stamps/base-image-build*
+	rm -f .stamps/base-image-build-*-$(BASE_IMAGE_TAG)
 
-.PHONY: docker-build 
-docker-build: docker-check update-git-version .stamps/docker-build-$(DBT)	## Build docker image (DBT=registry to build & push multi-arch)
+.PHONY: docker-build
+docker-build: docker-check .stamps/docker-build-$(DBT)-$(BUILD_VERSION)	## Build docker image (DBT=registry to build & push multi-arch)
 
-# We actually build a new image only if the code changed by checking code-scan stamp
-.stamps/docker-build-$(DBT): .stamps/ssh-agent.env .stamps/code-scan
+# Rebuild only when the label-scoped stamp is missing (concept 3). The
+# prerequisite is the git-state manifest: its mtime updates precisely when
+# repository state changes (concepts 2 + 4), and it exists in every project
+# regardless of whether VERSION_LOCATION is defined.
+.stamps/docker-build-$(DBT)-$(BUILD_VERSION): .stamps/git-version-manifest .stamps/ssh-agent.env
 	@echo "Building for $(DB_ARCH) using $(DOCKER) version: $(shell $(DOCKER) --version)"
 	@echo "Building Docker image: $(FULL_IMAGE_NAME):$(IMAGE_TAG)"
 	@echo "Build version: $(BUILD_VERSION)"
@@ -208,8 +214,8 @@ docker-build: docker-check update-git-version .stamps/docker-build-$(DBT)	## Bui
 		-t $(FULL_IMAGE_NAME):latest \
 		--$(DB_ACTION) \
 		. || exit 1; \
-		touch .stamps/docker-build-$(DBT); \
-		touch .stamps/docker-get; \
+		touch .stamps/docker-build-$(DBT)-$(BUILD_VERSION); \
+		touch .stamps/docker-get-$(BUILD_VERSION); \
 	elif [ "$(DOCKER)" = "podman" ]; then \
 		if [ "$(DBT)" = "registry" ]; then \
 			$(DOCKER) build --no-cache=true \
@@ -245,8 +251,8 @@ docker-build: docker-check update-git-version .stamps/docker-build-$(DBT)	## Bui
 			-t $(FULL_IMAGE_NAME):latest \
 			. || exit 1; \
 		fi; \
-		touch .stamps/docker-build-$(DBT); \
-		touch .stamps/docker-get; \
+		touch .stamps/docker-build-$(DBT)-$(BUILD_VERSION); \
+		touch .stamps/docker-get-$(BUILD_VERSION); \
     else \
 		echo "Unsupported Docker version: $(DOCKER)"; \
 		echo "Please use Docker or Podman"; \
@@ -270,21 +276,23 @@ docker-pull: docker-check ## Pull the latest docker image from registry
 		echo "✓ Successfully pulled image: $(FULL_IMAGE_NAME):latest"; \
 		$(DOCKER) tag $(FULL_IMAGE_NAME):latest $(FULL_IMAGE_NAME):$(IMAGE_TAG); \
 		echo "✓ Tagged as: $(FULL_IMAGE_NAME):$(IMAGE_TAG)"; \
-		touch .stamps/docker-get; \
+		touch .stamps/docker-get-$(BUILD_VERSION); \
 	else \
 		echo "✗ Failed to pull image: $(FULL_IMAGE_NAME):latest"; \
 		exit 1; \
 	fi
 
+# The get-stamp encodes concept 3's invariant: "an image at the current label
+# is present locally". Either a local build or a successful pull satisfies it.
 .PHONY: docker-get
-docker-get: .stamps/docker-get
+docker-get: .stamps/docker-get-$(BUILD_VERSION)
 	@true
 
 ifdef SBD_DEV
-.stamps/docker-get: docker-build ## Get docker image (SBD_DEV set: build only)
+.stamps/docker-get-$(BUILD_VERSION): docker-build ## Get docker image (SBD_DEV set: build only)
 	@echo "SBD_DEV is set - using locally built image"
 else
-.stamps/docker-get: ## Get docker image (pull latest or build if pull fails)
+.stamps/docker-get-$(BUILD_VERSION): ## Get docker image (pull latest or build if pull fails)
 	@echo "Attempting to get Docker image: $(FULL_IMAGE_NAME):latest"
 	@if $(MAKE) docker-pull; then \
 		echo "✓ Using pulled image"; \
@@ -320,8 +328,8 @@ docker-rmi: docker-check docker-clean ## Remove the docker container, image, and
 	@echo "Removing Docker image: $(FULL_IMAGE_NAME):$(IMAGE_TAG)"
 	@$(DOCKER) rmi -f $(FULL_IMAGE_NAME):$(IMAGE_TAG) > /dev/null 2>&1 || true
 	@$(DOCKER) rmi -f $(FULL_IMAGE_NAME):latest > /dev/null 2>&1 || true
-	@rm -f .stamps/docker-build*
-	@rm -f .stamps/docker-get 
+	@rm -f .stamps/docker-build-*-$(BUILD_VERSION)
+	@rm -f .stamps/docker-get-$(BUILD_VERSION)
 
 .PHONY: docker-clean
 docker-clean: docker-check docker-stop ## Remove the docker container and temporary files, but keeping the image

--- a/skillberry-common/.mk/globals.mk
+++ b/skillberry-common/.mk/globals.mk
@@ -11,7 +11,7 @@ ARCH := $(shell uname -m)
 OS := $(shell uname -s)
 
 # Location of private SSH key for git+ssh dependencies, e.g., during docker build
-SSH_KEY ?= ~/.ssh/id_rsa 2>/dev/null
+SSH_KEY ?= $(HOME)/.ssh/id_rsa
 
 LLM_SVCS_ENV_VARS := RITS_API_KEY WATSONX_APIKEY WATSONX_PROJECT_ID WATSONX_URL
 
@@ -34,50 +34,18 @@ MAIN_SERVICE_PORT = $(firstword $(SERVICE_PORTS))
 		$(SB_COMMON_PATH)/scripts/mk_srv_env.sh "$(ACRONYM)" "$(SERVICE_PORTS)" "$(SERVICE_PORT_ROLES)" "$(SERVICE_HOST)" 2>/dev/null || true; \
 	fi
 
-# Set BUILD_VERSION variable
+# BUILD_VERSION: single label that identifies the current repository state.
 #
-# In SkillBerry every tag/release is created in a separate branch (to have dedicated toml with
-# proper @ to sdk). So we implement our logic to maintain git format for 'git describe --always --dirty'
-# - i.e. 0.5.3 or 0.5.3-5-gc9b7ddd or 0.5.3-5-gc9b7ddd-dirty
-
-_LATEST_RELEASE=$(shell git branch -r | grep 'branch-' | sed 's|.*/branch-||' | sort -V | tail -n 1 | head -n 1)
-
-#
-# _LATEST_RELEASE is the actual tag e.g. 0.5.3
-#
-ifeq ($(_LATEST_RELEASE),)
-	#
-	# Latest release does not exist
-	#
-
-	_CURRENT_COMMIT=$(shell git rev-parse --short=7 HEAD)
-	# sets with "dirty" if there are uncommitted changes
-	_DIRTY=$(shell git diff --quiet || echo "-dirty")
-	# e.g. gc9b7ddd, gc9b7ddd-dirty
-	BUILD_VERSION="g$(_CURRENT_COMMIT)$(_DIRTY)"
-else
-	# Find the common ancestor (branch point)
-	# TODO: confirm _BASE_COMMIT not needed and remove 
-	# _BASE_COMMIT=$(shell git merge-base origin/main origin/branch-$(_LATEST_RELEASE))
-
-	#
-	# Count commits in main after the branch point
-	# tag is git global - can be safely used
-	#
-	_COMMIT_COUNT=$(shell git rev-list --count $(_LATEST_RELEASE)..HEAD)
-
-	_CURRENT_COMMIT=$(shell git rev-parse --short=7 HEAD)
-
-	_DIRTY=$(shell git diff --quiet || echo "-dirty")
-
-	ifeq ($(_COMMIT_COUNT),0)
-		# e.g. 0.4
-		BUILD_VERSION="$(_LATEST_RELEASE)$(_DIRTY)"
-	else
-		# e.g. 0.4-70-gc9b7ddd
-		BUILD_VERSION="$(_LATEST_RELEASE)-$(_COMMIT_COUNT)-g$(_CURRENT_COMMIT)$(_DIRTY)"
-	endif
-endif
+# Computed by `scripts/git_state.py version`, which:
+#   - matches `git describe --always --dirty` conventions:
+#       clean at release commit:            <release>            (e.g. 0.5.3)
+#       N commits past latest release:      <release>-<N>-g<sha> (e.g. 0.5.3-5-gc9b7ddd)
+#       no release yet:                     g<sha>               (e.g. gc9b7ddd)
+#   - detects dirty state via `git status --porcelain` (staged + unstaged +
+#     untracked non-ignored) and appends `-dirty-<7hex>`, where the hex is a
+#     fingerprint of the actual dirty content, so different dirty states get
+#     different labels (concept 1 of docs/design/build_concepts.md).
+BUILD_VERSION := $(shell python $(SB_COMMON_PATH)/scripts/git_state.py version)
 
 # Platform-specific variables
 ifeq ($(OS),Windows_NT)

--- a/skillberry-common/scripts/docker-reconcile-stamp.sh
+++ b/skillberry-common/scripts/docker-reconcile-stamp.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# docker-reconcile-stamp.sh <docker-cmd> <full-image-name> <build-version> <dbt>
+#
+# Enforces concept 3 of docs/design/build_concepts.md: a Docker build/get stamp
+# is only valid if a Docker image with the current label tag actually exists.
+#
+# For DBT=local: if the get/build stamps for the current BUILD_VERSION exist
+# but the local image is gone (e.g., `docker rmi` was run), delete those
+# stamps so the next `make` invocation rebuilds.
+#
+# For DBT=registry: no reliable local check is possible without hitting the
+# registry; do nothing. Concept 3 accepts push presence as satisfying the
+# invariant for registry builds.
+#
+# Called at make parse time via $(shell ...); must be silent on the happy
+# path and produce no stdout.
+
+set -eu
+
+if [ "$#" -lt 4 ]; then
+    exit 0
+fi
+
+docker_cmd="$1"
+full_image_name="$2"
+build_version="$3"
+dbt="$4"
+
+# Only reconcile local builds; skip if BUILD_VERSION is empty or docker command
+# is missing.
+if [ "$dbt" != "local" ] || [ -z "$build_version" ]; then
+    exit 0
+fi
+
+if ! command -v "$docker_cmd" > /dev/null 2>&1; then
+    exit 0
+fi
+
+stamp_dir=".stamps"
+get_stamp="${stamp_dir}/docker-get-${build_version}"
+build_stamp="${stamp_dir}/docker-build-local-${build_version}"
+
+# Only bother running docker if there's a stamp to potentially invalidate.
+if [ ! -f "$get_stamp" ] && [ ! -f "$build_stamp" ]; then
+    exit 0
+fi
+
+if "$docker_cmd" image inspect "${full_image_name}:${build_version}" > /dev/null 2>&1; then
+    # Image present at the current label; stamps are valid.
+    exit 0
+fi
+
+# Image is gone. Invalidate the label-scoped stamps so Make rebuilds.
+rm -f -- "$get_stamp" "$build_stamp"
+exit 0

--- a/skillberry-common/scripts/git_state.py
+++ b/skillberry-common/scripts/git_state.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""Git-state management for the SkillBerry build system.
+
+Consolidates the small shell/awk scripts that previously handled the
+BUILD_VERSION label, the state manifest, and content-idempotent updates.
+See ``docs/design/build_concepts.md`` for the semantics — concepts 1, 2,
+and 4.
+
+Subcommands:
+  version   Print the BUILD_VERSION label to stdout.
+  manifest  Print the canonical state manifest to stdout.
+  update    Content-idempotent update of the state manifest at the given
+            path, with observability lines to stderr on real state changes.
+            If a VERSION_LOCATION path is given as the third argument, the
+            label is projected there using the same content-idempotence
+            rule (concept 2).
+
+Observability for ``update``:
+  * No state change             → no output.
+  * State changed               → single line: ``==> BUILD_VERSION updated to '<label>'``.
+  * State changed, VERBOSE mode → the above plus a per-file breakdown of
+    what changed (commit-delta ``~``, newly-dirty ``+``, no-longer-dirty
+    ``-``, still-dirty-with-different-content ``!``).
+
+VERBOSE mode is enabled by setting the ``VERBOSE_BUILD_VERSION`` environment
+variable (any value, including empty string, counts as set).
+
+All human-facing output goes to stderr, so any subcommand is safe to call
+from a Makefile's ``$(shell ...)``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# git helpers
+# ---------------------------------------------------------------------------
+
+def _git(*args: str) -> str:
+    """Run ``git <args>`` and return stdout as text; empty string on failure."""
+    try:
+        r = subprocess.run(["git", *args], capture_output=True, text=True)
+    except FileNotFoundError:
+        return ""
+    return r.stdout if r.returncode == 0 else ""
+
+
+def _git_bytes(*args: str) -> bytes:
+    """Run ``git <args>`` and return stdout as bytes; empty on failure."""
+    try:
+        r = subprocess.run(["git", *args], capture_output=True)
+    except FileNotFoundError:
+        return b""
+    return r.stdout if r.returncode == 0 else b""
+
+
+def _in_repo() -> bool:
+    r = subprocess.run(
+        ["git", "rev-parse", "--is-inside-work-tree"],
+        capture_output=True, text=True,
+    )
+    return r.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# BUILD_VERSION label (concept 1)
+# ---------------------------------------------------------------------------
+
+def compute_version() -> str:
+    """Return the BUILD_VERSION label for the current repository state.
+
+    Formats (matching ``git describe --always --dirty`` conventions):
+      * clean at release commit:       ``<release>``            (e.g. ``0.5.3``)
+      * N commits past latest release: ``<release>-<N>-g<sha>``
+      * no releases in the repo yet:   ``g<sha>``
+      * any dirty state adds:          ``-dirty-<7hex>``
+
+    The dirty fingerprint is a hash over ``git diff HEAD`` plus the sorted
+    list and contents of untracked non-ignored files, so different dirty
+    states produce different labels.
+    """
+    if not _in_repo():
+        return "unknown"
+
+    latest_release = _latest_release()
+    commit = _git("rev-parse", "--short=7", "HEAD").strip() or "0000000"
+
+    if not latest_release:
+        base = f"g{commit}"
+    else:
+        count_out = _git("rev-list", "--count", f"{latest_release}..HEAD").strip()
+        if count_out.isdigit():
+            count = int(count_out)
+            base = latest_release if count == 0 else f"{latest_release}-{count}-g{commit}"
+        else:
+            # Tag not resolvable locally — fall back to the no-release form
+            # rather than emitting a spurious label.
+            base = f"g{commit}"
+
+    if not _git("status", "--porcelain").strip():
+        return base
+    return f"{base}-dirty-{_dirty_fingerprint()}"
+
+
+def _latest_release() -> str:
+    """Return the highest ``branch-*`` release found on remote refs, or ``""``."""
+    releases: list[str] = []
+    for line in _git("branch", "-r").splitlines():
+        line = line.strip()
+        idx = line.find("branch-")
+        if idx >= 0:
+            releases.append(line[idx + len("branch-"):])
+    if not releases:
+        return ""
+    return sorted(releases, key=_version_key)[-1]
+
+
+def _version_key(v: str) -> tuple:
+    """Key for ``sort -V``-like ordering — numeric parts numerically, others lex."""
+    parts: list[tuple[int, object]] = []
+    for p in v.split("."):
+        if p.isdigit():
+            parts.append((0, int(p)))
+        else:
+            parts.append((1, p))
+    return tuple(parts)
+
+
+def _dirty_fingerprint() -> str:
+    """7-char SHA1-prefix fingerprint of the current dirty content.
+
+    Covers tracked diffs (staged + unstaged) plus untracked non-ignored file
+    contents, matching the state manifest's scope.
+    """
+    h = hashlib.sha1()
+    h.update(_git_bytes("diff", "HEAD"))
+    untracked = _git_bytes("ls-files", "--others", "--exclude-standard", "-z")
+    paths = [p for p in untracked.split(b"\0") if p]
+    for path in sorted(paths):
+        h.update(b"\n== ")
+        h.update(path)
+        h.update(b" ==\n")
+        try:
+            with open(path, "rb") as f:
+                for chunk in iter(lambda: f.read(65536), b""):
+                    h.update(chunk)
+        except OSError:
+            pass
+    return h.hexdigest()[:7]
+
+
+# ---------------------------------------------------------------------------
+# State manifest (concept 4 pivot)
+# ---------------------------------------------------------------------------
+#
+# Manifest format:
+#     HEAD: <sha>
+#     <status>\t<hash>\t<path>
+#     <status>\t<hash>\t<path>
+#     ...
+#
+#   <status> is git status --porcelain=v1's 2-char XY code.
+#   <hash>   is `git hash-object` of the current on-disk file, or
+#            '-' for a deletion, '<dir>' for an untracked directory,
+#            '<missing>' if the path resolves to nothing.
+#   <path>   is the working-tree path (renames use the destination path).
+#
+# Body lines are sorted so equivalent states produce byte-identical
+# manifests; different states produce different manifests, and two manifests
+# can be diffed to enumerate the files responsible for a change.
+
+def compute_manifest() -> str:
+    if not _in_repo():
+        return "HEAD: unknown\n"
+
+    head = _git("rev-parse", "HEAD").strip() or "unknown"
+    lines = [f"HEAD: {head}"]
+
+    raw = _git_bytes("status", "--porcelain=v1", "-z", "--untracked-files=all")
+    entries = raw.split(b"\0")
+    body: list[str] = []
+    i = 0
+    while i < len(entries):
+        entry = entries[i]
+        i += 1
+        if len(entry) < 3:
+            continue
+        status = entry[:2].decode("utf-8", errors="replace")
+        path = entry[3:].decode("utf-8", errors="replace")
+        # Rename/copy emits <new>\0<origin>; the destination reflects the
+        # current on-disk state, so we skip the origin slot.
+        if status[0] in ("R", "C"):
+            i += 1
+        if "D" in status:
+            fh = "-"
+        elif os.path.isfile(path):
+            fh = _git("hash-object", "--", path).strip() or "unknown"
+        elif os.path.isdir(path):
+            fh = "<dir>"
+        else:
+            fh = "<missing>"
+        body.append(f"{status}\t{fh}\t{path}")
+
+    body.sort()
+    return "\n".join(lines + body) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Update (manifest + optional VERSION_LOCATION) with observability
+# ---------------------------------------------------------------------------
+
+def cmd_update(version: str, manifest_path: str, version_location: str) -> int:
+    if not _in_repo():
+        print("Skipping git-state update: not inside a Git repository.", file=sys.stderr)
+        return 0
+
+    # Observability levels:
+    #   - no state change              → no output
+    #   - state changed, VERBOSE unset → single line naming the new label
+    #   - state changed, VERBOSE set   → single line + per-file breakdown
+    # VERBOSE is opt-in via the VERBOSE_BUILD_VERSION env var (any value,
+    # including empty string, counts as "set" per the concept doc).
+    verbose = "VERBOSE_BUILD_VERSION" in os.environ
+
+    new_manifest = compute_manifest()
+    mp = Path(manifest_path)
+    if mp.exists():
+        old_manifest = mp.read_text()
+        if old_manifest == new_manifest:
+            return 0  # No change → keep mtime stable so downstream isn't invalidated.
+        _print_observability(version, True, old_manifest, new_manifest, verbose)
+    else:
+        _print_observability(version, False, "", new_manifest, verbose)
+
+    mp.parent.mkdir(parents=True, exist_ok=True)
+    mp.write_text(new_manifest)
+
+    if version_location:
+        _write_version_file(version, version_location, verbose)
+    return 0
+
+
+def _print_observability(
+    version: str, prior_exists: bool, old: str, new: str, verbose: bool,
+) -> None:
+    verb = "updated" if prior_exists else "set"
+    print(f"==> BUILD_VERSION {verb} to '{version}'", file=sys.stderr)
+
+    if not verbose:
+        return
+
+    if not prior_exists:
+        print("    No prior BUILD_VERSION detected.", file=sys.stderr)
+        return
+
+    print(
+        "    The following changes have been detected since previous BUILD_VERSION:",
+        file=sys.stderr,
+    )
+
+    old_head, old_body = _split_manifest(old)
+    new_head, new_body = _split_manifest(new)
+
+    if old_head != new_head:
+        print(f"    HEAD: {old_head} -> {new_head}", file=sys.stderr)
+        if old_head != "unknown" and new_head != "unknown":
+            r = subprocess.run(
+                ["git", "rev-parse", "--verify", "--quiet", old_head],
+                capture_output=True,
+            )
+            if r.returncode == 0:
+                names = _git("diff", "--name-only", old_head, new_head).splitlines()
+                for p in sorted(set(names)):
+                    print(f"    ~ {p}", file=sys.stderr)
+
+    old_map = _body_map(old_body)
+    new_map = _body_map(new_body)
+    for path in sorted(set(old_map) | set(new_map)):
+        o, n = old_map.get(path), new_map.get(path)
+        if o is not None and n is not None:
+            if o != n:
+                print(f"    ! {path}", file=sys.stderr)
+        elif n is not None:
+            print(f"    + {path}", file=sys.stderr)
+        else:
+            print(f"    - {path}", file=sys.stderr)
+
+
+def _split_manifest(text: str) -> tuple[str, list[str]]:
+    if not text:
+        return "unknown", []
+    lines = text.splitlines()
+    if lines and lines[0].startswith("HEAD: "):
+        return lines[0][len("HEAD: "):], lines[1:]
+    return "unknown", lines
+
+
+def _body_map(body: list[str]) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for line in body:
+        parts = line.split("\t")
+        if len(parts) >= 3:
+            status, fh, path = parts[0], parts[1], "\t".join(parts[2:])
+            out[path] = f"{status}\t{fh}"
+    return out
+
+
+def _write_version_file(version: str, path: str, verbose: bool) -> None:
+    """Content-idempotent write of ``__git_version__ = "<version>"``.
+
+    Progress is printed only when ``verbose`` is set — the terse observability
+    mode keeps output to the single BUILD_VERSION line.
+    """
+    new = f'__git_version__ = "{version}"\n'
+    p = Path(path)
+    if p.exists() and p.read_text() == new:
+        return
+    p.parent.mkdir(parents=True, exist_ok=True)
+    verb = "Updated" if p.exists() else "Created"
+    p.write_text(new)
+    if verbose:
+        print(f"{verb} git version in {path} to {version}", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Git-state management for the SkillBerry build system.")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("version", help="Print BUILD_VERSION")
+    sub.add_parser("manifest", help="Print state manifest")
+    up = sub.add_parser("update", help="Content-idempotent manifest update")
+    up.add_argument("version")
+    up.add_argument("manifest_path")
+    up.add_argument("version_location", nargs="?", default="")
+    args = ap.parse_args()
+
+    if args.cmd == "version":
+        print(compute_version())
+    elif args.cmd == "manifest":
+        sys.stdout.write(compute_manifest())
+    elif args.cmd == "update":
+        return cmd_update(args.version, args.manifest_path, args.version_location)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skillberry-common/scripts/install-requirements.sh
+++ b/skillberry-common/scripts/install-requirements.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# install-requirements.sh <odeps> <skipopt>
+#
+# Runs `uv pip install -e .[<odeps>]` and maintains the install stamps per
+# concept 6 of docs/design/build_concepts.md:
+#
+#   * `uv pip install -e .[X]` replaces the previous set of extras, so any
+#     older non-empty-ODEPS stamp becomes a lie.
+#   * `uv pip install -e .[X]` also installs the base package, so the
+#     empty-ODEPS stamp is always valid after any successful install.
+#   * If SKIPOPT=1 and the extras install fails, fall back to installing just
+#     the base package; in that case only the empty-ODEPS stamp is valid.
+#   * On outright failure, touch nothing so retry is forced.
+
+set -eu
+
+odeps="${1:-}"
+skipopt="${2:-}"
+
+stamp_dir=".stamps"
+mkdir -p -- "$stamp_dir"
+
+# Marks the current environment as base-only (empty-ODEPS). Called on any
+# successful install path.
+touch_base_only() {
+    rm -f -- "$stamp_dir"/install-requirements-*
+    touch -- "$stamp_dir/install-requirements-"
+}
+
+# Marks the current environment as base + <odeps>.
+touch_with_extras() {
+    rm -f -- "$stamp_dir"/install-requirements-*
+    touch -- "$stamp_dir/install-requirements-"
+    touch -- "$stamp_dir/install-requirements-$odeps"
+}
+
+if [ -z "$odeps" ]; then
+    uv pip install -e . || exit 1
+    touch_base_only
+    exit 0
+fi
+
+if uv pip install -e ".[$odeps]"; then
+    touch_with_extras
+    exit 0
+fi
+
+if [ "$skipopt" = "1" ]; then
+    echo "Optional dependency install failed for ODEPS=$odeps; retrying without optional dependencies because SKIPOPT=1" >&2
+    uv pip install -e . || exit 1
+    touch_base_only
+    exit 0
+fi
+
+exit 1


### PR DESCRIPTION
## Summary

Rework the Makefile build system around a small, well-defined "state →
label → build" pipeline documented in a new design doc, and fold in a
couple of unrelated fixes surfaced while touching the same files.

This PR is **independent** of #305 (openshift-compliance) — it branches off
current `main`.

## Commits (in order)

1. **`docs: Add build system design concepts`** — new
   `docs/design/build_concepts.md`. This is the reference the follow-up
   commit is aligned against. Worth reading first.

2. **`build: Align makefiles and scripts with build_concepts.md`** —
   implementation. Highlights:
   - **BUILD_VERSION** is now a pure function of full working-tree state
     (staged + unstaged + untracked non-ignored), with a content
     fingerprint so distinct dirty states get distinct labels. Previous
     `git diff --quiet || echo -dirty` missed staged/untracked changes
     and collapsed all dirty states into one label.
   - **`.stamps/git-version-manifest`** replaces the old
     `.stamps/code-scan` `find`-based mechanism as the change-detection
     pivot. Content-idempotent — its mtime is stable when repository
     state hasn't changed, so downstream stamps don't refire spuriously.
     Deleted the old hand-maintained `CODE_SUBTREES` / `CODE_FILTER`
     scan.
   - **`VERSION_LOCATION` is optional.** The manifest is the pivot;
     `VERSION_LOCATION` is written as a content-idempotent projection
     when set. Projects without one still work.
   - **Docker stamps carry `-$(BUILD_VERSION)` suffix** so different
     labels never share a stamp. A parse-time reconciler invalidates
     stamps if the local image at the current label was removed (e.g.
     `docker rmi`), restoring the "image present at label" invariant.
   - **Install stamp bookkeeping** enforced by a small script: on
     success, wipe prior stamps, always mark the base install, only mark
     the ODEPS-specific stamp when extras actually installed. On failure,
     touch nothing.
   - **Observability:** on state changes, the manifest recipe prints one
     line naming the new label. Set `VERBOSE_BUILD_VERSION` to also see
     a per-file breakdown (`~` commit-delta / `+` newly-dirty / `-`
     no-longer-dirty / `!` content-changed).
   - **Consolidation:** the small shell helpers created during the
     rework are folded into a single Python module
     `skillberry-common/scripts/git_state.py` with `version` /
     `manifest` / `update` subcommands. Standard library only.
   - **Ancillary fixes:** removed a stray file-scope `@echo` in
     `docker.mk`; fixed `SSH_KEY ?= ~/.ssh/id_rsa 2>/dev/null` which
     embedded a shell redirect in the variable value; replaced an
     invalid `@echo`/`@exit` fallback inside `ifeq` with `$(error …)`.

3. **`fix(release): push release branch alongside tag; wipe stale docker
   stamps on REDO`** — two bugs surfaced by the new stricter build
   pipeline:
   - The recipe pushed only the tag; the release branch stayed local. On
     the release branch the docker-build sub-make's `_LATEST_RELEASE`
     detection (which reads remote branches) picked up the previous
     release, so the image was tagged with a previous-release-based
     label instead of `$(RELEASE_VERSION)`. Fix: push both refs.
   - `REDO=1` cleaned up the docker image tag but left
     `.stamps/docker-build-registry-*` and `.stamps/docker-get-*`
     stamps. A retry could see a stale stamp and skip the rebuild. Fix:
     sweep them.

4. **`docs: Fix lint target help text`** — `.mk/dev.mk`, one-line typo
   fix: `## List the tools-service` → `## Lint the codebase`.

## Test plan

- [ ] `make print_build_version` — label reflects current tree, changes
      with untracked files added/modified/removed, unaffected by
      gitignored files.
- [ ] `make install-requirements` — manifest is created, observability
      prints once; subsequent runs are silent.
- [ ] `make install-requirements ODEPS=test` then `ODEPS=dev` — the
      previous `-test` stamp is wiped; the empty and `-dev` stamps are
      present.
- [ ] `make docker-build` — image tagged with the current label; second
      invocation is a no-op; deleting the image and re-running triggers
      a rebuild.
- [ ] `make help`, `make print_build_version` — no manifest activity
      (they don't depend on the pivot).
- [ ] `VERBOSE_BUILD_VERSION=1 make ...` — per-file breakdown appears on
      state changes.
- [ ] A staging release using `RELEASE_VERSION=<X> make release` — the
      resulting docker image is tagged with `<X>`, not with the
      previous-release form.