### PR TITLE
Docker build customizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,6 +170,9 @@ cython_debug/
 # stamp files for make
 .stamps/
 
+# staging area for EXTRA_COPY_FILES content (see .mk/docker.mk)
+.extra-copy/
+
 .idea/
 .vscode/
 

--- a/.mk/dev.mk
+++ b/.mk/dev.mk
@@ -17,6 +17,12 @@ UI_SOURCES  := $(shell find $(UI_DIR)/src -type f 2>/dev/null) \
                $(UI_DIR)/vite.config.ts \
                $(UI_DIR)/tsconfig.json \
                $(UI_DIR)/tsconfig.node.json
+# ACL mode is baked into the bundle at build time by vite.config.ts, so the
+# access-control config is a build input too — mirror its path resolution
+# here. Wildcard-guarded: an absent config is a supported setup (both
+# vite.config.ts and load_config() fall back to mode=disabled), so it must
+# not become a hard "No rule to make target" failure.
+ACL_CONFIG  := $(wildcard $(or $(SBS_ACCESS_CONTROL_CONFIG),access_control_config.yaml))
 
 .PHONY: ui-build ui-clean ui-dev ui-typecheck
 ui-build: $(UI_STAMP) ## Build the UI static bundle (idempotent, stamp-based)
@@ -24,7 +30,7 @@ ui-build: $(UI_STAMP) ## Build the UI static bundle (idempotent, stamp-based)
 # Bundle only — no `tsc` prefix. Vite/esbuild strips types without checking,
 # which matches how `npx vite` (dev) and `vitest` have always run. Type
 # checking is a separate concern; use `make ui-typecheck` as a CI gate.
-$(UI_STAMP): $(UI_SOURCES) $(UI_NM_STAMP)
+$(UI_STAMP): $(UI_SOURCES) $(UI_NM_STAMP) $(ACL_CONFIG)
 	@echo "===> Building UI static bundle"
 	@cd $(UI_DIR) && npx vite build
 	@mkdir -p .stamps && touch $@

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,14 +31,40 @@ ARG PLUGIN_EXTRAS=
 # makefile's `BUILD_VERSION ?=` respect the passed-in value instead of trying
 # to re-derive it from git inside the container (.git is not shipped into the
 # build context; see .dockerignore).
+# APP_HOME mirrors the runtime stage: the base image only sets WORKDIR, so
+# without this the $APP_HOME references below would expand to empty.
 ENV BUILD_VERSION=$BUILD_VERSION \
-    DEPLOY_ONLY=TRUE
+    DEPLOY_ONLY=TRUE \
+    APP_HOME=/app
 
 # Python, NodeJS and venv are already set in the base image
 # WORKDIR is already set in the base image to /app
 
 # Copy the application
 COPY . .
+
+# Unpack the extra host content staged into the build context by
+# scripts/stage-extra-copy.sh (make docker-build EXTRA_COPY_FILES=<src>:<dst>,...).
+# The staged tree mirrors the absolute target paths, so one recursive copy into
+# "/" lands every entry at its target.
+#
+# This must precede every build step that reads the copied tree: the staged
+# files are real build inputs. `make ui-build` below bakes the ACL mode from
+# access_control_config.yaml into the UI bundle, so unpacking only in the
+# runtime stage shipped a bundle built against the repo's config while the
+# image ran with the operator's — a UI stuck in the wrong auth mode.
+#
+# This is the only unpack. Afterwards the staging tree is moved out of
+# $APP_HOME (so it does not ride along with the $APP_HOME copy in the runtime
+# stage) and its $APP_HOME mirror is pruned, leaving exactly the targets that
+# $APP_HOME cannot carry across the stage boundary. That split matters: paths
+# under $APP_HOME travel in whatever state the build left them, instead of
+# being reverted to the staged original by a second application. mkdir -p
+# keeps the recipe unconditional when EXTRA_COPY_FILES is unset.
+RUN mkdir -p "$APP_HOME/.extra-copy" \
+    && cp -a "$APP_HOME/.extra-copy/." / \
+    && mv "$APP_HOME/.extra-copy" /extra-copy \
+    && rm -rf "/extra-copy$APP_HOME"
 
 # Uncomment this to test your SSH cconnection to github.ibm.com
 # RUN --mount=type=ssh \
@@ -115,23 +141,27 @@ ENV MALLOC_ARENA_MAX=2
 # This includes the application code and the .venv with all installed dependencies
 COPY --from=builder $APP_HOME $APP_HOME
 
-# Unpack the extra host content staged into the build context by
-# scripts/stage-extra-copy.sh (make docker-build EXTRA_COPY_FILES=<src>:<dst>,...).
-# The staged tree mirrors the absolute target paths, so one recursive copy into
-# "/" lands every entry at its target; the staging folder is then dropped.
-# Absent when EXTRA_COPY_FILES is empty. Done before the ownership fixups below
-# so extra content under $APP_HOME gets the same treatment.
+# Place the staged extra host content whose targets sit outside $APP_HOME
+# (e.g. /etc/ssl/extra). The builder applied the whole staged tree and pruned
+# its $APP_HOME mirror, so this is exactly the complement of what the copy
+# above carries — no path is written twice, and nothing reverts a $APP_HOME
+# target to its staged original. Copies the tree's contents, so the staging
+# folder itself never appears in the image, and resolves to a no-op when
+# EXTRA_COPY_FILES is unset.
 #
+# Note these entries cross as staged, not as the build left them: a build step
+# that rewrote a target outside $APP_HOME would lose that edit. Placing them
+# by path would require the target list at parse time, which a Dockerfile
+# cannot have; nothing in this build writes outside $APP_HOME.
+COPY --from=builder /extra-copy/ /
+
 # OpenShift compliance:
 #  - safe.directory '*' lets git operate under any UID (the image is immutable,
 #    so the CVE-2022-24765 threat model does not apply).
 #  - gid 0 + `chmod g=u` on runtime-writable paths lets the arbitrary UID that
 #    OpenShift assigns (always in gid 0) read/write everything the app needs.
 #    Harmless on plain Docker/k8s: group perms equal user perms.
-RUN if [ -d "$APP_HOME/.extra-copy" ]; then \
-        cp -a "$APP_HOME/.extra-copy/." / && rm -rf "$APP_HOME/.extra-copy"; \
-    fi \
-    && git config --system --add safe.directory '*' \
+RUN git config --system --add safe.directory '*' \
     && mkdir -p "$UV_CACHE_DIR" "$PIP_CACHE_DIR" "$APP_DATA_DIR" \
     && chgrp -R 0 "$APP_HOME" "$XDG_CACHE_HOME" "$APP_DATA_DIR" \
     && chmod -R g=u "$APP_HOME" "$XDG_CACHE_HOME" "$APP_DATA_DIR"

--- a/Dockerfile
+++ b/Dockerfile
@@ -115,13 +115,23 @@ ENV MALLOC_ARENA_MAX=2
 # This includes the application code and the .venv with all installed dependencies
 COPY --from=builder $APP_HOME $APP_HOME
 
+# Unpack the extra host content staged into the build context by
+# scripts/stage-extra-copy.sh (make docker-build EXTRA_COPY_FILES=<src>:<dst>,...).
+# The staged tree mirrors the absolute target paths, so one recursive copy into
+# "/" lands every entry at its target; the staging folder is then dropped.
+# Absent when EXTRA_COPY_FILES is empty. Done before the ownership fixups below
+# so extra content under $APP_HOME gets the same treatment.
+#
 # OpenShift compliance:
 #  - safe.directory '*' lets git operate under any UID (the image is immutable,
 #    so the CVE-2022-24765 threat model does not apply).
 #  - gid 0 + `chmod g=u` on runtime-writable paths lets the arbitrary UID that
 #    OpenShift assigns (always in gid 0) read/write everything the app needs.
 #    Harmless on plain Docker/k8s: group perms equal user perms.
-RUN git config --system --add safe.directory '*' \
+RUN if [ -d "$APP_HOME/.extra-copy" ]; then \
+        cp -a "$APP_HOME/.extra-copy/." / && rm -rf "$APP_HOME/.extra-copy"; \
+    fi \
+    && git config --system --add safe.directory '*' \
     && mkdir -p "$UV_CACHE_DIR" "$PIP_CACHE_DIR" "$APP_DATA_DIR" \
     && chgrp -R 0 "$APP_HOME" "$XDG_CACHE_HOME" "$APP_DATA_DIR" \
     && chmod -R g=u "$APP_HOME" "$XDG_CACHE_HOME" "$APP_DATA_DIR"

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,15 @@ COPY . .
 
 # Unpack the extra host content staged into the build context by
 # scripts/stage-extra-copy.sh (make docker-build EXTRA_COPY_FILES=<src>:<dst>,...).
-# The staged tree mirrors the absolute target paths, so one recursive copy into
-# "/" lands every entry at its target.
+# The staged tree mirrors the absolute target paths, so one recursive unpack
+# into "/" lands every entry at its target.
+#
+# tar --no-overwrite-dir, and not "cp -a", because the mirror necessarily
+# carries a folder for every component of every target path, and cp applies
+# the mirror folder's mode to the pre-existing folder it lands on -- resetting
+# /tmp from 1777 to 755, for one. tar leaves existing folders' metadata alone
+# and still applies the archived mode to the content itself and to folders it
+# creates.
 #
 # This must precede every build step that reads the copied tree: the staged
 # files are real build inputs. `make ui-build` below bakes the ACL mode from
@@ -62,7 +69,7 @@ COPY . .
 # being reverted to the staged original by a second application. mkdir -p
 # keeps the recipe unconditional when EXTRA_COPY_FILES is unset.
 RUN mkdir -p "$APP_HOME/.extra-copy" \
-    && cp -a "$APP_HOME/.extra-copy/." / \
+    && tar -cf - -C "$APP_HOME/.extra-copy" . | tar -xf - --no-overwrite-dir -C / \
     && mv "$APP_HOME/.extra-copy" /extra-copy \
     && rm -rf "/extra-copy$APP_HOME"
 
@@ -145,15 +152,23 @@ COPY --from=builder $APP_HOME $APP_HOME
 # (e.g. /etc/ssl/extra). The builder applied the whole staged tree and pruned
 # its $APP_HOME mirror, so this is exactly the complement of what the copy
 # above carries — no path is written twice, and nothing reverts a $APP_HOME
-# target to its staged original. Copies the tree's contents, so the staging
-# folder itself never appears in the image, and resolves to a no-op when
-# EXTRA_COPY_FILES is unset.
+# target to its staged original. Resolves to an empty tree, and the unpack
+# below to a no-op, when EXTRA_COPY_FILES is unset.
 #
 # Note these entries cross as staged, not as the build left them: a build step
 # that rewrote a target outside $APP_HOME would lose that edit. Placing them
 # by path would require the target list at parse time, which a Dockerfile
 # cannot have; nothing in this build writes outside $APP_HOME.
-COPY --from=builder /extra-copy/ /
+#
+# The tree lands in a scratch folder instead of on "/" directly, because COPY
+# applies the mirror folders' modes to the pre-existing folders they land on
+# just as "cp -a" would -- resetting /tmp from 1777 to 755, which locks the
+# service out of its own log and pid files. The RUN below unpacks it with
+# tar --no-overwrite-dir, which leaves existing folders' metadata alone, and
+# drops the scratch folder. Unpacking there also puts the content in place
+# ahead of the ownership fixups, so targets under $APP_DATA_DIR (or any other
+# path fixed up below) get the same treatment.
+COPY --from=builder /extra-copy /extra-copy
 
 # OpenShift compliance:
 #  - safe.directory '*' lets git operate under any UID (the image is immutable,
@@ -161,7 +176,9 @@ COPY --from=builder /extra-copy/ /
 #  - gid 0 + `chmod g=u` on runtime-writable paths lets the arbitrary UID that
 #    OpenShift assigns (always in gid 0) read/write everything the app needs.
 #    Harmless on plain Docker/k8s: group perms equal user perms.
-RUN git config --system --add safe.directory '*' \
+RUN tar -cf - -C /extra-copy . | tar -xf - --no-overwrite-dir -C / \
+    && rm -rf /extra-copy \
+    && git config --system --add safe.directory '*' \
     && mkdir -p "$UV_CACHE_DIR" "$PIP_CACHE_DIR" "$APP_DATA_DIR" \
     && chgrp -R 0 "$APP_HOME" "$XDG_CACHE_HOME" "$APP_DATA_DIR" \
     && chmod -R g=u "$APP_HOME" "$XDG_CACHE_HOME" "$APP_DATA_DIR"

--- a/skillberry-common/.mk/docker.mk
+++ b/skillberry-common/.mk/docker.mk
@@ -9,6 +9,8 @@
 #           B. This operation may not create a local image (docker buildx limitation).
 # 5. To bake host content that lives outside the build context into the image, set EXTRA_COPY_FILES (see below),
 #    e.g., make docker-build EXTRA_COPY_FILES=./certs:/etc/ssl/extra,../site.yaml:/app/site.yaml
+# 6. To give the image a single tag of your choosing instead of the usual versioned + "latest" pair,
+#    set CUSTOM_TAG (see below), e.g., make docker-build CUSTOM_TAG=my-experiment
 
 # Supported container architectures
 SUPPORTED_ARCHS := linux/amd64 linux/arm64
@@ -46,11 +48,39 @@ CNTR_NAME = $(SERVICE_NAME)
 # service can publish build variants side by side (e.g. IMAGE_TAG_SUFFIX=-full
 # yields :<version>-full and :latest-full). Empty by default. Every target that
 # refers to IMAGE_TAG/LATEST_TAG -- build, run, pull, rmi -- follows the suffix,
-# so `make docker-run IMAGE_TAG_SUFFIX=-full` runs the variant.
+# so `make docker-run IMAGE_TAG_SUFFIX=-full` runs the variant. Ignored when
+# CUSTOM_TAG is set.
 IMAGE_TAG_SUFFIX ?=
+
+# Custom tag: when set, the image carries exactly this one tag -- neither the
+# version tag nor "latest" is applied, and IMAGE_TAG_SUFFIX is ignored. It is
+# also the tag that run/pull/rmi operate on, so `make docker-run
+# CUSTOM_TAG=<tag>` runs the custom-tagged image. Empty by default.
+CUSTOM_TAG ?=
+
+FULL_IMAGE_NAME = $(REPOSITORY_NAME)/$(IMAGE_NAME)
+
+ifeq ($(strip $(CUSTOM_TAG)),)
 IMAGE_TAG = $(BUILD_VERSION)$(IMAGE_TAG_SUFFIX)
 LATEST_TAG = latest$(IMAGE_TAG_SUFFIX)
-FULL_IMAGE_NAME = $(REPOSITORY_NAME)/$(IMAGE_NAME)
+# All tags the build applies to the image; IMAGE_TAG is the primary one.
+IMAGE_TAGS = $(IMAGE_TAG) $(LATEST_TAG)
+# Tag that docker-pull fetches from the registry.
+PULL_TAG = $(LATEST_TAG)
+# Suffix keeping the build stamps of one tagging scheme apart from another's.
+TAG_STAMP_SFX = $(IMAGE_TAG_SUFFIX)
+else
+IMAGE_TAG = $(CUSTOM_TAG)
+LATEST_TAG = $(CUSTOM_TAG)
+IMAGE_TAGS = $(IMAGE_TAG)
+PULL_TAG = $(CUSTOM_TAG)
+TAG_STAMP_SFX = -$(CUSTOM_TAG)
+endif
+
+# Tags other than the primary one, applied on top of it after the build.
+SECONDARY_IMAGE_TAGS = $(filter-out $(IMAGE_TAG),$(IMAGE_TAGS))
+# The tags as build flags, e.g. "-t <image>:1.2.3 -t <image>:latest"
+IMAGE_TAG_FLAGS = $(foreach tag,$(IMAGE_TAGS),-t $(FULL_IMAGE_NAME):$(tag))
 
 # Extra flags forwarded verbatim to the image build, typically service-specific
 # --build-arg values. Empty by default.
@@ -209,12 +239,12 @@ base-image-rm: docker-check ## Remove the local base image
 	rm -f .stamps/base-image-build*
 
 .PHONY: docker-build 
-docker-build: docker-check update-git-version .stamps/docker-build-$(DBT)$(IMAGE_TAG_SUFFIX)	## Build docker image (DBT=registry for multi-arch & push, EXTRA_COPY_FILES for extra files & folders)
+docker-build: docker-check update-git-version .stamps/docker-build-$(DBT)$(TAG_STAMP_SFX)	## Build docker image (DBT=registry for multi-arch & push, EXTRA_COPY_FILES for extra files & folders, CUSTOM_TAG for a single custom tag)
 
 # We actually build a new image only if the code changed by checking code-scan stamp
-.stamps/docker-build-$(DBT)$(IMAGE_TAG_SUFFIX): .stamps/ssh-agent.env .stamps/code-scan
+.stamps/docker-build-$(DBT)$(TAG_STAMP_SFX): .stamps/ssh-agent.env .stamps/code-scan
 	@echo "Building for $(DB_ARCH) using $(DOCKER) version: $(shell $(DOCKER) --version)"
-	@echo "Building Docker image: $(FULL_IMAGE_NAME):$(IMAGE_TAG)"
+	@echo "Building Docker image with tag(s): $(foreach tag,$(IMAGE_TAGS),$(FULL_IMAGE_NAME):$(tag))"
 	@echo "Build version: $(BUILD_VERSION)"
 	@echo "Build date: $(BUILD_DATE)"
 	@echo "Building using the Docker file: $(DOCKER_FILE)"
@@ -233,12 +263,11 @@ docker-build: docker-check update-git-version .stamps/docker-build-$(DBT)$(IMAGE
 		--build-arg SERVICE_ENTRY_MODULE="$(SERVICE_ENTRY_MODULE)" \
 		$(EXTRA_BUILD_ARGS) \
 		--ssh default=$$SSH_AUTH_SOCK \
-		-t $(FULL_IMAGE_NAME):$(IMAGE_TAG) \
-		-t $(FULL_IMAGE_NAME):$(LATEST_TAG) \
+		$(IMAGE_TAG_FLAGS) \
 		--$(DB_ACTION) \
 		. || exit 1; \
-		touch .stamps/docker-build-$(DBT)$(IMAGE_TAG_SUFFIX); \
-		touch .stamps/docker-get$(IMAGE_TAG_SUFFIX); \
+		touch .stamps/docker-build-$(DBT)$(TAG_STAMP_SFX); \
+		touch .stamps/docker-get$(TAG_STAMP_SFX); \
 	elif [ "$(DOCKER)" = "podman" ]; then \
 		if [ "$(DBT)" = "registry" ]; then \
 			$(DOCKER) build --no-cache=true \
@@ -256,8 +285,10 @@ docker-build: docker-check update-git-version .stamps/docker-build-$(DBT)$(IMAGE
 			--manifest $(FULL_IMAGE_NAME):$(IMAGE_TAG) \
 			. && \
 			$(DOCKER) manifest push $(FULL_IMAGE_NAME):$(IMAGE_TAG) && \
-			$(DOCKER) tag $(FULL_IMAGE_NAME):$(IMAGE_TAG) $(FULL_IMAGE_NAME):$(LATEST_TAG) && \
-			$(DOCKER) manifest push $(FULL_IMAGE_NAME):$(LATEST_TAG) \
+			for tag in $(SECONDARY_IMAGE_TAGS); do \
+				$(DOCKER) tag $(FULL_IMAGE_NAME):$(IMAGE_TAG) $(FULL_IMAGE_NAME):$$tag && \
+				$(DOCKER) manifest push $(FULL_IMAGE_NAME):$$tag || exit 1; \
+			done \
 			|| exit 1; \
 		else \
 			$(DOCKER) build --no-cache=true \
@@ -272,12 +303,11 @@ docker-build: docker-check update-git-version .stamps/docker-build-$(DBT)$(IMAGE
 			--build-arg SERVICE_ENTRY_MODULE="$(SERVICE_ENTRY_MODULE)" \
 			$(EXTRA_BUILD_ARGS) \
 			--ssh default=$$SSH_AUTH_SOCK \
-			-t $(FULL_IMAGE_NAME):$(IMAGE_TAG) \
-			-t $(FULL_IMAGE_NAME):$(LATEST_TAG) \
+			$(IMAGE_TAG_FLAGS) \
 			. || exit 1; \
 		fi; \
-		touch .stamps/docker-build-$(DBT)$(IMAGE_TAG_SUFFIX); \
-		touch .stamps/docker-get$(IMAGE_TAG_SUFFIX); \
+		touch .stamps/docker-build-$(DBT)$(TAG_STAMP_SFX); \
+		touch .stamps/docker-get$(TAG_STAMP_SFX); \
     else \
 		echo "Unsupported Docker version: $(DOCKER)"; \
 		echo "Please use Docker or Podman"; \
@@ -296,27 +326,29 @@ docker-build: docker-check update-git-version .stamps/docker-build-$(DBT)$(IMAGE
 
 .PHONY: docker-pull
 docker-pull: docker-check ## Pull the latest docker image from registry
-	@echo "Attempting to pull Docker image: $(FULL_IMAGE_NAME):$(LATEST_TAG)"
-	@if $(DOCKER) pull $(FULL_IMAGE_NAME):$(LATEST_TAG); then \
-		echo "✓ Successfully pulled image: $(FULL_IMAGE_NAME):$(LATEST_TAG)"; \
-		$(DOCKER) tag $(FULL_IMAGE_NAME):$(LATEST_TAG) $(FULL_IMAGE_NAME):$(IMAGE_TAG); \
-		echo "✓ Tagged as: $(FULL_IMAGE_NAME):$(IMAGE_TAG)"; \
-		touch .stamps/docker-get$(IMAGE_TAG_SUFFIX); \
+	@echo "Attempting to pull Docker image: $(FULL_IMAGE_NAME):$(PULL_TAG)"
+	@if $(DOCKER) pull $(FULL_IMAGE_NAME):$(PULL_TAG); then \
+		echo "✓ Successfully pulled image: $(FULL_IMAGE_NAME):$(PULL_TAG)"; \
+		if [ "$(PULL_TAG)" != "$(IMAGE_TAG)" ]; then \
+			$(DOCKER) tag $(FULL_IMAGE_NAME):$(PULL_TAG) $(FULL_IMAGE_NAME):$(IMAGE_TAG); \
+			echo "✓ Tagged as: $(FULL_IMAGE_NAME):$(IMAGE_TAG)"; \
+		fi; \
+		touch .stamps/docker-get$(TAG_STAMP_SFX); \
 	else \
-		echo "✗ Failed to pull image: $(FULL_IMAGE_NAME):$(LATEST_TAG)"; \
+		echo "✗ Failed to pull image: $(FULL_IMAGE_NAME):$(PULL_TAG)"; \
 		exit 1; \
 	fi
 
 .PHONY: docker-get
-docker-get: .stamps/docker-get$(IMAGE_TAG_SUFFIX)
+docker-get: .stamps/docker-get$(TAG_STAMP_SFX)
 	@true
 
 ifdef SBD_DEV
-.stamps/docker-get$(IMAGE_TAG_SUFFIX): docker-build ## Get docker image (SBD_DEV set: build only)
+.stamps/docker-get$(TAG_STAMP_SFX): docker-build ## Get docker image (SBD_DEV set: build only)
 	@echo "SBD_DEV is set - using locally built image"
 else
-.stamps/docker-get$(IMAGE_TAG_SUFFIX): ## Get docker image (pull latest or build if pull fails)
-	@echo "Attempting to get Docker image: $(FULL_IMAGE_NAME):$(LATEST_TAG)"
+.stamps/docker-get$(TAG_STAMP_SFX): ## Get docker image (pull latest or build if pull fails)
+	@echo "Attempting to get Docker image: $(FULL_IMAGE_NAME):$(PULL_TAG)"
 	@if $(MAKE) docker-pull; then \
 		echo "✓ Using pulled image"; \
 	else \
@@ -348,9 +380,10 @@ endif
 
 .PHONY: docker-rmi
 docker-rmi: docker-check docker-clean ## Remove the docker container, image, and temporary files
-	@echo "Removing Docker image: $(FULL_IMAGE_NAME):$(IMAGE_TAG)"
-	@$(DOCKER) rmi -f $(FULL_IMAGE_NAME):$(IMAGE_TAG) > /dev/null 2>&1 || true
-	@$(DOCKER) rmi -f $(FULL_IMAGE_NAME):$(LATEST_TAG) > /dev/null 2>&1 || true
+	@echo "Removing Docker image tag(s): $(foreach tag,$(IMAGE_TAGS),$(FULL_IMAGE_NAME):$(tag))"
+	@for tag in $(IMAGE_TAGS); do \
+		$(DOCKER) rmi -f $(FULL_IMAGE_NAME):$$tag > /dev/null 2>&1 || true; \
+	done
 	@rm -f .stamps/docker-build*
 	@rm -f .stamps/docker-get*
 

--- a/skillberry-common/.mk/docker.mk
+++ b/skillberry-common/.mk/docker.mk
@@ -7,6 +7,8 @@
 # 4. If you want to push a new image or new base image to GHCR (multi-platform build & push), do: DBT=registry make docker-build, or DBT=registry make base-image-build. 
 #    Notes: A. This operation requires multi-platform docker support (you will get an error message with detailed instructions if it's not available). 
 #           B. This operation may not create a local image (docker buildx limitation).
+# 5. To bake host content that lives outside the build context into the image, set EXTRA_COPY_FILES (see below),
+#    e.g., make docker-build EXTRA_COPY_FILES=./certs:/etc/ssl/extra,../site.yaml:/app/site.yaml
 
 # Supported container architectures
 SUPPORTED_ARCHS := linux/amd64 linux/arm64
@@ -53,6 +55,20 @@ FULL_IMAGE_NAME = $(REPOSITORY_NAME)/$(IMAGE_NAME)
 # Extra flags forwarded verbatim to the image build, typically service-specific
 # --build-arg values. Empty by default.
 EXTRA_BUILD_ARGS ?=
+
+# Extra host content to bake into the image: a comma-separated list of
+# <source>:<target> pairs. A directory source contributes its tree contents to
+# the target folder; a file source is copied to the target path (or into it,
+# when the target ends with "/"). Targets are absolute container paths. Empty
+# by default.
+#
+# A container build only reads from its build context, so the sources are first
+# staged into the context by scripts/stage-extra-copy.sh and then unpacked to
+# their targets by the Dockerfile. Staging also grants the group the owner's
+# access to the copied content (the image runs with gid 0), so it stays
+# readable at runtime under an arbitrary OpenShift UID -- and writable exactly
+# when it was writable to its owner on the host.
+EXTRA_COPY_FILES ?=
 
 DOCKER_FILE ?= Dockerfile
 
@@ -193,7 +209,7 @@ base-image-rm: docker-check ## Remove the local base image
 	rm -f .stamps/base-image-build*
 
 .PHONY: docker-build 
-docker-build: docker-check update-git-version .stamps/docker-build-$(DBT)$(IMAGE_TAG_SUFFIX)	## Build docker image (DBT=registry to build & push multi-arch)
+docker-build: docker-check update-git-version .stamps/docker-build-$(DBT)$(IMAGE_TAG_SUFFIX)	## Build docker image (DBT=registry for multi-arch & push, EXTRA_COPY_FILES for extra files & folders)
 
 # We actually build a new image only if the code changed by checking code-scan stamp
 .stamps/docker-build-$(DBT)$(IMAGE_TAG_SUFFIX): .stamps/ssh-agent.env .stamps/code-scan
@@ -202,6 +218,7 @@ docker-build: docker-check update-git-version .stamps/docker-build-$(DBT)$(IMAGE
 	@echo "Build version: $(BUILD_VERSION)"
 	@echo "Build date: $(BUILD_DATE)"
 	@echo "Building using the Docker file: $(DOCKER_FILE)"
+	@$(SB_COMMON_PATH)/scripts/stage-extra-copy.sh "$(EXTRA_COPY_FILES)"
 	@. .stamps/ssh-agent.env; \
 	if [ "$(DOCKER)" = "docker" ]; then \
 		DOCKER_BUILDKIT=1 $(DOCKER) buildx build \

--- a/skillberry-common/default/.gitignore.default
+++ b/skillberry-common/default/.gitignore.default
@@ -157,6 +157,9 @@ cython_debug/
 # stamp files for make
 .stamps/
 
+# staging area for EXTRA_COPY_FILES content (see .mk/docker.mk)
+.extra-copy/
+
 .idea/
 .vscode/
 

--- a/skillberry-common/default/Dockerfile.default
+++ b/skillberry-common/default/Dockerfile.default
@@ -59,6 +59,15 @@ ENV BUILD_VERSION=$BUILD_VERSION \
 # This includes the application code and the .venv with all installed dependencies
 COPY --from=builder /app /app
 
+# Unpack the extra host content staged into the build context by
+# scripts/stage-extra-copy.sh (make docker-build EXTRA_COPY_FILES=<src>:<dst>,...).
+# The staged tree mirrors the absolute target paths, so one recursive copy into
+# "/" lands every entry at its target; the staging folder is then dropped.
+# Absent when EXTRA_COPY_FILES is empty.
+RUN if [ -d /app/.extra-copy ]; then \
+        cp -a /app/.extra-copy/. / && rm -rf /app/.extra-copy; \
+    fi
+
 # Expose all service ports
 EXPOSE $SERVICE_PORTS
 

--- a/skillberry-common/default/Dockerfile.default
+++ b/skillberry-common/default/Dockerfile.default
@@ -61,11 +61,19 @@ COPY --from=builder /app /app
 
 # Unpack the extra host content staged into the build context by
 # scripts/stage-extra-copy.sh (make docker-build EXTRA_COPY_FILES=<src>:<dst>,...).
-# The staged tree mirrors the absolute target paths, so one recursive copy into
-# "/" lands every entry at its target; the staging folder is then dropped.
+# The staged tree mirrors the absolute target paths, so one recursive unpack
+# into "/" lands every entry at its target; the staging folder is then dropped.
 # Absent when EXTRA_COPY_FILES is empty.
+#
+# tar --no-overwrite-dir, and not "cp -a", because the mirror necessarily
+# carries a folder for every component of every target path, and cp applies the
+# mirror folder's mode to the pre-existing folder it lands on -- resetting /tmp
+# from 1777 to 755, for one. tar leaves existing folders' metadata alone and
+# still applies the archived mode to the content itself and to folders it
+# creates.
 RUN if [ -d /app/.extra-copy ]; then \
-        cp -a /app/.extra-copy/. / && rm -rf /app/.extra-copy; \
+        tar -cf - -C /app/.extra-copy . | tar -xf - --no-overwrite-dir -C / \
+        && rm -rf /app/.extra-copy; \
     fi
 
 # Expose all service ports

--- a/skillberry-common/scripts/stage-extra-copy.sh
+++ b/skillberry-common/scripts/stage-extra-copy.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Stage extra host content into the container build context.
+#
+# Usage: stage-extra-copy.sh "<src>:<dst>[,<src>:<dst>...]"
+# Example: stage-extra-copy.sh "./certs:/etc/ssl/extra,../my.yaml:/app/conf.yaml"
+#
+# A container build can only read from its build context, so host content that
+# lives outside the project root cannot be COPY'd directly. This script copies
+# each source into the staging folder below, laid out as a mirror of its
+# absolute target path. The Dockerfile then unpacks that mirror with a single
+# recursive copy into "/", which lands every entry at its target.
+#
+# Per pair: a directory source contributes its tree *contents* to <dst>; a file
+# source is copied to <dst> (or into it, if <dst> ends with "/").
+# <dst> must be an absolute path inside the container.
+#
+# The staging folder is rewritten from scratch on every call, so it always
+# reflects the current spec (an empty spec removes it altogether).
+
+set -e
+
+# Normalize the staged content for the container runtime:
+#
+#  - umask 022 keeps the mirror's intermediate folders traversable (755)
+#    whatever the caller's umask is. This matters because the Dockerfile
+#    unpacks the mirror with "cp -a", which applies the mirror folder's mode to
+#    an already-existing target folder as well - so a private mirror folder
+#    would lock down, e.g., /etc for every non-root UID.
+#
+#  - "chmod g=u" per staged item (below) gives the group the owner's access.
+#    The build COPY forces ownership of everything in the context to root and
+#    gid 0, and both the image's USER and the arbitrary UID that OpenShift
+#    assigns run with gid 0 - so this is what makes the content readable at
+#    runtime, and writable exactly when it was writable to its owner on the
+#    host. It is the same policy the Dockerfile applies to $APP_HOME, extended
+#    to targets outside it.
+umask 022
+
+# Keep in sync with the staging folder unpacked by the Dockerfile.
+STAGE_DIR=".extra-copy"
+
+SPEC="$1"
+
+rm -rf "$STAGE_DIR"
+[ -n "$SPEC" ] || exit 0
+
+IFS=',' read -ra PAIRS <<< "$SPEC"
+for pair in "${PAIRS[@]}"; do
+    src="${pair%%:*}"
+    dst="${pair#*:}"
+    if [ "$src" = "$pair" ] || [ -z "$src" ] || [ -z "$dst" ]; then
+        echo "EXTRA_COPY_FILES: expected <source>:<target>, got '$pair'" >&2
+        exit 1
+    fi
+    case "$dst" in
+        /*) ;;
+        *)  echo "EXTRA_COPY_FILES: target '$dst' must be an absolute container path" >&2
+            exit 1 ;;
+    esac
+
+    staged="$STAGE_DIR/${dst#/}"
+    if [ -d "$src" ]; then
+        mkdir -p "$staged"
+        cp -aL "$src/." "$staged/"
+        chmod -R g=u "$staged"
+    elif [ -f "$src" ]; then
+        case "$dst" in
+            */) mkdir -p "$staged" && cp -aL "$src" "$staged/" \
+                    && chmod g=u "$staged/$(basename "$src")" ;;
+            *)  mkdir -p "$(dirname "$staged")" && cp -aL "$src" "$staged" \
+                    && chmod g=u "$staged" ;;
+        esac
+    else
+        echo "EXTRA_COPY_FILES: source '$src' does not exist" >&2
+        exit 1
+    fi
+    echo "Staged for copy into the image: $src -> $dst"
+done

--- a/skillberry-common/scripts/stage-extra-copy.sh
+++ b/skillberry-common/scripts/stage-extra-copy.sh
@@ -22,10 +22,11 @@ set -e
 # Normalize the staged content for the container runtime:
 #
 #  - umask 022 keeps the mirror's intermediate folders traversable (755)
-#    whatever the caller's umask is. This matters because the Dockerfile
-#    unpacks the mirror with "cp -a", which applies the mirror folder's mode to
-#    an already-existing target folder as well - so a private mirror folder
-#    would lock down, e.g., /etc for every non-root UID.
+#    whatever the caller's umask is. The unpack applies an archived folder's
+#    mode to any folder it has to create along a target path, so under a
+#    private umask the app could not reach its own content. (Folders that
+#    already exist in the image keep their own metadata - the Dockerfile
+#    unpacks with tar --no-overwrite-dir for exactly that reason.)
 #
 #  - "chmod g=u" per staged item (below) gives the group the owner's access.
 #    The build COPY forces ownership of everything in the context to root and

--- a/src/skillberry_store/contrib/examples/skills-sh-importer/README.md
+++ b/src/skillberry_store/contrib/examples/skills-sh-importer/README.md
@@ -7,19 +7,69 @@ Automated tool to download and import skills from [skills.sh](https://skills.sh)
 This tool implements a 6-phase process to:
 1. Extract all repository metadata from skills.sh (sorted by popularity)
 2. Clone repositories iteratively until finding N skill subfolders with SKILL.md
-3. Discover skills in /skills/ folders
+3. Discover skill folders (`SKILL.md`) — see [Skill Detection](#skill-detection)
 4. Import skills via Anthropic API (handles transformation automatically) **with automatic benchmarking**
 5. Validate imports
 6. Generate comprehensive reports with benchmark statistics
 
 **Key Features:**
-- A "skill" is defined as a subfolder in `/skills/` directory containing a `SKILL.md` file
+- A "skill" is a folder containing a `SKILL.md` file; **`--flex-import`** finds such folders at any depth (see [Skill Detection](#skill-detection))
 - **Clone mode** clones repositories from skills.sh until it finds N such skills (up to ~9,700 repos)
 - **Automatic benchmarking** of all import operations (timing, size, file counts, throughput)
 - **Clone-only mode** for downloading skills without importing (Phases 1-2)
 - **Import-only mode** for importing already-downloaded skills (Phases 3-6) — useful for repeated benchmarking
 - **`--overwrite`** re-clones repositories that already exist on disk (default: reuse them)
 - Failed or empty clones are cleaned up automatically — no partial or useless data is kept on disk
+
+## Skill Detection
+
+A skill is a folder that directly contains a `SKILL.md` file — that folder, with
+all of its contents, is imported as one skill in Anthropic format. Two modes
+control **which** folders qualify:
+
+### Default mode (backward-compatible)
+
+Only the direct children of a `skills/` directory are recognised:
+
+```
+<skills-dir>/
+└── <repo>/               <- one "repository" per group
+    └── skills/
+        ├── <skill>/SKILL.md
+        └── <skill>/SKILL.md
+```
+
+This is the layout produced by cloning (Phases 1-2), so clone and full modes
+behave exactly as before. A directory tree that keeps its skills anywhere else
+(directly under `<skills-dir>/<set>/`, in `.claude/skills/`, nested deeper) yields
+`Found 0 repositories with skills` in this mode.
+
+### `--flex-import` (flexible detection)
+
+Every directory containing a `SKILL.md` file anywhere below `--skills-dir` is a
+skill, regardless of nesting depth or folder names:
+
+```bash
+python3 download_and_import_skills.py --import-only --flex-import --skills-dir ./skill-sets
+```
+
+- **Outermost match wins** — once a folder is recognised as a skill, its subtree
+  is not searched further. Sub-skills bundled inside a skill folder therefore stay
+  part of their parent skill instead of being imported twice.
+- `.git` directories are never searched; symlinks are followed with loop protection.
+- Skills are grouped by their top-level directory under `--skills-dir` so the rest
+  of the pipeline still reports per-"repository" counts. For the default layout the
+  group names come out identical to default mode.
+- The flag applies to clone mode too: a cloned repo counts (and keeps) skills found
+  anywhere in its tree, instead of only those under `<repo>/skills/`.
+
+Effect on the bundled sample trees:
+
+| `--skills-dir` | default mode | `--flex-import` |
+|----------------|--------------|-----------------|
+| `./skills` (cloned repos) | 60 repos, 2,936 skills | 60 repos, 7,044 skills |
+| `./skill-sets` (`<set>/skills/<skill>/`) | 4 sets, 800 skills | 4 sets, 800 skills |
+| `./skill-sets/advertising` (a single set) | 0 repos — aborts | 1 group, 200 skills |
 
 ## How skills.sh exposes its catalog
 
@@ -107,6 +157,7 @@ python3 download_and_import_skills.py \
 | `--output-dir` | `.` (current directory) | Directory for output files. A timestamped subdirectory is created per run |
 | `--clone-only` | false | Run only Phases 1-2 (extract + clone); skip discovery and import |
 | `--import-only` | false | Skip Phases 1-2; use existing skills from `--skills-dir` |
+| `--flex-import` | false | Treat any folder containing `SKILL.md` as a skill, at any depth (see [Skill Detection](#skill-detection)) |
 | `--overwrite` | false | Remove and re-clone repo directories that already exist on disk |
 
 `--clone-only` and `--import-only` are mutually exclusive.
@@ -156,6 +207,7 @@ Use `--import-only` to skip cloning and use existing skills already on disk. Ide
 - **Repeated benchmarking**: Test import performance multiple times on the same skill set
 - **Performance optimization**: Benchmark after making changes to the import process
 - **Selective importing**: Import a subset of previously downloaded skills
+- **Importing hand-curated skill sets**: Combine with `--flex-import` for trees that do not follow the cloned-repo layout
 
 ### Example Usage
 
@@ -168,6 +220,9 @@ python3 download_and_import_skills.py --import-only --max-skills 10 --skills-dir
 
 # Benchmark with a different SBS instance
 python3 download_and_import_skills.py --import-only --sbs-url http://localhost:9000 --output-dir ./benchmarks
+
+# Import any tree containing SKILL.md folders, whatever its layout
+python3 download_and_import_skills.py --import-only --flex-import --skills-dir ./skill-sets
 ```
 
 ### Output in Import-Only Mode
@@ -218,18 +273,21 @@ Reads `sitemap-owners.xml` to obtain the full catalog of ~9,700 `owner/repo` pai
 ### Phase 2: Clone Repositories Until N Skills Found
 
 - Clones repositories from the list produced by Phase 1
-- After each clone, counts subfolders in `/skills/` that contain `SKILL.md`
+- After each clone, counts the skill folders it contains (`<repo>/skills/<skill>/` by
+  default, anywhere in the tree with `--flex-import`)
 - Accumulates the count until reaching `--max-skills`
-- Repos without a `/skills/` folder (or with no valid skills) are cleaned up immediately
+- Repos with no valid skills are cleaned up immediately
 - Already-cloned repositories are reused by default; use `--overwrite` to force re-clone
 
 **Output:**
 - `clone-results.json` — `cloned_repos`, `skipped_repos`, `failed_repos`, `summary`
 - `<skills-dir>/` — Cloned repositories (valid ones only)
 
-### Phase 3: Discover Skills in /skills/ Folders
+### Phase 3: Discover Skill Folders
 
-Scans the skill directories on disk (produced by Phase 2), finds every subfolder containing `SKILL.md`, and loads content and metadata.
+Scans the skill directories on disk (produced by Phase 2, or pre-existing under
+`--import-only`), finds every folder containing `SKILL.md` per the active
+[detection mode](#skill-detection), and loads content and metadata.
 
 **Output:** `discovered-skills.json`
 

--- a/src/skillberry_store/contrib/examples/skills-sh-importer/download_and_import_skills.py
+++ b/src/skillberry_store/contrib/examples/skills-sh-importer/download_and_import_skills.py
@@ -5,14 +5,21 @@ Download and Import Skills from skills.sh
 This script implements a 6-phase process to:
 1. Extract repository metadata from skills.sh
 2. Clone repositories until finding N skills
-3. Discover skills in /skills/ folders
+3. Discover skills (see --flex-import for the two detection modes)
 4. Import via Anthropic API
 5. Validate imports
 6. Generate final report
 
+Skill detection has two modes:
+    default        a skill is a direct child of a /skills/ directory that
+                   contains SKILL.md, i.e. <skills-dir>/<repo>/skills/<skill>/
+    --flex-import  a skill is ANY directory containing SKILL.md, at any depth
+                   under --skills-dir (outermost match wins)
+
 Usage:
     python download_and_import_skills.py --max-skills 10
     python download_and_import_skills.py --max-skills 10 --overwrite
+    python download_and_import_skills.py --import-only --flex-import --skills-dir ./skill-sets
 """
 
 import argparse
@@ -36,10 +43,19 @@ logger = logging.getLogger(__name__)
 
 class SkillsImporter:
     """Main class for importing skills from skills.sh"""
-    
+
+    # Marker file that identifies a skill folder (Anthropic skill format)
+    SKILL_FILE = 'SKILL.md'
+
+    # Directory names never descended into while searching for skill folders
+    SKIP_DIR_NAMES = {'.git'}
+
     def __init__(self, args):
         self.args = args
         self.script_dir = Path(__file__).parent
+
+        # Flexible skill detection (see find_skill_folders)
+        self.flex_import = getattr(args, 'flex_import', False)
         
         # Determine skills directory (where repos are cloned)
         if args.skills_dir:
@@ -106,6 +122,11 @@ class SkillsImporter:
         
         logger.info(f"Initialized SkillsImporter")
         logger.info(f"Skills directory: {self.repos_dir}")
+        logger.info(
+            "Skill detection: "
+            + ("flexible (any folder containing SKILL.md)" if self.flex_import
+               else "default (<repo>/skills/<skill>/SKILL.md)")
+        )
         logger.info(f"Output directory: {self.output_dir}")
         logger.info(f"Max skills: {self.max_skills if self.max_skills is not None else 'unlimited'}")
         logger.info(f"SBS URL: {args.sbs_url}")
@@ -226,26 +247,88 @@ class SkillsImporter:
     
     # ========== PHASE 2: Clone Repositories ==========
     
+    def find_skill_folders(self, root: Path) -> List[Path]:
+        """
+        Recursively locate every skill folder under root.
+
+        A skill folder is a directory that directly contains a SKILL.md file;
+        that directory, with all of its contents, is the skill in Anthropic
+        format.
+
+        Two detection modes, selected by --flex-import:
+
+        default (backward-compatible)
+            Only the direct children of ``root/skills/`` are considered, i.e.
+            the classic ``<root>/skills/<skill>/SKILL.md`` layout.
+
+        --flex-import
+            Layout-agnostic: every directory containing SKILL.md anywhere below
+            ``root`` is a skill, so ``<root>/<set>/skills/<skill>/``,
+            ``<root>/<skill>/``, ``.claude/skills/<skill>/`` and any other
+            nesting depth all work.  The outermost match wins - once a
+            directory is recognised as a skill its subtree is not searched
+            further, so sub-skills bundled inside a skill folder remain part of
+            their parent skill instead of being imported separately.
+
+        Args:
+            root: Directory to search
+
+        Returns:
+            List of skill folder paths, in deterministic (sorted) order
+        """
+        if not self.flex_import:
+            # Default mode: direct children of root/skills/ only
+            skills_dir = root / 'skills'
+            if not skills_dir.is_dir():
+                return []
+            return [
+                subfolder for subfolder in sorted(skills_dir.iterdir())
+                if subfolder.is_dir() and (subfolder / self.SKILL_FILE).is_file()
+            ]
+
+        found: List[Path] = []
+        visited = set()
+
+        def walk(directory: Path) -> None:
+            # Guard against symlink loops / repeated visits
+            try:
+                real = directory.resolve()
+            except OSError:
+                return
+            if real in visited:
+                return
+            visited.add(real)
+
+            if (directory / self.SKILL_FILE).is_file():
+                found.append(directory)
+                return  # outermost match wins - do not descend into a skill
+
+            try:
+                children = sorted(directory.iterdir())
+            except OSError as e:
+                logger.debug(f"  Cannot read {directory}: {e}")
+                return
+
+            for child in children:
+                if child.is_dir() and child.name not in self.SKIP_DIR_NAMES:
+                    walk(child)
+
+        if root.is_dir():
+            walk(root)
+
+        return found
+
     def count_skills_in_repo(self, repo_path: Path) -> int:
         """
-        Count skill subfolders with SKILL.md in /skills/ directory
+        Count skill folders in a repo (see find_skill_folders for the modes)
         
         Args:
             repo_path: Path to cloned repository
             
         Returns:
-            Number of valid skill subfolders found
+            Number of valid skill folders found
         """
-        skills_dir = repo_path / 'skills'
-        if not skills_dir.exists() or not skills_dir.is_dir():
-            return 0
-        
-        count = 0
-        for subfolder in skills_dir.iterdir():
-            if subfolder.is_dir() and (subfolder / 'SKILL.md').exists():
-                count += 1
-        
-        return count
+        return len(self.find_skill_folders(repo_path))
     
     def clone_repositories(self, metadata: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """
@@ -345,11 +428,12 @@ class SkillsImporter:
 
                     logger.info(f"  ✓ Successfully cloned to {repo_path}")
 
-                # Count skills in /skills/ directory
-                skill_count = self.count_skills_in_repo(repo_path)
+                # Locate skill folders (any directory containing SKILL.md)
+                skill_folders = self.find_skill_folders(repo_path)
+                skill_count = len(skill_folders)
 
                 if skill_count == 0:
-                    logger.info(f"  ⊘ No /skills/ folder or no SKILL.md files found")
+                    logger.info(f"  ⊘ No SKILL.md files found")
                     # Remove only directories we cloned in this run (not pre-existing ones)
                     if not pre_existed:
                         shutil.rmtree(repo_path, ignore_errors=True)
@@ -364,7 +448,7 @@ class SkillsImporter:
 
                 # Found skills!
                 total_skills_found += skill_count
-                logger.info(f"  ✓ Found {skill_count} skill(s) in /skills/ folder")
+                logger.info(f"  ✓ Found {skill_count} skill(s)")
                 logger.info(f"  Progress: {total_skills_found}/{self.max_skills} skills found")
 
                 cloned_repos.append({
@@ -372,6 +456,7 @@ class SkillsImporter:
                     'repo_name': repo_name,
                     'repo_path': str(repo_path),
                     'skills_count': skill_count,
+                    'skill_folders': [str(f) for f in skill_folders],
                     'already_existed': pre_existed,
                 })
 
@@ -445,7 +530,15 @@ class SkillsImporter:
             return []
         
         cloned_repos = []
-        
+
+        if self.flex_import:
+            cloned_repos = self._scan_existing_repos_flex()
+            logger.info(f"\n{'='*60}")
+            logger.info(f"Found {len(cloned_repos)} repositories with skills")
+            logger.info(f"Total skills available: {sum(r['skills_count'] for r in cloned_repos)}")
+            logger.info(f"{'='*60}")
+            return cloned_repos
+
         # Scan for directories that look like cloned repos
         for repo_dir in self.repos_dir.iterdir():
             if not repo_dir.is_dir():
@@ -480,12 +573,60 @@ class SkillsImporter:
         logger.info(f"{'='*60}")
         
         return cloned_repos
-    
+
+    def _scan_existing_repos_flex(self) -> List[Dict[str, Any]]:
+        """
+        Flexible variant of scan_existing_repos (--flex-import).
+
+        Locates every skill folder anywhere under the skills directory, then
+        groups the results by their top-level directory so the remaining phases
+        still see a list of "repositories".  For the classic
+        <skills-dir>/<repo>/skills/<skill>/ layout this reproduces the same repo
+        names as the default mode; for other layouts it groups by whatever the
+        first level happens to be (e.g. one group per skill-set).
+
+        Returns:
+            List of repository info dictionaries
+        """
+        groups: Dict[str, List[Path]] = {}
+
+        for folder in self.find_skill_folders(self.repos_dir):
+            parts = folder.relative_to(self.repos_dir).parts
+            if len(parts) >= 2 and parts[0] != 'skills':
+                # <skills-dir>/<group>/.../<skill>
+                group_path = self.repos_dir / parts[0]
+            elif len(parts) >= 2:
+                # <skills-dir>/skills/<skill> - the skills dir is the group
+                group_path = self.repos_dir
+            elif len(parts) == 1:
+                # Skill sits directly under the skills dir
+                group_path = self.repos_dir
+            else:
+                # The skills dir is itself a single skill folder
+                group_path = self.repos_dir.parent
+            groups.setdefault(str(group_path), []).append(folder)
+
+        cloned_repos = []
+        for group_path, folders in groups.items():
+            group_name = Path(group_path).name
+            logger.info(f"  Found: {group_name} with {len(folders)} skill(s)")
+            cloned_repos.append({
+                'source': 'unknown',  # We don't know the original source
+                'repo_name': group_name,
+                'repo_path': group_path,
+                'skills_count': len(folders),
+                'skill_folders': [str(f) for f in folders],
+                'already_existed': True,
+            })
+
+        return cloned_repos
+
     def discover_skills(self, cloned_repos: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """
-        Phase 3: Discover skills in /skills/ subfolders with SKILL.md
+        Phase 3: Discover the skill folders found for each repository
         
-        A skill is a subfolder in /skills/ directory containing SKILL.md file
+        A skill is a folder containing a SKILL.md file; which folders qualify
+        depends on the detection mode (see find_skill_folders / --flex-import)
         
         Args:
             cloned_repos: List of cloned repository info
@@ -494,7 +635,7 @@ class SkillsImporter:
             List of discovered skills with their SKILL.md content
         """
         logger.info("\n" + "=" * 60)
-        logger.info("PHASE 3: Discovering skills in /skills/ folders")
+        logger.info("PHASE 3: Discovering skill folders (SKILL.md)")
         logger.info("=" * 60)
         
         discovered = []
@@ -508,19 +649,20 @@ class SkillsImporter:
             logger.info(f"\nScanning {repo_name}...")
             logger.info(f"  Expected skills: {repo['skills_count']}")
             
-            # Look for /skills/ directory
-            skills_dir = repo_path / 'skills'
-            if not skills_dir.exists() or not skills_dir.is_dir():
-                logger.warning(f"  ✗ No /skills/ directory found (unexpected!)")
+            # Reuse the skill folders located earlier, or search the repo now
+            if repo.get('skill_folders') is not None:
+                skill_folders = [Path(f) for f in repo['skill_folders']]
+            else:
+                skill_folders = self.find_skill_folders(repo_path)
+            
+            if not skill_folders:
+                logger.warning(f"  ✗ No skill folder with SKILL.md found (unexpected!)")
                 continue
             
-            # Find all subfolders with SKILL.md
+            # Read each skill folder
             skills_found = 0
-            for subfolder in skills_dir.iterdir():
-                if not subfolder.is_dir():
-                    continue
-                
-                skill_md = subfolder / 'SKILL.md'
+            for subfolder in skill_folders:
+                skill_md = subfolder / self.SKILL_FILE
                 if not skill_md.exists():
                     logger.debug(f"  - Skipping {subfolder.name} (no SKILL.md)")
                     continue
@@ -1133,6 +1275,18 @@ def parse_arguments():
         '--import-only',
         action='store_true',
         help='Skip phases 1-2, use existing downloaded skills from skills-dir and start from phase 3. If --max-skills specified, import up to that limit; otherwise import all discovered skills.'
+    )
+
+    parser.add_argument(
+        '--flex-import',
+        action='store_true',
+        help=(
+            'Flexible skill detection: treat every directory containing a SKILL.md '
+            'file as a skill, at any depth under --skills-dir (outermost match wins, '
+            'so sub-skills stay part of their parent skill). '
+            'Without this flag only the default layout '
+            '<skills-dir>/<repo>/skills/<skill>/SKILL.md is recognised.'
+        )
     )
 
     parser.add_argument(


### PR DESCRIPTION
## Summary

This is an aggregated PR of several small changes I need to do to enable custom containers for the demo stuff. However, it's generally useful. See below:

1. **`EXTRA_COPY_FILES`** — Allow importing additional folders into the created container beyond repo stuff (e.g., `skillberry-store` data from `/tmo/skillberry-store` for demo containers 
2. **CUSTOM_TAG** - Allow building locally and pushing (multi-arch) out-of-band custom tags that do not modify the regular `latest` tags of CI/CD and so are not consumed by regular development efforts such as developing with rosso
3. More flexible CLI skill import utility that does not rely on a fixed structure from skills.sh and instead detects `SKILL.md` (needed for the business skill-sets)
4. Small related bug fixes in the build system (stale UI builds)

## What changed

- **`EXTRA_COPY_FILES`** — a comma-separated list of `<source>:<target>` pairs.
  A container build only reads from its build context and a Dockerfile cannot
  loop over a list, so the work splits at a path-mirror contract:
  `stage-extra-copy.sh` copies each source into `.extra-copy/` laid out as a
  mirror of its absolute target path, and the image unpacks that mirror into
  `/` — no manifest or per-pair logic inside the Dockerfile. Staged content is
  applied in the **builder** stage, right after `COPY . .`, so it is a build
  *input*: the UI bundle compiles against the operator's ACL config rather
  than the repo default. Content is unpacked with `tar --no-overwrite-dir`, so
  a target under an existing folder (`/tmp`, `/etc`) cannot reset that
  folder's mode. OpenShift-compliant: extra content lands ahead of the
  existing gid-0 fixups and access is preserved, never over-granted.

- **`CUSTOM_TAG`** — build the image with exactly one tag of your choosing
  instead of the default `<version>` + `latest` pair. Tagging is now a list
  (`IMAGE_TAGS`) that the docker, podman, local and registry paths all derive
  from, with its own build stamp so a custom-tag build neither skips nor
  clobbers the regular one.

- **UI bundle vs. ACL config** *(bug fix)* — `vite.config.ts` inlines the
  access-control `mode:` into the bundle at build time, but the config was not
  a prerequisite of the UI stamp. Editing the mode left a stale bundle in
  place, so `make run` could serve a `standalone` login screen against a
  backend running with access control disabled. The config is now a
  wildcard-guarded prerequisite.

- **`skills-sh-importer --flex-import`** — skill discovery only recognised
  `<skills-dir>/<repo>/skills/<skill>/`, so any other layout reported "Found 0
  repositories with skills". The new flag treats any folder containing
  `SKILL.md` as a skill at any depth, outermost match winning. Default
  behaviour is unchanged.

## Test plan

- [ ] `make docker-build EXTRA_COPY_FILES=<acl>:/app/access_control_config.yaml,/tmp/skillberry-store:/tmp/skillberry-store`
      — config and data land, `/tmp` is still `drwxrwxrwt`, and as an
      arbitrary UID with gid 0 the service writes its log and pid file and
      serves `/health`
- [ ] The UI bundle reflects the staged ACL config (login flow works on a
      `standalone` config supplied via `EXTRA_COPY_FILES`)
- [ ] `make docker-build CUSTOM_TAG=my-experiment` — one tag only; `make
      docker-run` / `docker-pull` / `docker-rmi` follow it
- [ ] Editing `access_control_config.yaml` then `make run` rebuilds the bundle
- [ ] `download_and_import_skills.py` with and without `--flex-import`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
