### PR TITLE
Build fixes for SAST and DAST

### DIFF
--- a/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/engine/__init__.py
+++ b/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/engine/__init__.py
@@ -22,7 +22,8 @@ from .fuzz import (
 )
 from .observe import EVENT_SINK_ENV, SHIM_SOURCE, findings_from_output, parse_events
 from .runner import run_dast
-from .twin import BenignMcpTwin, host_address_for_container
+from .tool_source import StoreApiToolSource
+from .twin import BenignMcpTwin
 
 __all__ = [
     "DastReport",
@@ -40,7 +41,7 @@ __all__ = [
     "findings_from_output",
     "run_dast",
     "BenignMcpTwin",
-    "host_address_for_container",
+    "StoreApiToolSource",
     "progress",
     "scope",
 ]

--- a/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/engine/tool_source.py
+++ b/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/engine/tool_source.py
@@ -1,0 +1,51 @@
+"""StoreAPI-backed tool source for the benign vMCP twin.
+
+Implements the store's ``ToolSource`` protocol using nothing but the sanctioned
+plugin API, so the twin resolves manifests and executes tools **through
+StoreAPI** rather than reaching into store internals.
+
+Execution delegates to ``StoreAPI.execute_tool``, i.e. the store's own
+execution path — which is what a *faithful* twin wants: the skill's tools run
+exactly as they would in production, dependency closure and all, rather than
+through a bundle this plugin assembled itself.
+
+One deliberate difference from the in-process path: the store re-resolves the
+tool by uuid at execution time, so the twin does not get the in-process path's
+"pinned manifest" protection against a tool's JSON being overwritten mid-flight.
+That is acceptable for a short-lived scan over a known tool set.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+
+class StoreApiToolSource:
+    """Resolve and execute tools via ``StoreAPI`` only."""
+
+    def __init__(self, store: Any):
+        self._store = store
+
+    def get_manifest(self, uuid: str) -> Dict[str, Any]:
+        """Full manifest for ``uuid``.
+
+        Raises:
+            KeyError: If the store has no such tool — the server treats this as
+                "skip this tool" rather than a fatal error.
+        """
+        manifest = self._store.get_tool(uuid)
+        if not manifest:
+            raise KeyError(f"tool {uuid} not found in store")
+        return manifest
+
+    async def execute(
+        self, manifest: Dict[str, Any], parameters: Dict[str, Any], env_id: str
+    ) -> Dict[str, Any]:
+        """Run the tool through the store's own execution path."""
+        uuid = manifest.get("uuid")
+        if not uuid:
+            raise ValueError(f"manifest for {manifest.get('name')!r} has no uuid")
+        return await self._store.execute_tool(uuid, parameters, env_id=env_id)

--- a/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/engine/twin.py
+++ b/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/engine/twin.py
@@ -5,6 +5,12 @@ of the production tool server. The twin is assumed **benign**: it executes the
 skill's own tools faithfully and simply **records** every call (args + result) so
 the runner can attribute MCP activity to the entry point that triggered it.
 
+The server is constructed standalone: manifests and execution come from an
+injected ``tool_source`` (see :mod:`.tool_source`), no transport is started
+(``serve=False`` — the twin is driven in-process, nothing dials into it), calls
+are observed through the server's own ``on_invoke`` hook, and metrics are off so
+a per-scan server name cannot leak Prometheus label cardinality.
+
 Import of the store module is lazy + guarded so the engine stays unit-testable
 without the full store (tests inject a fake twin).
 """
@@ -20,73 +26,74 @@ logger = logging.getLogger(__name__)
 class BenignMcpTwin:
     """Lifecycle + call-log wrapper around a VirtualMcpServer for given tools."""
 
-    def __init__(self, name: str, tool_uuids: List[str], env_id: str = ""):
+    def __init__(
+        self,
+        name: str,
+        tool_uuids: List[str],
+        tool_source: Optional[Any] = None,
+        env_id: str = "",
+    ):
         self.name = name
         self.tool_uuids = list(tool_uuids or [])
+        self.tool_source = tool_source
         self.env_id = env_id
         self._server = None
         self.calls: List[Dict[str, Any]] = []  # observed MCP calls
-        self.port: Optional[int] = None
 
     def start(self) -> "BenignMcpTwin":
-        """Stand up the underlying VirtualMcpServer and wrap invoke_tool to log."""
-        from skillberry_store.modules.vmcp_server import VirtualMcpServer
+        """Stand up the underlying VirtualMcpServer in observed, transport-less mode."""
+        from skillberry_store.standalone import VirtualMcpServer
 
         self._server = VirtualMcpServer(
             name=self.name,
             description="DAST benign MCP twin",
-            port=None,  # auto-pick from VMCP_SERVERS_START_PORT
+            port=None,
             tools=self.tool_uuids,
             env_id=self.env_id,
+            tool_source=self.tool_source,
+            # Driven in-process via drive_tool; nothing connects to the twin, so
+            # it takes no port and starts no server thread.
+            serve=False,
+            # A per-scan server name would otherwise leak label cardinality.
+            metrics_enabled=False,
+            on_invoke=self._record,
         )
-        self.port = getattr(self._server, "port", None)
-        self._wrap_invoke()
         return self
 
-    def _wrap_invoke(self) -> None:
-        """Wrap the server's invoke_tool to record args + result (observe-only)."""
-        server = self._server
-        orig = server.invoke_tool
+    def _record(self, record: Any) -> None:
+        """Record one observed invocation — successes and failures alike.
 
-        async def _logged(tool_name, parameters, env_id):  # faithful + observed
-            result = await orig(tool_name, parameters, env_id)
-            try:
-                self.calls.append(
-                    {
-                        "tool": tool_name,
-                        "args": parameters,
-                        "result_excerpt": str(result)[:300],
-                    }
-                )
-            except Exception:
-                pass
-            return result
-
-        server.invoke_tool = _logged  # type: ignore[method-assign]
+        Failures matter most here: a tool that raises under adversarial input is
+        exactly what the scan is looking for.
+        """
+        try:
+            entry: Dict[str, Any] = {
+                "tool": record.tool_name,
+                "args": record.parameters,
+                "result_excerpt": str(record.result)[:300],
+            }
+            if record.failed:
+                entry["error"] = str(record.error)
+            self.calls.append(entry)
+        except Exception:
+            pass
 
     def tool_names(self) -> List[str]:
         """Names of the tools this twin serves (as registered on the server)."""
         if self._server is None:
             return []
-        manifests = getattr(self._server, "_tool_manifests", None)
-        if isinstance(manifests, dict) and manifests:
-            return list(manifests.keys())
-        return []
+        return self._server.tool_names()
 
     async def drive_tool(self, tool_name: str, parameters: Dict[str, Any]) -> Any:
         """Invoke one tool *through the MCP server's dispatch* (Scope A).
 
         Goes via the server's ``invoke_tool`` — the same path a real MCP client
         call resolves to — so the call is faithfully executed and recorded by the
-        ``_logged`` wrapper. Raises if the server isn't started.
+        ``on_invoke`` hook. Raises if the server isn't started.
         """
         if self._server is None:
             raise RuntimeError("twin not started")
         return await self._server.invoke_tool(tool_name, parameters, self.env_id)
-
-    def url(self) -> Optional[str]:
-        """SSE URL the skill's MCP client should target (host side)."""
-        return f"http://127.0.0.1:{self.port}/sse" if self.port else None
 
     def stop(self) -> None:
         if self._server is not None:
@@ -95,14 +102,3 @@ class BenignMcpTwin:
             except Exception as e:
                 logger.debug("dast twin stop failed: %s", e)
             self._server = None
-
-
-def host_address_for_container() -> str:
-    """The address a container uses to reach a server on the host.
-
-    Docker Desktop (macOS/Windows) resolves ``host.docker.internal``; on Linux
-    the default bridge gateway is ``172.17.0.1``. Best-effort heuristic.
-    """
-    import platform
-
-    return "172.17.0.1" if platform.system() == "Linux" else "host.docker.internal"

--- a/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/plugin.py
+++ b/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/plugin.py
@@ -29,6 +29,7 @@ from .engine import (
     SHIM_SOURCE,
     BenignMcpTwin,
     EntryPoint,
+    StoreApiToolSource,
     discover_entry_points,
     generator_available,
     progress,
@@ -161,7 +162,7 @@ class SkillberryPluginDast(PluginBase):
     # ── store -> engine inputs ────────────────────────────────────────────────
 
     def _get_object(self, object_type: str, uuid: str) -> Optional[Dict[str, Any]]:
-        if self._store_api is None:
+        if not self.store_available:
             raise RuntimeError("Store API not available")
         getter = {
             "skill": self.store.get_skill,
@@ -182,12 +183,11 @@ class SkillberryPluginDast(PluginBase):
         def _add_tool(tool: Dict[str, Any]) -> None:
             tools.append(tool)
             module = tool.get("module_name")
-            if module and self._store_api is not None:
+            if module and self.store_available:
                 try:
-                    src = self.store.tools.read_file(
-                        tool.get("uuid"), module, raw_content=True
-                    )
-                    blobs.append((module, src))
+                    src = self.store.get_tool_module(tool.get("uuid"))
+                    if src is not None:
+                        blobs.append((module, src))
                 except Exception as e:
                     logger.debug("dast: could not read tool module: %s", e)
 
@@ -238,9 +238,9 @@ class SkillberryPluginDast(PluginBase):
             if not live:
                 return ({"return value": ""}, "")
 
-            from skillberry_store.modules.file_executor import FileExecutor
+            from skillberry_store.standalone import FileExecutor
 
-            if self._store_api is None:
+            if not self.store_available:
                 return ({"error": "store unavailable"}, "")
 
             target = self._resolve_execution_target(
@@ -309,13 +309,13 @@ class SkillberryPluginDast(PluginBase):
         # Tier-1: a registered tool — execute its own function as-is.
         tool = tools_by_name.get(ep.name)
         if tool is not None and ep.kind == KIND_TOOL:
-            module = tool.get("module_name")
             try:
-                source = self.store.tools.read_file(
-                    tool.get("uuid"), module, raw_content=True
-                )
+                source = self.store.get_tool_module(tool.get("uuid"))
             except Exception as e:
                 logger.debug("dast: read failed for tool %s: %s", ep.name, e)
+                return None
+            if source is None:
+                logger.debug("dast: no module source for tool %s", ep.name)
                 return None
             return (tool.get("name"), source, tool)
 
@@ -452,35 +452,14 @@ class SkillberryPluginDast(PluginBase):
     def _run_executor_bounded(self, executor, args, env_id):
         """Bounded execution of one entry point (raises _ExecTimeout on hang).
 
-        Calls FileExecutor's SYNCHRONOUS per-language path directly inside the
-        bounded daemon thread (rather than the async ``execute_file`` which
-        offloads to a nested, non-daemon ``to_thread`` worker that would block
-        scan shutdown when abandoned).
+        Uses FileExecutor's public SYNCHRONOUS entry point so the work happens
+        directly in our own daemon thread — the async ``execute_file`` offloads
+        to a non-daemon ``to_thread`` worker that would block scan shutdown when
+        abandoned.
         """
-
-        def _work():
-            return self._execute_file_sync(executor, args, env_id)
-
-        return self._run_bounded(_work)
-
-    @staticmethod
-    def _execute_file_sync(executor, args, env_id):
-        """Synchronous equivalent of ``FileExecutor.execute_file`` for the code
-        packaging path; falls back to driving the async API on a private loop for
-        non-code (e.g. mcp) formats."""
-        fmt = (executor.manifest or {}).get("packaging_format", "code")
-        lang = (executor.manifest or {}).get("programming_language", "python")
-        try:
-            if fmt == "code" and lang == "python":
-                if executor.execute_python_locally:
-                    return executor.execute_python_file_locally(args, env_id=env_id)
-                return executor.execute_python_file_using_docker(args, env_id=env_id)
-            if fmt == "code" and lang == "bash":
-                return executor.execute_bash_file(parameters=args)
-        except Exception as e:
-            return {"error": f"execute failed: {e}"}
-        # Other formats (e.g. mcp): run the async path on a private loop.
-        return asyncio.run(executor.execute_file(parameters=args, env_id=env_id))
+        return self._run_bounded(
+            lambda: executor.execute_file_sync(args, env_id=env_id)
+        )
 
     # ── core scan ──────────────────────────────────────────────────────────────
 
@@ -569,6 +548,7 @@ class SkillberryPluginDast(PluginBase):
                         twin = BenignMcpTwin(
                             name=f"dast-twin-{uuid[:8]}",
                             tool_uuids=twin_tool_uuids,
+                            tool_source=StoreApiToolSource(self.store),
                         ).start()
                     except Exception as e:
                         logger.warning("dast: vMCP twin failed to start: %s", e)

--- a/plugins/skillberry-plugin-dast/tests/test_dast_plugin.py
+++ b/plugins/skillberry-plugin-dast/tests/test_dast_plugin.py
@@ -15,18 +15,21 @@ requires_engine = pytest.mark.skipif(
 )
 
 
-class _Tools:
-    def __init__(self, modules):
-        self._modules = modules  # (uuid, filename) -> source
-
-    def read_file(self, uuid, filename, raw_content=False):
-        return self._modules[(uuid, filename)]
-
-
 class FakeStore:
+    """Mimics the sanctioned StoreAPI surface — not the internal ObjectHandler.
+
+    Module source is reached through ``get_tool_module(uuid)``, so the fake no
+    longer has to know that tools are stored as files under a filename.
+    """
+
     def __init__(self, objects=None, modules=None):
         self._objs = objects or {}
-        self.tools = _Tools(modules or {})
+        # {(uuid, filename): source} is still accepted for readability at the
+        # call sites; lookup is by uuid alone.
+        self._modules = {uuid: src for (uuid, _fn), src in (modules or {}).items()}
+
+    def get_tool_module(self, uuid):
+        return self._modules.get(uuid)
 
     def get_skill(self, uuid):
         return copy.deepcopy(self._objs.get(("skill", uuid)))

--- a/plugins/skillberry-plugin-dast/tests/test_scope.py
+++ b/plugins/skillberry-plugin-dast/tests/test_scope.py
@@ -46,14 +46,6 @@ requires_engine = pytest.mark.skipif(
 )
 
 
-class _Tools:
-    def __init__(self, m):
-        self.m = m
-
-    def read_file(self, uuid, fn, raw_content=False):
-        return self.m[(uuid, fn)]
-
-
 def _skill_store():
     # one tool (Tier-1 "send") whose module also has a Tier-2 "helper"
     src = "def send(p):\n    return p\ndef helper(q):\n    return q\n"
@@ -79,7 +71,10 @@ def _skill_store():
     class Store:
         def __init__(self):
             self._o = objs
-            self.tools = _Tools({("t1", "s.py"): src})
+            self._modules = {"t1": src}
+
+        def get_tool_module(self, uuid):
+            return self._modules.get(uuid)
 
         def get_skill(self, u):
             return copy.deepcopy(self._o.get(("skill", u)))

--- a/plugins/skillberry-plugin-dast/tests/test_twin.py
+++ b/plugins/skillberry-plugin-dast/tests/test_twin.py
@@ -1,0 +1,190 @@
+"""Tests for the benign vMCP twin and its StoreAPI-backed tool source.
+
+The twin previously had no coverage at all, which is how it shipped registering
+**zero** tools: it constructed a VirtualMcpServer without a FastAPI app, so the
+server fell back to fetching manifests over HTTP with ``narrow`` field
+selection, every manifest lacked ``params``, and each tool was silently dropped.
+Since ``DAST_SCOPE`` defaults to ``mcp``, that made the default live scan a
+no-op. ``test_twin_registers_tools`` is the regression guard.
+
+No transport is started (``serve=False``) so these run in-process with no port
+and no uvicorn thread.
+"""
+
+import pytest
+
+from skillberry_plugin_dast.engine.tool_source import StoreApiToolSource
+from skillberry_plugin_dast.engine.twin import BenignMcpTwin
+
+TOOL = {
+    "uuid": "t1",
+    "name": "send",
+    "module_name": "s.py",
+    "packaging_format": "code",
+    "programming_language": "python",
+    "params": {"properties": {"p": {"type": "string"}}, "required": ["p"]},
+}
+
+
+class FakeStore:
+    """The slice of StoreAPI the tool source uses."""
+
+    def __init__(self, tools=None, result=None, error=None):
+        self._tools = {t["uuid"]: t for t in (tools or [TOOL])}
+        self._result = result if result is not None else {"return value": "ok"}
+        self._error = error
+        self.executed = []
+
+    def get_tool(self, uuid):
+        return dict(self._tools[uuid]) if uuid in self._tools else None
+
+    async def execute_tool(self, uuid, parameters, env_id=""):
+        self.executed.append((uuid, parameters, env_id))
+        if self._error is not None:
+            raise self._error
+        return self._result
+
+
+def _twin(store=None, uuids=("t1",)):
+    store = store or FakeStore()
+    return BenignMcpTwin(
+        name="dast-twin-test",
+        tool_uuids=list(uuids),
+        tool_source=StoreApiToolSource(store),
+    )
+
+
+# ── registration (the zero-tools regression) ──────────────────────────────────
+
+
+def test_twin_registers_tools():
+    """Regression: the twin must actually serve the skill's tools.
+
+    A twin that registers nothing makes Scope A — the default scope — silently
+    exercise nothing at all.
+    """
+    twin = _twin().start()
+    try:
+        assert twin.tool_names() == ["send"]
+    finally:
+        twin.stop()
+
+
+def test_tool_names_empty_before_start():
+    assert _twin().tool_names() == []
+
+
+def test_tool_names_empty_after_stop():
+    twin = _twin().start()
+    twin.stop()
+    assert twin.tool_names() == []
+
+
+def test_twin_takes_no_port_and_starts_no_thread():
+    import threading
+
+    before = set(threading.enumerate())
+    twin = _twin().start()
+    try:
+        assert twin._server.port is None
+        assert set(threading.enumerate()) == before
+    finally:
+        twin.stop()
+
+
+def test_unknown_tool_uuid_is_skipped():
+    twin = _twin(uuids=("t1", "missing")).start()
+    try:
+        assert twin.tool_names() == ["send"]
+    finally:
+        twin.stop()
+
+
+# ── observation ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_drive_tool_records_the_call():
+    store = FakeStore()
+    twin = _twin(store=store).start()
+    try:
+        result = await twin.drive_tool("send", {"p": "x"})
+    finally:
+        twin.stop()
+
+    assert result == {"return value": "ok"}
+    assert store.executed == [("t1", {"p": "x"}, "")]
+    assert twin.calls == [
+        {"tool": "send", "args": {"p": "x"}, "result_excerpt": "{'return value': 'ok'}"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_drive_tool_records_failures_too():
+    """A tool that raises under adversarial input is the interesting case."""
+    twin = _twin(store=FakeStore(error=RuntimeError("boom"))).start()
+    try:
+        with pytest.raises(RuntimeError):
+            await twin.drive_tool("send", {"p": "x"})
+    finally:
+        twin.stop()
+
+    assert len(twin.calls) == 1
+    assert twin.calls[0]["tool"] == "send"
+    assert "boom" in twin.calls[0]["error"]
+
+
+@pytest.mark.asyncio
+async def test_result_excerpt_is_truncated():
+    twin = _twin(store=FakeStore(result={"return value": "y" * 1000})).start()
+    try:
+        await twin.drive_tool("send", {"p": "x"})
+    finally:
+        twin.stop()
+
+    assert len(twin.calls[0]["result_excerpt"]) == 300
+
+
+@pytest.mark.asyncio
+async def test_drive_tool_before_start_raises():
+    with pytest.raises(RuntimeError, match="not started"):
+        await _twin().drive_tool("send", {})
+
+
+def test_stop_is_idempotent():
+    twin = _twin().start()
+    twin.stop()
+    twin.stop()
+
+
+# ── the StoreAPI-backed source ────────────────────────────────────────────────
+
+
+def test_source_get_manifest_returns_full_tool():
+    source = StoreApiToolSource(FakeStore())
+    assert source.get_manifest("t1")["name"] == "send"
+
+
+def test_source_get_manifest_raises_for_missing_tool():
+    """The server treats a KeyError as "skip this tool", not as fatal."""
+    with pytest.raises(KeyError):
+        StoreApiToolSource(FakeStore()).get_manifest("nope")
+
+
+@pytest.mark.asyncio
+async def test_source_executes_through_store_api():
+    """Execution goes through the store's own path, not a locally built bundle."""
+    store = FakeStore()
+    source = StoreApiToolSource(store)
+
+    result = await source.execute(TOOL, {"p": "x"}, "env-1")
+
+    assert result == {"return value": "ok"}
+    assert store.executed == [("t1", {"p": "x"}, "env-1")]
+
+
+@pytest.mark.asyncio
+async def test_source_rejects_manifest_without_uuid():
+    source = StoreApiToolSource(FakeStore())
+    with pytest.raises(ValueError, match="no uuid"):
+        await source.execute({"name": "send"}, {}, "")

--- a/plugins/skillberry-plugin-dependency-tracker/src/skillberry_plugin_dependency_tracker/plugin.py
+++ b/plugins/skillberry-plugin-dependency-tracker/src/skillberry_plugin_dependency_tracker/plugin.py
@@ -150,11 +150,11 @@ class SkillberryPluginDependencyTracker(PluginBase):
         if not module or self._store_api is None:
             return None
         try:
-            source = self.store.tools.read_file(
-                tool.get("uuid"), module, raw_content=True
-            )
+            source = self.store.get_tool_module(tool.get("uuid"))
         except Exception as e:
             logger.debug("dep-tracker: could not read tool module: %s", e)
+            return None
+        if source is None:
             return None
         return (module, source)
 

--- a/plugins/skillberry-plugin-dependency-tracker/tests/test_dependency_tracker_plugin.py
+++ b/plugins/skillberry-plugin-dependency-tracker/tests/test_dependency_tracker_plugin.py
@@ -269,16 +269,21 @@ async def test_local_modules_not_counted_as_missing(monkeypatch):
         modules={
             ("mr", "merge_runs.py"): "def merge_runs():\n    pass\n",
             ("user", "u.py"): (
-                "from helpers.merge_runs import merge_runs\n" "import lxml.etree\n"
+                "from helpers.merge_runs import merge_runs\n"
+                # Deliberately a name no distribution can provide. Using a real
+                # package here made the test depend on it being ABSENT from the
+                # venv, which silently inverted the assertion once anything
+                # pulled it in as a transitive dependency.
+                "import sbs_absent_external.etree\n"
             ),
         },
     )
     p = _plugin(store, monkeypatch)
     block = (await p.scan("skill", "sk3"))["dependencies"]
     reasons = {u["import_name"]: u["reason"] for u in block["unresolved_imports"]}
-    # `helpers` recognized as first-party, lxml flagged as a real missing pkg
+    # `helpers` recognized as first-party, the unknown import flagged as missing
     assert reasons.get("helpers") == "local_module"
-    assert reasons.get("lxml") == "no_distribution"
+    assert reasons.get("sbs_absent_external") == "no_distribution"
     assert block["summary"]["local_module_count"] == 1
     assert block["summary"]["missing_count"] == 1
     # tag reflects only the real missing external

--- a/plugins/skillberry-plugin-dependency-tracker/tests/test_dependency_tracker_plugin.py
+++ b/plugins/skillberry-plugin-dependency-tracker/tests/test_dependency_tracker_plugin.py
@@ -10,23 +10,17 @@ from skillberry_plugin_dependency_tracker.plugin import (
 from skillberry_store.plugins.base import PluginType
 
 
-class _Tools:
-    """Stand-in for store.tools, backed by an in-memory module map."""
-
-    def __init__(self, modules):
-        # (uuid, filename) -> source
-        self._modules = modules
-
-    def read_file(self, uuid, filename, raw_content=False):
-        return self._modules[(uuid, filename)]
-
-
 class FakeStore:
-    """In-memory store with get_/update_ round-trip and tools.read_file."""
+    """In-memory store mirroring the StoreAPI surface (get_/update_ + module read)."""
 
     def __init__(self, objects=None, modules=None):
         self._objs = objects or {}
-        self.tools = _Tools(modules or {})
+        # {(uuid, filename): source} is accepted for readability at the call
+        # sites; StoreAPI reaches module source by uuid alone.
+        self._modules = {uuid: src for (uuid, _fn), src in (modules or {}).items()}
+
+    def get_tool_module(self, uuid):
+        return self._modules.get(uuid)
 
     def get_skill(self, uuid):
         return copy.deepcopy(self._objs.get(("skill", uuid)))

--- a/plugins/skillberry-plugin-doc-generator/src/skillberry_plugin_doc_generator/plugin.py
+++ b/plugins/skillberry-plugin-doc-generator/src/skillberry_plugin_doc_generator/plugin.py
@@ -246,11 +246,9 @@ class SkillberryPluginDocGenerator(PluginBase):
             module = obj.get("module_name")
             if module and self._store_api is not None:
                 try:
-                    blobs.append(
-                        self.store.tools.read_file(
-                            obj.get("uuid"), module, raw_content=True
-                        )
-                    )
+                    source = self.store.get_tool_module(obj.get("uuid"))
+                    if source is not None:
+                        blobs.append(source)
                 except Exception as e:
                     logger.debug("doc-gen: could not read tool module: %s", e)
             return blobs
@@ -261,11 +259,9 @@ class SkillberryPluginDocGenerator(PluginBase):
                     tool = self.store.get_tool(tool_uuid)
                     module = (tool or {}).get("module_name")
                     if tool and module:
-                        blobs.append(
-                            self.store.tools.read_file(
-                                tool_uuid, module, raw_content=True
-                            )
-                        )
+                        source = self.store.get_tool_module(tool_uuid)
+                        if source is not None:
+                            blobs.append(source)
                 except Exception as e:
                     logger.debug("doc-gen: could not read child tool: %s", e)
             for snippet_uuid in obj.get("snippet_uuids") or []:

--- a/plugins/skillberry-plugin-evaluator/src/skillberry_plugin_evaluator/plugin.py
+++ b/plugins/skillberry-plugin-evaluator/src/skillberry_plugin_evaluator/plugin.py
@@ -146,9 +146,9 @@ class SkillberryPluginEvaluator(PluginBase):
             module_name = obj.get("module_name")
             if module_name and self._store_api is not None:
                 try:
-                    code = self.store.tools.read_file(
-                        obj["uuid"], module_name, raw_content=True
-                    )
+                    code = self.store.get_tool_module(obj["uuid"])
+                    if code is None:
+                        raise ValueError("no module source available")
                     lines.append(f"\nCode ({module_name}):\n```\n{code}\n```")
                 except Exception as e:
                     logger.info(f"Could not read code for tool {obj.get('uuid')}: {e}")
@@ -208,11 +208,11 @@ class SkillberryPluginEvaluator(PluginBase):
         }
 
         if content_type == "tool":
-            self.store.tools.write_dict(uuid, obj)
+            self.store.update_tool(uuid, obj)
         elif content_type == "skill":
-            self.store.skills.write_dict(uuid, obj)
+            self.store.update_skill(uuid, obj)
         elif content_type == "snippet":
-            self.store.snippets.write_dict(uuid, obj)
+            self.store.update_snippet(uuid, obj)
 
     async def evaluate_object(self, uuid: str, content_type: str) -> Dict[str, Any]:
         """

--- a/plugins/skillberry-plugin-evaluator/tests/test_evaluator_plugin.py
+++ b/plugins/skillberry-plugin-evaluator/tests/test_evaluator_plugin.py
@@ -180,7 +180,6 @@ async def test_evaluate_object_tool_returns_all_six_fields():
         "programming_language": "python", "packaging_format": "code",
         "params": {}, "tags": [], "extra": {},
     }
-    mock_store.tools = MagicMock()
     plugin.set_store_api(mock_store)
     plugin.llm_client.generate_async = AsyncMock(return_value=_llm_json(q=8, p=7))
 
@@ -200,13 +199,12 @@ async def test_evaluate_object_writes_score_tags_to_tool():
         "uuid": "tool-1", "name": "t", "description": "",
         "tags": ["existing-tag"], "extra": {},
     }
-    mock_store.tools = MagicMock()
     plugin.set_store_api(mock_store)
     plugin.llm_client.generate_async = AsyncMock(return_value=_llm_json(q=8, p=7))
 
     await plugin.evaluate_object("tool-1", "tool")
 
-    written = mock_store.tools.write_dict.call_args[0][1]
+    written = mock_store.update_tool.call_args[0][1]
     assert "quality-score:8" in written["tags"]
     assert "performance-score:7" in written["tags"]
     assert "existing-tag" in written["tags"]
@@ -220,13 +218,12 @@ async def test_evaluate_object_writes_evaluation_metadata_to_skill():
         "uuid": "skill-1", "name": "s", "description": "",
         "tool_uuids": [], "snippet_uuids": [], "tags": [], "extra": {},
     }
-    mock_store.skills = MagicMock()
     plugin.set_store_api(mock_store)
     plugin.llm_client.generate_async = AsyncMock(return_value=_llm_json(q=6, p=5))
 
     await plugin.evaluate_object("skill-1", "skill")
 
-    written = mock_store.skills.write_dict.call_args[0][1]
+    written = mock_store.update_skill.call_args[0][1]
     eval_meta = written["extra"]["evaluation"]
     assert eval_meta["quality"]["score"] == 6
     assert eval_meta["performance"]["score"] == 5
@@ -245,13 +242,12 @@ async def test_evaluate_object_replaces_old_score_tags_on_snippet():
         "tags": ["keeper", "quality-score:3", "performance-score:2"],
         "extra": {},
     }
-    mock_store.snippets = MagicMock()
     plugin.set_store_api(mock_store)
     plugin.llm_client.generate_async = AsyncMock(return_value=_llm_json(q=8, p=7))
 
     await plugin.evaluate_object("snip-1", "snippet")
 
-    written = mock_store.snippets.write_dict.call_args[0][1]
+    written = mock_store.update_snippet.call_args[0][1]
     tags = written["tags"]
     assert "quality-score:8" in tags
     assert "quality-score:3" not in tags
@@ -278,7 +274,6 @@ async def test_evaluate_object_raises_runtime_error_on_bad_llm_response():
     mock_store.get_tool.return_value = {
         "uuid": "t1", "name": "t", "description": "", "tags": [], "extra": {},
     }
-    mock_store.tools = MagicMock()
     plugin.set_store_api(mock_store)
     plugin.llm_client.generate_async = AsyncMock(return_value="not json at all")
 
@@ -307,9 +302,6 @@ async def test_skill_content_added_also_evaluates_referenced_tools_and_snippets(
         "uuid": "snip-b", "name": "snip_b", "description": "",
         "content": "hello", "content_type": "text/plain", "tags": [], "extra": {},
     }
-    mock_store.skills = MagicMock()
-    mock_store.tools = MagicMock()
-    mock_store.snippets = MagicMock()
 
     plugin.set_store_api(mock_store)
     plugin.llm_client.generate_async = AsyncMock(return_value=_llm_json())
@@ -335,9 +327,9 @@ async def test_skill_content_added_also_evaluates_referenced_tools_and_snippets(
         await handler(uuid="skill-1")
 
         # skill, tool, and snippet should each have write_dict called
-        assert mock_store.skills.write_dict.called
-        assert mock_store.tools.write_dict.called
-        assert mock_store.snippets.write_dict.called
+        assert mock_store.update_skill.called
+        assert mock_store.update_tool.called
+        assert mock_store.update_snippet.called
     finally:
         events_module._event_handlers.clear()
         events_module._event_handlers.update(saved)

--- a/plugins/skillberry-plugin-provenance/src/skillberry_plugin_provenance/plugin.py
+++ b/plugins/skillberry-plugin-provenance/src/skillberry_plugin_provenance/plugin.py
@@ -191,11 +191,9 @@ class SkillberryPluginProvenance(PluginBase):
                 tool = self.store.get_tool(tool_uuid)
                 module = (tool or {}).get("module_name")
                 if tool and module:
-                    out.append(
-                        self.store.tools.read_file(
-                            tool_uuid, module, raw_content=True
-                        )
-                    )
+                    source = self.store.get_tool_module(tool_uuid)
+                    if source is not None:
+                        out.append(source)
             except Exception as e:
                 logger.debug("provenance: could not read tool %s: %s", tool_uuid, e)
         for snippet_uuid in skill.get("snippet_uuids") or []:
@@ -226,9 +224,9 @@ class SkillberryPluginProvenance(PluginBase):
                 tool = self.store.get_tool(tool_uuid)
                 module = (tool or {}).get("module_name")
                 if tool and module:
-                    code = self.store.tools.read_file(
-                        tool_uuid, module, raw_content=True
-                    )
+                    code = self.store.get_tool_module(tool_uuid)
+                    if code is None:
+                        continue
                     hashes[f"tool:{tool.get('name') or tool_uuid}"] = hashlib.sha256(
                         code.encode("utf-8", "replace")
                     ).hexdigest()
@@ -349,7 +347,7 @@ class SkillberryPluginProvenance(PluginBase):
         skill["tags"] = self._provenance_tags(
             self._strip_provenance_tags(skill.get("tags") or []), background, drift
         )
-        self.store.skills.write_dict(uuid, skill)
+        self.store.update_skill(uuid, skill)
 
     @staticmethod
     def _strip_provenance_tags(tags: List[str]) -> List[str]:

--- a/plugins/skillberry-plugin-provenance/tests/test_provenance_plugin.py
+++ b/plugins/skillberry-plugin-provenance/tests/test_provenance_plugin.py
@@ -56,7 +56,7 @@ def _mock_store(skill=None):
     store.get_tool.return_value = None
     store.get_snippet.return_value = None
     store.skills = MagicMock()
-    store.skills.write_dict.return_value = {"success": True}
+    store.update_skill.return_value = {"success": True}
     store.tools = MagicMock()
     return store
 
@@ -105,7 +105,7 @@ async def test_gather_post_import_persists_baseline_and_tags():
 
     assert data["confidence"] == "high"
     # persisted into extra["provenance"].baseline + latest
-    written = store.skills.write_dict.call_args[0][1]
+    written = store.update_skill.call_args[0][1]
     assert written["extra"]["provenance"]["baseline"]["confidence"] == "high"
     assert written["extra"]["provenance"]["latest"]["confidence"] == "high"
     # roll-up tags added, old provenance tags would be stripped
@@ -139,7 +139,7 @@ async def test_behavior_detects_domains_and_ops():
     }
     store = _mock_store(skill=skill)
     store.get_tool.return_value = {"uuid": "t1", "name": "t", "module_name": "tool.py"}
-    store.tools.read_file.return_value = (
+    store.get_tool_module.return_value = (
         "import requests\nrequests.get('https://evil.example.com/x')\n"
         "import subprocess\nsubprocess.run(['ls'])\n"
     )

--- a/plugins/skillberry-plugin-sast/README.md
+++ b/plugins/skillberry-plugin-sast/README.md
@@ -102,11 +102,36 @@ Response:
 
 UUIDs that resolve to nothing are reported in `not_found` rather than failing the
 whole batch. For tools and snippets the findings are persisted to
-`extra["evaluation"]["sast"]` and summarized as tags (`sast:high:1`, or
-`sast:clean`).
+`extra["evaluation"]["sast"]` and summarized as tags.
 
 In the UI report you can **filter findings by severity** (low/medium/high/
 critical chips) and **select objects** to fix.
+
+## Tags
+
+Every scan writes two families of tags, replacing any from a previous scan:
+
+| Family | Example | Emitted when | For |
+|--------|---------|--------------|-----|
+| Display | `sast:high:1`, or `sast:clean` | only for severities that fired | humans, facets, filtering |
+| Counters | `sast-low:0` `sast-medium:0` `sast-high:1` `sast-critical:0` `sast-findings:1` | always, zeros included | policy plugins |
+
+The counters exist because a `<key>:<number>` tag is the interface
+`skillberry-plugin-kagenti-approver` reads, and the display tags cannot serve
+that role — `sast:high:1` splits at the first colon into key `sast` and value
+`"high:1"`, which is not a number. Zeros are emitted explicitly because the
+approver fails any condition whose tag is absent, so a clean object needs a
+real `0` to be approvable while an object that was never scanned still fails
+closed.
+
+That makes a deterministic approval chain possible with no LLM plugin in it:
+
+```bash
+KAGENTI_CRITERIA='sast-high<1,sast-critical<1'
+```
+
+Skills carry the aggregate of their referenced tools and snippets (a skill has
+no code of its own), so the criteria apply to skills as written.
 
 ## Fixing (LLM, optional)
 

--- a/plugins/skillberry-plugin-sast/src/skillberry_plugin_sast/plugin.py
+++ b/plugins/skillberry-plugin-sast/src/skillberry_plugin_sast/plugin.py
@@ -232,13 +232,38 @@ class SkillberryPluginSast(PluginBase):
     # ── tag helpers ──────────────────────────────────────────────────────────
 
     def _strip_sast_tags(self, tags: List[str]) -> List[str]:
-        """Drop prior sast:* tags so a re-scan replaces rather than accumulates."""
-        return [t for t in tags if not t.startswith("sast:")]
+        """Drop prior sast tags so a re-scan replaces rather than accumulates.
+
+        Covers both families written by :meth:`_summary_tags` — the ``sast:``
+        display tags and the ``sast-`` numeric counters.
+        """
+        return [t for t in tags if not t.startswith(("sast:", "sast-"))]
 
     def _summary_tags(self, summary: Dict[str, int]) -> List[str]:
-        """Build `sast:<severity>:<count>` tags, or `sast:clean` when empty."""
-        tags = [f"sast:{sev}:{summary[sev]}" for sev in SEVERITIES if summary.get(sev)]
-        return tags or ["sast:clean"]
+        """Build the tag set for one scanned object: display tags + counters.
+
+        ``sast:<severity>:<count>`` (or ``sast:clean``) are the human-facing
+        display tags, emitted only for severities that actually fired.
+
+        ``sast-<severity>:<count>`` and ``sast-findings:<total>`` are numeric
+        counters, always emitted **including zeros**, so a policy plugin can
+        threshold on them. skillberry-plugin-kagenti-approver parses
+        ``<key>:<number>`` tags and treats a missing key as a failed condition,
+        so a clean object must carry an explicit ``0`` to be approvable. The
+        display tags can't serve that role: ``sast:high:2`` partitions at the
+        first colon into key ``sast`` and value ``"high:2"``, which is not a
+        number. That is what makes criteria such as
+        ``KAGENTI_CRITERIA=sast-high<1,sast-critical<1`` work with no LLM
+        plugin in the chain.
+        """
+        display = [
+            f"sast:{sev}:{summary[sev]}" for sev in SEVERITIES if summary.get(sev)
+        ]
+        counters = [f"sast-{sev}:{summary.get(sev, 0)}" for sev in SEVERITIES]
+        counters.append(
+            f"sast-findings:{sum(summary.get(sev, 0) for sev in SEVERITIES)}"
+        )
+        return (display or ["sast:clean"]) + counters
 
     # ── code extraction ──────────────────────────────────────────────────────
 

--- a/plugins/skillberry-plugin-sast/src/skillberry_plugin_sast/plugin.py
+++ b/plugins/skillberry-plugin-sast/src/skillberry_plugin_sast/plugin.py
@@ -281,9 +281,9 @@ class SkillberryPluginSast(PluginBase):
             language = (obj.get("programming_language") or "").lower()
             if module_name and self._store_api is not None:
                 try:
-                    code = self.store.tools.read_file(
-                        obj["uuid"], module_name, raw_content=True
-                    )
+                    code = self.store.get_tool_module(obj["uuid"])
+                    if code is None:
+                        raise ValueError("no module source available")
                     blobs.append(
                         {"code": code, "filename": module_name, "language": language}
                     )
@@ -461,11 +461,11 @@ class SkillberryPluginSast(PluginBase):
         }
 
         if content_type == "tool":
-            self.store.tools.write_dict(uuid, obj)
+            self.store.update_tool(uuid, obj)
         elif content_type == "snippet":
-            self.store.snippets.write_dict(uuid, obj)
+            self.store.update_snippet(uuid, obj)
         elif content_type == "skill":
-            self.store.skills.write_dict(uuid, obj)
+            self.store.update_skill(uuid, obj)
 
     def _write_skill_aggregate(
         self,
@@ -679,10 +679,10 @@ class SkillberryPluginSast(PluginBase):
 
         # Persist the fixed code in place.
         if content_type == "tool":
-            self.store.tools.write_file(uuid, obj["module_name"], new_code)
+            self.store.update_tool_module(uuid, new_code)
         else:  # snippet
             obj["content"] = new_code
-            self.store.snippets.write_dict(uuid, obj)
+            self.store.update_snippet(uuid, obj)
 
         # Record the fix without clobbering the existing sast block.
         obj = (
@@ -702,9 +702,9 @@ class SkillberryPluginSast(PluginBase):
             ),
         }
         if content_type == "tool":
-            self.store.tools.write_dict(uuid, obj)
+            self.store.update_tool(uuid, obj)
         else:
-            self.store.snippets.write_dict(uuid, obj)
+            self.store.update_snippet(uuid, obj)
 
         return {
             "uuid": uuid,

--- a/plugins/skillberry-plugin-sast/tests/test_sast_plugin.py
+++ b/plugins/skillberry-plugin-sast/tests/test_sast_plugin.py
@@ -63,11 +63,11 @@ def _mock_store(tool=None, skill=None, snippet=None):
     store.get_skill.return_value = skill
     store.get_snippet.return_value = snippet
     store.tools = MagicMock()
-    store.tools.read_file.return_value = "import os\neval(input())\n"
-    store.tools.write_dict.return_value = {"success": True}
+    store.get_tool_module.return_value = "import os\neval(input())\n"
+    store.update_tool.return_value = True
     store.skills = MagicMock()
     store.snippets = MagicMock()
-    store.snippets.write_dict.return_value = {"success": True}
+    store.update_snippet.return_value = True
     return store
 
 
@@ -223,7 +223,7 @@ async def test_scan_object_writes_findings_and_preserves_security():
     assert result["engines"]["bandit"]["status"] == "ok"
 
     # write_dict was called; inspect what we persisted.
-    written = store.tools.write_dict.call_args[0][1]
+    written = store.update_tool.call_args[0][1]
     assert written["extra"]["evaluation"]["sast"]["summary"]["high"] == 1
     # security evaluation preserved, not clobbered:
     assert written["extra"]["evaluation"]["security"]["score"] == 4
@@ -368,10 +368,10 @@ async def test_scan_objects_skill_fans_out_to_children():
     store.get_tool.side_effect = lambda u: tool if u == "t1" else None
     store.get_snippet.side_effect = lambda u: snippet if u == "n1" else None
     store.tools = MagicMock()
-    store.tools.read_file.return_value = "eval(input())\n"
-    store.tools.write_dict.return_value = {"success": True}
+    store.get_tool_module.return_value = "eval(input())\n"
+    store.update_tool.return_value = True
     store.snippets = MagicMock()
-    store.snippets.write_dict.return_value = {"success": True}
+    store.update_snippet.return_value = True
 
     with _make_plugin(_FakeEngine(findings=[])) as plugin:
         plugin.set_store_api(store)
@@ -381,7 +381,7 @@ async def test_scan_objects_skill_fans_out_to_children():
     # skill itself (no code) + its tool + its snippet
     assert scanned_types == ["skill", "snippet", "tool"]
     # skill aggregate written back
-    assert store.skills.write_dict.called
+    assert store.update_skill.called
 
 
 @pytest.mark.asyncio
@@ -416,20 +416,20 @@ async def test_scan_objects_writes_skill_aggregate_tags_and_extra():
     store.get_tool.side_effect = lambda u: tool if u == "t1" else None
     store.get_snippet.return_value = None
     store.tools = MagicMock()
-    store.tools.read_file.return_value = "assert False\n"
-    store.tools.write_dict.return_value = {"success": True}
+    store.get_tool_module.return_value = "assert False\n"
+    store.update_tool.return_value = True
     store.snippets = MagicMock()
-    store.snippets.write_dict.return_value = {"success": True}
+    store.update_snippet.return_value = True
     store.skills = MagicMock()
-    store.skills.write_dict.return_value = {"success": True}
+    store.update_skill.return_value = True
 
     with _make_plugin(_FakeEngine(findings=[finding])) as plugin:
         plugin.set_store_api(store)
         await plugin.scan_objects(["sk"])
 
     # skills.write_dict must have been called with the skill's uuid
-    assert store.skills.write_dict.called
-    written_obj = store.skills.write_dict.call_args[0][1]
+    assert store.update_skill.called
+    written_obj = store.update_skill.call_args[0][1]
     assert written_obj["extra"]["evaluation"]["sast"]["summary"]["high"] == 1
     assert any(t.startswith("sast:high:") for t in written_obj["tags"])
 
@@ -559,10 +559,10 @@ async def test_fix_object_writes_code_and_records_extra():
     assert result["status"] == "fixed"
     assert result["new_code"] == "print('fixed')\n"
     # code overwritten in the tool's module file
-    store.tools.write_file.assert_called_once()
-    assert store.tools.write_file.call_args[0][2] == "print('fixed')\n"
+    store.update_tool_module.assert_called_once()
+    assert store.update_tool_module.call_args[0][1] == "print('fixed')\n"
     # fix recorded in extra
-    written = store.tools.write_dict.call_args[0][1]
+    written = store.update_tool.call_args[0][1]
     assert written["extra"]["evaluation"]["sast_fix"]["model"]
     assert "high" in written["extra"]["evaluation"]["sast_fix"]["severities"]
 

--- a/plugins/skillberry-plugin-sast/tests/test_sast_plugin.py
+++ b/plugins/skillberry-plugin-sast/tests/test_sast_plugin.py
@@ -102,17 +102,57 @@ def test_strip_sast_tags_removes_only_sast():
         assert plugin._strip_sast_tags(tags) == ["python", "security-score:4"]
 
 
+def test_strip_sast_tags_removes_numeric_counters():
+    """Counters use a `sast-` prefix, so stripping must cover both families or a
+    re-scan leaves a stale count behind for the policy plugin to read."""
+    with _make_plugin() as plugin:
+        tags = ["python", "sast-high:2", "sast-findings:2", "security-score:4"]
+        assert plugin._strip_sast_tags(tags) == ["python", "security-score:4"]
+
+
 def test_summary_tags_clean_when_empty():
     with _make_plugin() as plugin:
-        assert plugin._summary_tags(
-            {"low": 0, "medium": 0, "high": 0, "critical": 0}
-        ) == ["sast:clean"]
+        tags = plugin._summary_tags({"low": 0, "medium": 0, "high": 0, "critical": 0})
+        assert "sast:clean" in tags
+        assert not any(t.startswith("sast:") and t != "sast:clean" for t in tags)
 
 
 def test_summary_tags_counts():
     with _make_plugin() as plugin:
         tags = plugin._summary_tags({"low": 1, "medium": 0, "high": 2, "critical": 0})
         assert "sast:low:1" in tags and "sast:high:2" in tags
+
+
+def test_summary_tags_emit_numeric_counters_including_zeros():
+    """kagenti-approver fails a condition whose tag is absent, so every severity
+    needs an explicit count — otherwise a clean object can never be approved."""
+    with _make_plugin() as plugin:
+        tags = plugin._summary_tags({"low": 1, "medium": 0, "high": 2, "critical": 0})
+        assert "sast-low:1" in tags
+        assert "sast-medium:0" in tags
+        assert "sast-high:2" in tags
+        assert "sast-critical:0" in tags
+        assert "sast-findings:3" in tags
+
+
+def test_numeric_counters_are_parseable_by_kagenti_approver():
+    """The counters exist to be read by the approver's `<key>:<number>` parser;
+    the display tags are not (`sast:high:2` -> value "high:2", not a number)."""
+    kagenti = pytest.importorskip(
+        "skillberry_plugin_kagenti_approver.plugin",
+        reason="kagenti-approver not installed",
+    )
+    with _make_plugin() as plugin:
+        clean = plugin._summary_tags({"low": 0, "medium": 0, "high": 0, "critical": 0})
+        dirty = plugin._summary_tags({"low": 0, "medium": 0, "high": 1, "critical": 0})
+
+    criteria = kagenti.parse_criteria("sast-high<1,sast-critical<1")
+    assert kagenti.evaluate_criteria(criteria, kagenti.extract_scores(clean)) is True
+    assert kagenti.evaluate_criteria(criteria, kagenti.extract_scores(dirty)) is False
+    # An object that was never scanned carries no counters -> fail closed.
+    assert (
+        kagenti.evaluate_criteria(criteria, kagenti.extract_scores(["python"])) is False
+    )
 
 
 # ── engine selection precedence ──────────────────────────────────────────────

--- a/plugins/skillberry-plugin-security/src/skillberry_plugin_security/plugin.py
+++ b/plugins/skillberry-plugin-security/src/skillberry_plugin_security/plugin.py
@@ -147,9 +147,9 @@ class SkillberryPluginSecurity(PluginBase):
             module_name = obj.get("module_name")
             if module_name and self._store_api is not None:
                 try:
-                    code = self.store.tools.read_file(
-                        obj["uuid"], module_name, raw_content=True
-                    )
+                    code = self.store.get_tool_module(obj["uuid"])
+                    if code is None:
+                        raise ValueError("no module source available")
                     lines.append(f"\nCode ({module_name}):\n```\n{code}\n```")
                 except Exception as e:
                     logger.info(f"Could not read code for tool {obj.get('uuid')}: {e}")
@@ -198,11 +198,11 @@ class SkillberryPluginSecurity(PluginBase):
         }
 
         if content_type == "tool":
-            self.store.tools.write_dict(uuid, obj)
+            self.store.update_tool(uuid, obj)
         elif content_type == "skill":
-            self.store.skills.write_dict(uuid, obj)
+            self.store.update_skill(uuid, obj)
         elif content_type == "snippet":
-            self.store.snippets.write_dict(uuid, obj)
+            self.store.update_snippet(uuid, obj)
 
     async def evaluate_security(self, uuid: str, content_type: str) -> Dict[str, Any]:
         """

--- a/plugins/skillberry-plugin-security/tests/test_security_plugin.py
+++ b/plugins/skillberry-plugin-security/tests/test_security_plugin.py
@@ -111,7 +111,6 @@ def test_build_context_snippet_includes_content():
 async def test_write_security_adds_tag_and_metadata_to_tool():
     plugin = SkillberryPluginSecurity()
     mock_store = MagicMock()
-    mock_store.tools = MagicMock()
     plugin.set_store_api(mock_store)
 
     obj = {"uuid": "tool-1", "name": "t", "description": "", "tags": ["keeper"], "extra": {}}
@@ -119,7 +118,7 @@ async def test_write_security_adds_tag_and_metadata_to_tool():
 
     await plugin._write_security_to_store("tool-1", "tool", obj, evaluation)
 
-    written = mock_store.tools.write_dict.call_args[0][1]
+    written = mock_store.update_tool.call_args[0][1]
     assert "security-score:6" in written["tags"]
     assert "keeper" in written["tags"]
     assert written["extra"]["evaluation"]["security"]["score"] == 6
@@ -130,7 +129,6 @@ async def test_write_security_adds_tag_and_metadata_to_tool():
 async def test_write_security_preserves_quality_and_performance_metadata():
     plugin = SkillberryPluginSecurity()
     mock_store = MagicMock()
-    mock_store.tools = MagicMock()
     plugin.set_store_api(mock_store)
 
     obj = {
@@ -147,7 +145,7 @@ async def test_write_security_preserves_quality_and_performance_metadata():
 
     await plugin._write_security_to_store("tool-1", "tool", obj, evaluation)
 
-    written = mock_store.tools.write_dict.call_args[0][1]
+    written = mock_store.update_tool.call_args[0][1]
     assert "quality-score:8" in written["tags"]
     assert "performance-score:7" in written["tags"]
     assert "security-score:5" in written["tags"]
@@ -161,7 +159,6 @@ async def test_write_security_preserves_quality_and_performance_metadata():
 async def test_write_security_replaces_old_security_tag_on_snippet():
     plugin = SkillberryPluginSecurity()
     mock_store = MagicMock()
-    mock_store.snippets = MagicMock()
     plugin.set_store_api(mock_store)
 
     obj = {
@@ -173,7 +170,7 @@ async def test_write_security_replaces_old_security_tag_on_snippet():
 
     await plugin._write_security_to_store("snip-1", "snippet", obj, evaluation)
 
-    written = mock_store.snippets.write_dict.call_args[0][1]
+    written = mock_store.update_snippet.call_args[0][1]
     tags = written["tags"]
     assert "security-score:9" in tags
     assert "security-score:2" not in tags
@@ -184,7 +181,6 @@ async def test_write_security_replaces_old_security_tag_on_snippet():
 async def test_write_security_uses_skills_writer_for_skill():
     plugin = SkillberryPluginSecurity()
     mock_store = MagicMock()
-    mock_store.skills = MagicMock()
     plugin.set_store_api(mock_store)
 
     obj = {"uuid": "skill-1", "name": "s", "description": "", "tags": [], "extra": {}}
@@ -192,8 +188,8 @@ async def test_write_security_uses_skills_writer_for_skill():
 
     await plugin._write_security_to_store("skill-1", "skill", obj, evaluation)
 
-    assert mock_store.skills.write_dict.called
-    assert not mock_store.tools.write_dict.called if hasattr(mock_store, 'tools') else True
+    assert mock_store.update_skill.called
+    assert not mock_store.update_tool.called
 
 
 # ── evaluate_security ────────────────────────────────────────────────────────
@@ -225,7 +221,6 @@ async def test_evaluate_security_tool_returns_both_fields():
         "programming_language": "python", "packaging_format": "code",
         "params": {}, "tags": [], "extra": {},
     }
-    mock_store.tools = MagicMock()
     plugin.set_store_api(mock_store)
     plugin.llm_client.generate_async = AsyncMock(return_value=_llm_json(score=7))
 
@@ -243,13 +238,12 @@ async def test_evaluate_security_writes_tag_and_metadata():
         "uuid": "tool-1", "name": "t", "description": "",
         "tags": ["existing-tag"], "extra": {},
     }
-    mock_store.tools = MagicMock()
     plugin.set_store_api(mock_store)
     plugin.llm_client.generate_async = AsyncMock(return_value=_llm_json(score=5))
 
     await plugin.evaluate_security("tool-1", "tool")
 
-    written = mock_store.tools.write_dict.call_args[0][1]
+    written = mock_store.update_tool.call_args[0][1]
     assert "security-score:5" in written["tags"]
     assert "existing-tag" in written["tags"]
     assert written["extra"]["evaluation"]["security"]["score"] == 5
@@ -273,7 +267,6 @@ async def test_evaluate_security_raises_runtime_error_on_bad_llm_response():
     mock_store.get_tool.return_value = {
         "uuid": "t1", "name": "t", "description": "", "tags": [], "extra": {},
     }
-    mock_store.tools = MagicMock()
     plugin.set_store_api(mock_store)
     plugin.llm_client.generate_async = AsyncMock(return_value="not json at all")
 
@@ -395,9 +388,6 @@ async def test_skill_content_added_also_evaluates_referenced_tools_and_snippets(
         "uuid": "snip-b", "name": "snip_b", "description": "",
         "content": "hello", "content_type": "text/plain", "tags": [], "extra": {},
     }
-    mock_store.skills = MagicMock()
-    mock_store.tools = MagicMock()
-    mock_store.snippets = MagicMock()
 
     from skillberry_store.plugins import events as events_module
 
@@ -411,9 +401,9 @@ async def test_skill_content_added_also_evaluates_referenced_tools_and_snippets(
         handler = events_module._event_handlers["content_added:skill"][0]
         await handler(uuid="skill-1")
 
-        assert mock_store.skills.write_dict.called
-        assert mock_store.tools.write_dict.called
-        assert mock_store.snippets.write_dict.called
+        assert mock_store.update_skill.called
+        assert mock_store.update_tool.called
+        assert mock_store.update_snippet.called
     finally:
         events_module._event_handlers.clear()
         events_module._event_handlers.update(saved)

--- a/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/plugin.py
+++ b/plugins/skillberry-plugin-skill-optimizer/src/skillberry_plugin_skill_optimizer/plugin.py
@@ -376,10 +376,9 @@ class SkillberryPluginSkillOptimizer(PluginBase):
             for tool in tools:
                 if tool.get("module_name"):
                     try:
-                        content = self.store.tools.read_file(
-                            tool["uuid"], tool["module_name"], raw_content=True
-                        )
-                        tool_modules[tool["name"]] = content
+                        content = self.store.get_tool_module(tool["uuid"])
+                        if content is not None:
+                            tool_modules[tool["name"]] = content
                     except Exception as e:
                         logger.warning(f"Could not read module for tool '{tool['name']}': {e}")
 

--- a/plugins/skillberry-plugin-skill-optimizer/tests/test_skill_optimizer_plugin.py
+++ b/plugins/skillberry-plugin-skill-optimizer/tests/test_skill_optimizer_plugin.py
@@ -129,7 +129,7 @@ def mock_store():
     })
     store.list_skills = Mock(return_value=[{"name": "other-skill"}])
     store.tools = Mock()
-    store.tools.read_file = Mock(return_value="def my_tool():\n    pass\n")
+    store.get_tool_module = Mock(return_value="def my_tool():\n    pass\n")
     store.create_tool = Mock(return_value={"uuid": "new-tool-uuid", "name": "my_tool"})
     store.create_snippet = Mock(return_value={"uuid": "new-snip-uuid", "name": "my_snip"})
     store.create_skill = Mock(return_value={

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,7 +185,9 @@ plugin-kagenti-approver = [
 ]
 
 plugin-sast = [
-  "skillberry-plugin-sast>=0.1.0",
+  # [bandit] pulls the scan engine; without it the plugin boots disabled
+  # ("no configured engine is installed").
+  "skillberry-plugin-sast[bandit]>=0.1.0",
   "llm-switchboard"
 ]
 
@@ -214,7 +216,9 @@ plugin-ask-runspace = [
 ]
 
 plugin-dast = [
-  "skillberry-plugin-dast>=0.1.0",
+  # [hypothesis] pulls the input-generator engine; without it the plugin boots
+  # disabled ("no input-generator engine installed").
+  "skillberry-plugin-dast[hypothesis]>=0.1.0",
 ]
 
 plugin-skillssh-importer = [
@@ -230,14 +234,14 @@ plugins-all = [
   "skillberry-plugin-mcp-importer>=0.1.0",
   "skillberry-plugin-anthropic-skill-generator>=0.1.0",
   "skillberry-plugin-kagenti-approver>=0.1.0",
-  "skillberry-plugin-sast>=0.1.0",
+  "skillberry-plugin-sast[bandit]>=0.1.0",
   "skillberry-plugin-skill-optimizer>=0.1.0",
   "skillberry-plugin-simulate>=0.1.0",
   "skillberry-plugin-provenance>=0.1.0",
   "skillberry-plugin-doc-generator>=0.1.0",
   "skillberry-plugin-dependency-tracker>=0.1.0",
   "skillberry-plugin-ask-runspace>=0.1.0",
-  "skillberry-plugin-dast>=0.1.0",
+  "skillberry-plugin-dast[hypothesis]>=0.1.0",
   "skillberry-plugin-skillssh-importer>=0.1.0",
 ]
 

--- a/src/skillberry_store/fast_api/tools_api.py
+++ b/src/skillberry_store/fast_api/tools_api.py
@@ -28,6 +28,12 @@ class AddToolFromCodeRequest(BaseModel):
     module_name: Optional[str] = None
 
 
+class UpdateToolModuleRequest(BaseModel):
+    """Body for ``PUT /tools/{uuid_or_name}/module`` — replacement module source."""
+
+    content: str
+
+
 def register_tools_api(
     app: FastAPI,
     tags: str = "tools",
@@ -255,6 +261,50 @@ def register_tools_api(
         except Exception as e:
             raise HTTPException(
                 status_code=500, detail=f"Error retrieving module file: {str(e)}"
+            )
+
+    @requires("tools", "update")
+    @app.put(
+        "/tools/{uuid_or_name}/module",
+        tags=[tags],
+        openapi_extra={"x-cli-name": "update-tool-module", "x-mcp-tool": True},
+    )
+    async def update_tool_module(
+        uuid_or_name: str, request: UpdateToolModuleRequest
+    ) -> Dict:
+        """Replace the module file content for a specific tool.
+
+        The write counterpart to ``GET /tools/{uuid_or_name}/module``. The module
+        filename is resolved from the tool's own manifest, so it is not part of
+        the request. Only the module file is written — use
+        ``PUT /tools/{uuid_or_name}`` to change metadata.
+
+        Args:
+            uuid_or_name: The UUID or name of the tool whose module to replace.
+            request: Body carrying the new module source.
+
+        Returns:
+            dict: Success message confirming the write.
+
+        Raises:
+            HTTPException: 404 if tool not found, 400 if the tool has no module
+                file to write (including MCP-packaged tools), 500 for other errors.
+        """
+        try:
+            service.set_module(uuid_or_name, request.content)
+            return {
+                "message": (
+                    f"Module for tool with UUID or name '{uuid_or_name}' "
+                    "updated successfully."
+                )
+            }
+        except KeyError as e:
+            raise HTTPException(status_code=404, detail=str(e))
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+        except Exception as e:
+            raise HTTPException(
+                status_code=500, detail=f"Error updating module file: {str(e)}"
             )
 
     @requires("tools", "delete")

--- a/src/skillberry_store/modules/file_executor.py
+++ b/src/skillberry_store/modules/file_executor.py
@@ -193,10 +193,14 @@ class FileExecutor:
         """
         Initialize the PythonExecutor with the directory path.
 
-        The executor runtime is determined by the environment variable CODE_EXEC_RUNTIME.
-        If the variable is set to "podman", the executor will use Podman.
-        If the variable is set to "docker", the executor will use Docker.
-        If the variable is not set or has an invalid value, an HTTPException will be raised.
+        This class depends on no skillberry-store global state — every input
+        arrives through this constructor — so it can be instantiated standalone
+        by a plugin that owns its own execution.
+
+        Python code is run either in-process or in a container, selected by the
+        ``execute_python_locally`` argument, which defaults to the
+        EXECUTE_PYTHON_LOCALLY environment variable. Container execution uses
+        the Docker SDK; Podman is not currently supported.
 
         Args:
             name (str): the name of the execution
@@ -223,6 +227,80 @@ class FileExecutor:
             logger.error(f"Error parsing manifest: {e}")
             raise HTTPException(status_code=400, detail=f"Error parsing manifest: {e}")
 
+    # Execution paths this executor can dispatch to. ``mcp`` is the only
+    # natively-async one; the rest are blocking calls.
+    PATH_PYTHON_LOCAL = "python-local"
+    PATH_PYTHON_DOCKER = "python-docker"
+    PATH_BASH = "bash"
+    PATH_MCP = "mcp"
+
+    def _resolve_path(self) -> str:
+        """Resolve which execution path this manifest selects.
+
+        Single source of truth for dispatch, shared by the sync and async
+        entry points so they can never disagree.
+
+        Raises:
+            HTTPException: 400 for an unsupported language or packaging format.
+        """
+        language = self.manifest.get("programming_language")
+        if language == "bash":
+            return self.PATH_BASH
+        if language != "python":
+            raise HTTPException(
+                status_code=400, detail="Unsupported programming language"
+            )
+
+        packaging = self.manifest.get("packaging_format")
+        if packaging == "code":
+            # Read dynamically: the flag may be set after construction.
+            return (
+                self.PATH_PYTHON_LOCAL
+                if self.execute_python_locally
+                else self.PATH_PYTHON_DOCKER
+            )
+        if packaging == "mcp":
+            return self.PATH_MCP
+        raise HTTPException(status_code=400, detail="Unsupported packaging format")
+
+    def execute_file_sync(self, parameters: Dict[str, Any], env_id=None) -> dict:
+        """Execute synchronously, blocking the calling thread.
+
+        The counterpart to :meth:`execute_file` for callers that manage their
+        own threading — a caller that must be able to *abandon* a hung
+        execution needs the work to happen directly in a thread it owns, which
+        ``asyncio.to_thread`` cannot provide (its pool threads are non-daemon
+        and joined at interpreter exit).
+
+        The MCP path is internally async and is driven on a private event loop
+        here, so every path is callable synchronously.
+
+        Args:
+            parameters (Dict): Execution parameters.
+            env_id: Optional environment ID for execution isolation.
+
+        Returns:
+            dict: A message with the execution result or error message.
+        """
+        logger.info(f"Executing (sync): {self.name} with parameters: {parameters}")
+        try:
+            path = self._resolve_path()
+            if path == self.PATH_PYTHON_LOCAL:
+                return self.execute_python_file_locally(parameters, env_id=env_id)
+            if path == self.PATH_PYTHON_DOCKER:
+                return self.execute_python_file_using_docker(parameters, env_id=env_id)
+            if path == self.PATH_BASH:
+                return self.execute_bash_file(parameters=parameters)
+            # PATH_MCP — natively async, so drive it on a private loop.
+            return asyncio.run(self.execute_python_file_in_mcp_server(parameters))
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.error(f"Error executing file: {e}")
+            return {
+                "error": f"Error executing file: {str(e)}",
+            }
+
     async def execute_file(self, parameters: Dict[str, Any], env_id=None) -> dict:
         """
         Executes dynamically based on manifest and parameters.
@@ -236,9 +314,14 @@ class FileExecutor:
         logger.info(f"Executing: {self.name} with parameters: {parameters}")
 
         try:
-            result = await self.based_on_programming_language(
-                parameters=parameters, env_id=env_id
-            )
+            # The MCP path stays on the caller's loop; the blocking paths are
+            # offloaded to a worker thread via the shared sync entry point.
+            if self._resolve_path() == self.PATH_MCP:
+                result = await self.execute_python_file_in_mcp_server(parameters)
+            else:
+                result = await asyncio.to_thread(
+                    self.execute_file_sync, parameters, env_id
+                )
             # If result contains an error, return it as-is
             if isinstance(result, dict) and "error" in result:
                 return result
@@ -256,6 +339,9 @@ class FileExecutor:
     def based_on_programming_language(self, parameters, env_id=None):
         """
         Switches based on the programming_language field in the manifest.
+
+        Retained for callers that predate :meth:`execute_file_sync`; dispatch
+        itself lives in :meth:`_resolve_path`.
         """
         if self.manifest.get("programming_language") == "python":
             return self.execute_python_file(parameters=parameters, env_id=env_id)

--- a/src/skillberry_store/modules/vmcp_server.py
+++ b/src/skillberry_store/modules/vmcp_server.py
@@ -2,11 +2,11 @@ import logging
 import os
 import socket
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 from prometheus_client import Counter, Histogram
 from pydantic import Field
-from typing import Annotated, Any, Callable, Dict, List, Optional, Protocol
+from typing import Annotated, Any, Callable, List, Optional, Protocol
 
 from mcp.server.fastmcp import FastMCP
 from skillberry_store.modules.object_handler import get_object_handler

--- a/src/skillberry_store/modules/vmcp_server.py
+++ b/src/skillberry_store/modules/vmcp_server.py
@@ -2,14 +2,16 @@ import logging
 import os
 import socket
 import time
+from dataclasses import dataclass, field
 
-import requests
 from prometheus_client import Counter, Histogram
 from pydantic import Field
-from typing import Annotated, Any, List, Optional
+from typing import Annotated, Any, Callable, Dict, List, Optional, Protocol
 
 from mcp.server.fastmcp import FastMCP
 from skillberry_store.modules.object_handler import get_object_handler
+
+logger = logging.getLogger(__name__)
 
 # observability - metrics for runtime tool invocation inside the VMCP server.
 # These belong here (not in the FastAPI layer) because they describe runtime
@@ -65,6 +67,119 @@ def _patch_sse_starlette_for_multi_loop() -> None:
 _patch_sse_starlette_for_multi_loop()
 
 
+class ToolSource(Protocol):
+    """Where a server gets its tools' manifests, and how it runs them.
+
+    Supplying one lets a caller own a server instance without the core
+    server's process-global state. Deliberately expressed as *what the
+    server needs* rather than as an ``ObjectHandler`` mirror: the server
+    never reads module files or resolves dependencies itself, so execution
+    strategy stays with whoever owns the content.
+    """
+
+    def get_manifest(self, uuid: str) -> dict:
+        """Return the full manifest for ``uuid``. Raise if unavailable."""
+        ...
+
+    async def execute(self, manifest: dict, parameters: dict, env_id: str) -> dict:
+        """Execute the tool described by ``manifest`` and return its result."""
+        ...
+
+
+class SnippetSource(Protocol):
+    """Where a server gets its snippets' manifests."""
+
+    def get_manifest(self, uuid: str) -> dict:
+        """Return the full manifest for ``uuid``. Raise if unavailable."""
+        ...
+
+
+@dataclass
+class InvokeRecord:
+    """One observed tool invocation, passed to a server's ``on_invoke`` hook.
+
+    Recorded for failures as well as successes — a caller observing a server
+    to find misbehaviour cares most about the calls that blew up.
+    """
+
+    tool_name: str
+    parameters: dict
+    result: Any = None
+    error: Optional[BaseException] = None
+    duration: float = 0.0
+
+    @property
+    def failed(self) -> bool:
+        return self.error is not None
+
+
+class _HandlerToolSource:
+    """Default source: the core ``ObjectHandler`` singletons and service registry.
+
+    This is the behaviour every in-process server had before sources were
+    injectable, kept verbatim — including pinning the manifest captured at
+    registration time, so that a later overwrite of the tool JSON (e.g. by an
+    MCP wrapper of the same name) cannot recurse back through the server.
+    """
+
+    def __init__(self, handler=None):
+        self.handler = handler or get_object_handler("tool")
+
+    def get_manifest(self, uuid: str) -> dict:
+        return self.handler.read_dict(uuid)
+
+    async def execute(self, manifest: dict, parameters: dict, env_id: str) -> dict:
+        from skillberry_store.modules.file_executor import FileExecutor
+        from skillberry_store.services.registry import get_service
+
+        tool_name = manifest.get("name")
+        module_name = manifest.get("module_name")
+        if not module_name:
+            raise ValueError(
+                f"Tool '{tool_name}' has no module_name in cached manifest"
+            )
+
+        tool_uuid = manifest.get("uuid")
+        if not tool_uuid:
+            raise ValueError(f"Tool '{tool_name}' has no uuid in cached manifest")
+
+        # Read the module file from the tool's UUID subdirectory.
+        module_content = self.handler.read_file(
+            tool_uuid, module_name, raw_content=True
+        )
+        if not isinstance(module_content, str):
+            raise ValueError(f"Could not read module for tool '{tool_name}'")
+
+        # Load tool dependencies recursively via the shared service method.
+        dependencies = manifest.get("dependencies", [])
+        tool_dep_ids = get_service("tool").find_dependencies(dependencies, tool_uuid)
+
+        dep_dicts = self.handler.read_dicts(list(tool_dep_ids))
+        dep_files = [
+            self.handler.read_file(m["uuid"], m["module_name"], raw_content=True)
+            for m in dep_dicts
+        ]
+
+        executor = FileExecutor(
+            name=tool_name,
+            file_content=module_content,
+            file_manifest=manifest,
+            dependent_file_contents=dep_files,
+            dependent_tools_as_dict=dep_dicts,
+        )
+        return await executor.execute_file(parameters=parameters, env_id=env_id)
+
+
+class _HandlerSnippetSource:
+    """Default snippet source: the core ``ObjectHandler`` singleton."""
+
+    def __init__(self, handler=None):
+        self.handler = handler or get_object_handler("snippet")
+
+    def get_manifest(self, uuid: str) -> dict:
+        return self.handler.read_dict(uuid)
+
+
 class VirtualMcpServer:
     """
     Represents a virtual MCP server.
@@ -88,6 +203,11 @@ class VirtualMcpServer:
         sts_url: Optional[str] = None,
         app=None,
         env_id=None,
+        tool_source: Optional[ToolSource] = None,
+        snippet_source: Optional[SnippetSource] = None,
+        serve: bool = True,
+        metrics_enabled: bool = True,
+        on_invoke: Optional[Callable[[InvokeRecord], None]] = None,
     ):
         """
         Initializes and starts a new VirtualMcpServer instance.
@@ -99,6 +219,23 @@ class VirtualMcpServer:
             tools (List[str]): A list of tool UUIDs to register with the virtual MCP server.
             snippets (List[str]): A list of snippet UUIDs to register as prompts with the virtual MCP server.
             env_id (str): A string representing the environment id to be used for this server (Optional).
+            tool_source (ToolSource): Where to read tool manifests from and how to
+                execute them. Defaults to the core ObjectHandler singletons plus
+                the service registry — pass one to own a server instance without
+                depending on that process-global state.
+            snippet_source (SnippetSource): Likewise for snippets.
+            serve (bool): When False, register nothing over HTTP: no port is
+                taken, no FastMCP instance is built and no uvicorn thread is
+                started. The server still resolves manifests and dispatches
+                ``invoke_tool`` in-process, which is all a caller needs when it
+                drives the tools itself rather than exposing them to an MCP client.
+            metrics_enabled (bool): When False, skip the process-wide Prometheus
+                metrics. Short-lived instances should disable them: the series are
+                labelled by server name, so throwaway names accumulate cardinality
+                that is never reclaimed.
+            on_invoke (Callable): Called with an :class:`InvokeRecord` after every
+                ``invoke_tool`` dispatch, successful or not. Exceptions raised by
+                the hook are logged and swallowed.
 
         Raises:
             ValueError: If the specified port is not available.
@@ -110,10 +247,33 @@ class VirtualMcpServer:
         self.sts_url = sts_url or "http://localhost:8000"
         self.app = app
         self.env_id = env_id
+        self.serve = serve
+        self.metrics_enabled = metrics_enabled
+        self.on_invoke = on_invoke
 
-        # Initialize ObjectHandlers for resolving UUIDs to objects
-        self.tools_handler = get_object_handler("tool")
-        self.snippets_handler = get_object_handler("snippet")
+        # Content + execution sources. Defaults fall back to the core
+        # singletons so an in-process server behaves exactly as before, but they
+        # are resolved *lazily*: a caller that injects a tool source and serves
+        # no snippets must never touch a core singleton at all.
+        self._tool_source = tool_source
+        self._snippet_source = snippet_source
+
+        # Cache of tool_name -> raw manifest dict, populated during
+        # _load_manifests so that invoke_tool executes the manifest pinned at
+        # registration time rather than re-reading files (which may have been
+        # overwritten by an MCP wrapper with the same name after server creation).
+        self._tool_manifests: dict = {}
+
+        if not self.serve:
+            # In-process only: no port, no FastMCP, no transport.
+            self.port = None
+            self.mcp = None
+            self._load_manifests()
+            logging.info(
+                f"VirtualMcpServer '{name}' created (in-process, no transport) "
+                f"with {len(self._tool_manifests)} tools"
+            )
+            return
 
         if port is None:
             self.port = self._find_available_port()
@@ -127,40 +287,26 @@ class VirtualMcpServer:
         # Create FastMCP instance
         self.mcp = FastMCP(name=name, port=self.port)
 
-        # Configure CORS middleware for browser access
-        # This will be passed to mcp.run() in _start_server()
-        from starlette.middleware import Middleware
-        from starlette.middleware.cors import CORSMiddleware
-
-        self.cors_middleware = [
-            Middleware(
-                CORSMiddleware,
-                allow_origins=["*"],  # Allow all origins for development
-                allow_methods=["GET", "POST", "OPTIONS"],
-                allow_headers=[
-                    "mcp-protocol-version",
-                    "mcp-session-id",
-                    "Authorization",
-                    "Content-Type",
-                    "*",  # Allow all headers
-                ],
-                expose_headers=["mcp-session-id"],
-                allow_credentials=True,
-            )
-        ]
-        logging.info("CORS middleware configured for FastMCP server")
-
-        # Cache of tool_name -> raw manifest dict, populated during _register_tools so that
-        # invoke_tool can execute code tools directly without re-reading files (which may have
-        # been overwritten by an MCP wrapper with the same name after server creation).
-        self._tool_manifests: dict = {}
-
         self._register_tools()
         self._register_prompts()
         self._start_server()
         logging.info(
             f"VirtualMcpServer '{name}' created and started on port {self.port} with {len(self.tool_uuids)} tools and {len(self.snippet_uuids)} prompts"
         )
+
+    @property
+    def tool_source(self) -> ToolSource:
+        """The injected tool source, or the core-singleton default on first use."""
+        if self._tool_source is None:
+            self._tool_source = _HandlerToolSource()
+        return self._tool_source
+
+    @property
+    def snippet_source(self) -> SnippetSource:
+        """The injected snippet source, or the core-singleton default on first use."""
+        if self._snippet_source is None:
+            self._snippet_source = _HandlerSnippetSource()
+        return self._snippet_source
 
     def _is_port_available(self, port: int) -> bool:
         """
@@ -197,6 +343,40 @@ class VirtualMcpServer:
             port += 1
         return port
 
+    def _load_manifests(self) -> dict:
+        """Resolve this server's tool UUIDs to manifests and cache them.
+
+        Pure data resolution — no FastMCP involvement — so it is usable with or
+        without a transport. Populating the cache is the *point* of this method
+        rather than a side effect of listing, which is what lets ``tool_names``
+        report reliably.
+
+        Returns:
+            dict: the cache, mapping tool name -> manifest.
+        """
+        logger.debug("Loading manifests for tool UUIDs: %s", self.tool_uuids)
+        for tool_uuid in self.tool_uuids:
+            try:
+                tool_dict = self.tool_source.get_manifest(tool_uuid)
+                tool_name = tool_dict.get("name")
+                if not tool_name:
+                    logger.warning("Tool UUID %s has no name; skipping", tool_uuid)
+                    continue
+                self._tool_manifests[tool_name] = tool_dict
+                logger.debug("Loaded tool UUID %s as '%s'", tool_uuid, tool_name)
+            except Exception as e:
+                logging.warning(f"Failed to get tool UUID {tool_uuid}: {e}")
+        logger.debug("Loaded %d tool manifest(s)", len(self._tool_manifests))
+        return self._tool_manifests
+
+    def tool_names(self) -> List[str]:
+        """Names of the tools this server serves, as registered."""
+        return list(self._tool_manifests.keys())
+
+    def tool_manifest(self, tool_name: str) -> Optional[dict]:
+        """The pinned manifest for ``tool_name``, or None if not registered."""
+        return self._tool_manifests.get(tool_name)
+
     def list_tools(self):
         """
         Lists the tools registered with the virtual MCP server.
@@ -205,41 +385,13 @@ class VirtualMcpServer:
         Returns:
             List (mcp.types.Tool): A list of tools
         """
-        print(f"DEBUG list_tools: self.tool_uuids = {self.tool_uuids}")
         tools = []
-        for tool_uuid in self.tool_uuids:
+        for tool_name, tool_dict in self._load_manifests().items():
             try:
-
-                # Try HTTP first if available
-                if self.app:
-                    # Read tool dict by UUID
-                    tool_dict = self.tools_handler.read_dict(tool_uuid)
-                    tool_name = tool_dict.get("name")
-
-                    # Cache the tool dict
-                    if tool_name:
-                        self._tool_manifests[tool_name] = tool_dict
-
-                    print(
-                        f"DEBUG list_tools: Got tool UUID {tool_uuid}, name: {tool_name}"
-                    )
-                    tools.append(self.tool_dict_to_mcp_tool(tool_dict))
-                else:
-                    # Fallback to HTTP when app is not available
-                    response = requests.get(f"{self.sts_url}/tools/{tool_uuid}")
-                    response.raise_for_status()
-                    tool_dict = response.json()
-                    tool_name = tool_dict.get("name")
-                    print(
-                        f"DEBUG list_tools: Got tool {tool_uuid} from HTTP: {tool_name}"
-                    )
-                    self._tool_manifests[tool_name] = tool_dict
-                    tools.append(self.tool_dict_to_mcp_tool(tool_dict))
-
+                tools.append(self.tool_dict_to_mcp_tool(tool_dict))
             except Exception as e:
-                logging.warning(f"Failed to get tool UUID {tool_uuid}: {e}")
-                print(f"DEBUG list_tools: Failed to get tool UUID {tool_uuid}: {e}")
-        print(f"DEBUG list_tools: Returning {len(tools)} tools")
+                logging.warning(f"Failed to convert tool '{tool_name}': {e}")
+        logger.debug("Returning %d MCP tool(s)", len(tools))
         return tools
 
     def list_snippets(self):
@@ -250,34 +402,20 @@ class VirtualMcpServer:
         Returns:
             List[dict]: A list of snippet dictionaries
         """
-        print(f"DEBUG list_snippets: self.snippet_uuids = {self.snippet_uuids}")
+        logger.debug("Loading snippet UUIDs: %s", self.snippet_uuids)
         snippets = []
         for snippet_uuid in self.snippet_uuids:
             try:
-                if self.app:
-                    # Read snippet dict by UUID
-                    snippet_dict = self.snippets_handler.read_dict(snippet_uuid)
-                    snippet_name = snippet_dict.get("name")
-
-                    print(
-                        f"DEBUG list_snippets: Got snippet UUID {snippet_uuid}, name: {snippet_name}"
-                    )
-                    snippets.append(snippet_dict)
-                else:
-                    # Fallback to HTTP when app is not available
-                    response = requests.get(f"{self.sts_url}/snippets/{snippet_uuid}")
-                    response.raise_for_status()
-                    snippet_dict = response.json()
-                    print(
-                        f"DEBUG list_snippets: Got snippet {snippet_uuid} from HTTP: {snippet_dict.get('name')}"
-                    )
-                    snippets.append(snippet_dict)
+                snippet_dict = self.snippet_source.get_manifest(snippet_uuid)
+                logger.debug(
+                    "Loaded snippet UUID %s as '%s'",
+                    snippet_uuid,
+                    snippet_dict.get("name"),
+                )
+                snippets.append(snippet_dict)
             except Exception as e:
                 logging.warning(f"Failed to get snippet UUID {snippet_uuid}: {e}")
-                print(
-                    f"DEBUG list_snippets: Failed to get snippet UUID {snippet_uuid}: {e}"
-                )
-        print(f"DEBUG list_snippets: Returning {len(snippets)} snippets")
+        logger.debug("Returning %d snippet(s)", len(snippets))
         return snippets
 
     def _register_tools(self):
@@ -498,68 +636,42 @@ class VirtualMcpServer:
             result: The result of the tool invocation.
         """
         # Record invocation attempt
-        invoke_vmcp_tool_counter.labels(
-            server_name=self.name, tool_name=tool_name
-        ).inc()
+        if self.metrics_enabled:
+            invoke_vmcp_tool_counter.labels(
+                server_name=self.name, tool_name=tool_name
+            ).inc()
         start_time = time.time()
 
         # Check if tool_name is in our cached tool names
         if tool_name not in self._tool_manifests:
             raise ValueError(f"Tool {tool_name} not found")
 
+        # Execute the manifest pinned at registration time, not whatever is on
+        # disk now: a later overwrite of the tool JSON (e.g. by an MCP wrapper
+        # with the same name) would otherwise recurse back through this server.
+        tool_dict = self._tool_manifests.get(tool_name)
+        if tool_dict is None:
+            raise ValueError(f"No cached manifest for tool '{tool_name}'")
+
         try:
-            from skillberry_store.modules.file_executor import FileExecutor
-            from skillberry_store.services.registry import get_service
-
-            # Use the manifest cached at server creation time so that a later overwrite of the
-            # tool JSON file (e.g. by an MCP wrapper with the same name) cannot cause
-            # infinite recursion back through this server.
-            tool_dict = self._tool_manifests.get(tool_name)
-            if tool_dict is None:
-                raise ValueError(f"No cached manifest for tool '{tool_name}'")
-
-            module_name = tool_dict.get("module_name")
-            if not module_name:
-                raise ValueError(
-                    f"Tool '{tool_name}' has no module_name in cached manifest"
+            result = await self.tool_source.execute(tool_dict, parameters, env_id)
+        except Exception as e:
+            logging.error(
+                f"Error invoking tool {tool_name} on VMCP server {self.name}: {e}"
+            )
+            self._notify_invoke(
+                InvokeRecord(
+                    tool_name=tool_name,
+                    parameters=parameters,
+                    error=e,
+                    duration=time.time() - start_time,
                 )
-
-            tool_uuid = tool_dict.get("uuid")
-            if not tool_uuid:
-                raise ValueError(f"Tool '{tool_name}' has no uuid in cached manifest")
-
-            # Use the object handler to read the module file from the tool's UUID subdirectory
-            module_content = self.tools_handler.read_file(
-                tool_uuid, module_name, raw_content=True
             )
-            if not isinstance(module_content, str):
-                raise ValueError(f"Could not read module for tool '{tool_name}'")
+            raise
 
-            # Load tool dependencies recursively via the shared service method.
-            dependencies = tool_dict.get("dependencies", [])
-            tool_dep_ids = get_service("tool").find_dependencies(
-                dependencies, tool_uuid
-            )
-
-            dep_dicts = self.tools_handler.read_dicts(list(tool_dep_ids))
-            dep_files = [
-                self.tools_handler.read_file(
-                    m["uuid"], m["module_name"], raw_content=True
-                )
-                for m in dep_dicts
-            ]
-
-            executor = FileExecutor(
-                name=tool_name,
-                file_content=module_content,
-                file_manifest=tool_dict,
-                dependent_file_contents=dep_files,
-                dependent_tools_as_dict=dep_dicts,
-            )
-            result = await executor.execute_file(parameters=parameters, env_id=env_id)
-
-            # Record successful execution metrics
-            duration = time.time() - start_time
+        # Record successful execution metrics
+        duration = time.time() - start_time
+        if self.metrics_enabled:
             invoke_successfully_vmcp_tool_counter.labels(
                 server_name=self.name, tool_name=tool_name
             ).inc()
@@ -567,12 +679,31 @@ class VirtualMcpServer:
                 server_name=self.name, tool_name=tool_name
             ).observe(duration)
 
-            return result
-        except Exception as e:
-            logging.error(
-                f"Error invoking tool {tool_name} on VMCP server {self.name}: {e}"
+        self._notify_invoke(
+            InvokeRecord(
+                tool_name=tool_name,
+                parameters=parameters,
+                result=result,
+                duration=duration,
             )
-            raise
+        )
+        return result
+
+    def _notify_invoke(self, record: InvokeRecord) -> None:
+        """Hand one invocation to the ``on_invoke`` hook, if any.
+
+        An observer must never be able to break dispatch, so its exceptions are
+        logged and dropped.
+        """
+        if self.on_invoke is None:
+            return
+        try:
+            self.on_invoke(record)
+        except Exception as e:
+            logging.warning(
+                f"on_invoke hook failed for tool {record.tool_name} "
+                f"on VMCP server {self.name}: {e}"
+            )
 
     def tool_dict_to_mcp_tool(self, tool_dict: dict):
         """
@@ -701,6 +832,14 @@ class VirtualMcpServer:
                         f"VMCP server thread '{self.name}' did not stop within "
                         "timeout; leaving as daemon thread."
                     )
+
+    def __enter__(self) -> "VirtualMcpServer":
+        """Support ``with VirtualMcpServer(...) as server:`` so a served instance
+        always releases its port, even if the caller raises."""
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.stop()
 
     def to_dict(self):
         """

--- a/src/skillberry_store/plugins/base.py
+++ b/src/skillberry_store/plugins/base.py
@@ -146,6 +146,15 @@ class PluginBase(ABC):
         self._store_api = store_api
     
     @property
+    def store_available(self) -> bool:
+        """Whether the store API has been injected yet.
+
+        Use this to branch on availability; ``store`` raises when it is absent,
+        so it cannot answer the question itself.
+        """
+        return self._store_api is not None
+
+    @property
     def store(self) -> Any:
         """Access to store API for querying/updating content."""
         if self._store_api is None:

--- a/src/skillberry_store/plugins/store_api.py
+++ b/src/skillberry_store/plugins/store_api.py
@@ -6,8 +6,25 @@ for plugins without exposing internal implementation details.
 
 from typing import Any, Dict, List, Optional
 import logging
+import warnings
 
 logger = logging.getLogger(__name__)
+
+_HANDLER_PROPERTY_DEPRECATION = (
+    "StoreAPI.{name} returns the raw ObjectHandler and is deprecated for plugin "
+    "use: it exposes the whole persistence layer, not a supported interface. Use "
+    "the named accessors instead — get_tool_module()/update_tool_module() for "
+    "module source, and update_tool()/update_skill()/update_snippet() to write a "
+    "complete object."
+)
+
+
+def _warn_handler_property(name: str) -> None:
+    warnings.warn(
+        _HANDLER_PROPERTY_DEPRECATION.format(name=name),
+        DeprecationWarning,
+        stacklevel=3,
+    )
 
 
 class StoreAPI:
@@ -22,7 +39,12 @@ class StoreAPI:
 
     @property
     def tools(self):
-        """Expose tools handler for testing/plugin access."""
+        """Deprecated: the raw tools ObjectHandler.
+
+        Retained for out-of-tree plugins and for test injection. In-tree callers
+        use the named accessors; see :func:`_warn_handler_property`.
+        """
+        _warn_handler_property("tools")
         # For testing: check if attribute was set directly (bypassing property)
         if '_tools' in self.__dict__:
             return self._tools
@@ -38,7 +60,12 @@ class StoreAPI:
 
     @property
     def skills(self):
-        """Expose skills handler for testing/plugin access."""
+        """Deprecated: the raw skills ObjectHandler.
+
+        Retained for out-of-tree plugins and for test injection. In-tree callers
+        use the named accessors; see :func:`_warn_handler_property`.
+        """
+        _warn_handler_property("skills")
         # For testing: check if attribute was set directly (bypassing property)
         if '_skills' in self.__dict__:
             return self._skills
@@ -54,7 +81,12 @@ class StoreAPI:
 
     @property
     def snippets(self):
-        """Expose snippets handler for testing/plugin access."""
+        """Deprecated: the raw snippets ObjectHandler.
+
+        Retained for out-of-tree plugins and for test injection. In-tree callers
+        use the named accessors; see :func:`_warn_handler_property`.
+        """
+        _warn_handler_property("snippets")
         # For testing: check if attribute was set directly (bypassing property)
         if '_snippets' in self.__dict__:
             return self._snippets

--- a/src/skillberry_store/plugins/store_api.py
+++ b/src/skillberry_store/plugins/store_api.py
@@ -89,6 +89,57 @@ class StoreAPI:
         # ``narrow``, so opt back into ``full`` here.
         return self.tools_service.list_all(filter_criteria, fields="full")
 
+    def get_tool_module(self, uuid_or_name: str) -> Optional[str]:
+        """Return a tool's module source, or None if unavailable.
+
+        Prefer this over reaching for ``store.tools.read_file(...)``: it needs
+        no filename, and for MCP-packaged tools it returns the generated stub
+        instead of failing (there is no stored module file for those).
+        """
+        if not self.tools_service:
+            return None
+        try:
+            return self.tools_service.get_module(uuid_or_name)
+        except KeyError:
+            return None
+        except Exception as e:
+            logger.error(f"Failed to read module for {uuid_or_name}: {e}")
+            return None
+
+    def update_tool_module(self, uuid_or_name: str, content: str) -> bool:
+        """Replace a tool's module source. Returns False if it could not be written."""
+        if not self.tools_service:
+            return False
+        try:
+            self.tools_service.set_module(uuid_or_name, content)
+            return True
+        except Exception as e:
+            logger.error(f"Failed to write module for {uuid_or_name}: {e}")
+            return False
+
+    async def execute_tool(
+        self,
+        uuid_or_name: str,
+        parameters: Optional[Dict[str, Any]] = None,
+        env_id: str = "",
+    ) -> Dict[str, Any]:
+        """Execute a tool through the store's own execution path.
+
+        Resolves dependencies and runs the tool exactly as the REST
+        ``/tools/{uuid}/execute`` endpoint does, so callers do not have to
+        assemble execution inputs themselves.
+
+        Raises:
+            RuntimeError: If the tools service is unavailable, or the tool
+                reported an execution error.
+            KeyError: If the tool was not found.
+        """
+        if not self.tools_service:
+            raise RuntimeError("Tools service not available")
+        return await self.tools_service.execute(
+            uuid_or_name, parameters or {}, env_id=env_id
+        )
+
     def update_tool_tags(self, uuid: str, tags: List[str]) -> bool:
         if not self.tools_service:
             return False
@@ -129,7 +180,9 @@ class StoreAPI:
 
     def update_tool(self, uuid: str, tool_data: Dict[str, Any]) -> bool:
         """Write a complete tool object to the store."""
-        handler = self.tools
+        # Deliberately not via the public ``tools`` property: that accessor is
+        # deprecated for plugin use, and StoreAPI must not trip its own warning.
+        handler = self.tools_service.handler if self.tools_service else None
         if not handler:
             return False
         try:
@@ -210,7 +263,9 @@ class StoreAPI:
 
     def update_skill(self, uuid: str, skill_data: Dict[str, Any]) -> bool:
         """Write a complete skill object to the store."""
-        handler = self.skills
+        # Deliberately not via the public ``skills`` property: that accessor is
+        # deprecated for plugin use, and StoreAPI must not trip its own warning.
+        handler = self.skills_service.handler if self.skills_service else None
         if not handler:
             return False
         try:
@@ -276,7 +331,9 @@ class StoreAPI:
 
     def update_snippet(self, uuid: str, snippet_data: Dict[str, Any]) -> bool:
         """Write a complete snippet object to the store."""
-        handler = self.snippets
+        # Deliberately not via the public ``snippets`` property: that accessor is
+        # deprecated for plugin use, and StoreAPI must not trip its own warning.
+        handler = self.snippets_service.handler if self.snippets_service else None
         if not handler:
             return False
         try:

--- a/src/skillberry_store/services/tools_service.py
+++ b/src/skillberry_store/services/tools_service.py
@@ -41,6 +41,10 @@ get_tool_module_counter = Counter(
     f"{prom_prefix}get_tool_module_counter",
     "Count number of tool module get operations",
 )
+set_tool_module_counter = Counter(
+    f"{prom_prefix}set_tool_module_counter",
+    "Count number of tool module set operations",
+)
 delete_tool_counter = Counter(
     f"{prom_prefix}delete_tool_counter", "Count number of tool delete operations"
 )
@@ -435,6 +439,43 @@ class ToolsService:
             raise
         except Exception as e:
             logger.error(f"Error retrieving module for '{uuid_or_name}': {e}")
+            raise
+
+    def set_module(self, uuid_or_name: str, content: str) -> None:
+        """Replace the module file content for a code-packaged tool.
+
+        The write counterpart to :meth:`get_module`. The module filename is
+        resolved from the tool's own manifest, so callers do not need to know
+        it.
+
+        Args:
+            uuid_or_name: Tool UUID or name.
+            content: New module source to persist.
+
+        Raises:
+            KeyError: If the tool is not found.
+            ValueError: If the tool has no module file to write — which includes
+                MCP-packaged tools, whose module content is synthesized on read
+                rather than stored.
+        """
+        set_tool_module_counter.inc()
+        try:
+            uuid = self._resolve_uuid(uuid_or_name)
+            with self.handler.read_lock(uuid):
+                tool = self.handler.read_dict(uuid)
+                if tool.get("packaging_format") == "mcp":
+                    raise ValueError(
+                        f"Tool '{uuid_or_name}' is MCP-packaged and has no "
+                        "stored module file to write"
+                    )
+                module_name = tool.get("module_name")
+                if not module_name:
+                    raise ValueError(f"Tool '{uuid_or_name}' has no module file")
+                self.handler.write_file(uuid, module_name, content)
+        except (KeyError, ValueError):
+            raise
+        except Exception as e:
+            logger.error(f"Error writing module for '{uuid_or_name}': {e}")
             raise
 
     def list_all(

--- a/src/skillberry_store/standalone/__init__.py
+++ b/src/skillberry_store/standalone/__init__.py
@@ -1,0 +1,22 @@
+"""Store components that plugins may instantiate privately.
+
+Everything re-exported here is safe for a plugin to construct and own: it takes
+its inputs through its constructor and does not require the core server's
+process-global state (the service registry, the shared ``ObjectHandler``
+singletons, or a running FastAPI app).
+
+Plugins should import from here rather than from ``skillberry_store.modules.*``,
+which is internal and offers no such guarantee.
+
+- :class:`FileExecutor` — runs a single tool's code, given the source and a
+  manifest. Depends on no store state at all. Use
+  :meth:`FileExecutor.execute_file_sync` when you need to bound or abandon the
+  execution from a thread you own; ``execute_file`` is the async equivalent.
+
+"""
+
+from skillberry_store.modules.file_executor import FileExecutor
+
+__all__ = [
+    "FileExecutor",
+]

--- a/src/skillberry_store/standalone/__init__.py
+++ b/src/skillberry_store/standalone/__init__.py
@@ -13,10 +13,26 @@ which is internal and offers no such guarantee.
   :meth:`FileExecutor.execute_file_sync` when you need to bound or abandon the
   execution from a thread you own; ``execute_file`` is the async equivalent.
 
+- :class:`VirtualMcpServer` — serves a set of tools over MCP. Pass a
+  ``tool_source`` to supply manifests and execution yourself (otherwise it falls
+  back to the core singletons), ``serve=False`` for in-process dispatch with no
+  port or transport, ``on_invoke=`` to observe every call including failures, and
+  ``metrics_enabled=False`` to keep a short-lived instance out of the process
+  metric series.
 """
 
 from skillberry_store.modules.file_executor import FileExecutor
+from skillberry_store.modules.vmcp_server import (
+    InvokeRecord,
+    SnippetSource,
+    ToolSource,
+    VirtualMcpServer,
+)
 
 __all__ = [
     "FileExecutor",
+    "InvokeRecord",
+    "SnippetSource",
+    "ToolSource",
+    "VirtualMcpServer",
 ]

--- a/src/skillberry_store/tests/fast_api/test_tools_module_api.py
+++ b/src/skillberry_store/tests/fast_api/test_tools_module_api.py
@@ -1,0 +1,97 @@
+"""REST coverage for the tool module file endpoints.
+
+``GET /tools/{uuid_or_name}/module`` already existed; ``PUT`` is its write
+counterpart. Both are exercised against a real ``ToolsService`` backed by a
+mocked ``ObjectHandler``, so the service's error taxonomy (``KeyError`` for a
+missing tool, ``ValueError`` for a tool with nothing to write) is checked
+together with the status codes it maps to.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from skillberry_store.fast_api.tools_api import register_tools_api
+from skillberry_store.services.tools_service import ToolsService
+
+
+def _make_client(tool=None):
+    app = FastAPI()
+    handler = MagicMock()
+    handler.descriptions = None
+    handler.resolve_to_uuid_or_error.return_value = "cccc-3333"
+    handler.read_dict.return_value = tool if tool is not None else {
+        "uuid": "cccc-3333",
+        "name": "t1",
+        "module_name": "t1.py",
+        "packaging_format": "code",
+    }
+    handler.read_file.return_value = "def hello(): pass"
+    register_tools_api(app, service=ToolsService(handler))
+    return TestClient(app), handler
+
+
+def test_get_module_returns_plain_text():
+    client, _ = _make_client()
+
+    response = client.get("/tools/t1/module")
+
+    assert response.status_code == 200
+    assert response.text == "def hello(): pass"
+    assert response.headers["content-type"].startswith("text/plain")
+
+
+def test_put_module_writes_resolved_filename():
+    """The caller sends only content; the filename comes from the manifest."""
+    client, handler = _make_client()
+
+    response = client.put("/tools/t1/module", json={"content": "print('fixed')\n"})
+
+    assert response.status_code == 200
+    assert "updated successfully" in response.json()["message"]
+    handler.write_file.assert_called_once_with(
+        "cccc-3333", "t1.py", "print('fixed')\n"
+    )
+
+
+def test_put_module_missing_tool_is_404():
+    client, handler = _make_client()
+    handler.resolve_to_uuid_or_error.side_effect = HTTPException(
+        status_code=404, detail="not found"
+    )
+
+    response = client.put("/tools/nope/module", json={"content": "x"})
+
+    assert response.status_code == 404
+    handler.write_file.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "tool,expected_detail",
+    [
+        (
+            {"uuid": "cccc-3333", "name": "t1", "packaging_format": "mcp"},
+            "MCP-packaged",
+        ),
+        ({"uuid": "cccc-3333", "name": "t1"}, "no module file"),
+    ],
+    ids=["mcp_packaged", "no_module_name"],
+)
+def test_put_module_without_writable_module_is_400(tool, expected_detail):
+    """A tool that exists but has no stored module is a bad request, not a 404."""
+    client, handler = _make_client(tool=tool)
+
+    response = client.put("/tools/t1/module", json={"content": "x"})
+
+    assert response.status_code == 400
+    assert expected_detail in response.json()["detail"]
+    handler.write_file.assert_not_called()
+
+
+def test_put_module_requires_content_field():
+    """The body is a model, so a missing field is a 422 from validation."""
+    client, _ = _make_client()
+
+    assert client.put("/tools/t1/module", json={}).status_code == 422

--- a/src/skillberry_store/tests/modules/test_file_executor_sync.py
+++ b/src/skillberry_store/tests/modules/test_file_executor_sync.py
@@ -1,0 +1,194 @@
+"""Coverage for FileExecutor's dispatch resolution and synchronous entry point.
+
+``execute_file_sync`` exists for callers that manage their own threading and
+must be able to abandon a hung execution — ``asyncio.to_thread``'s pool threads
+are non-daemon and joined at interpreter exit, so work offloaded there cannot be
+walked away from. Both entry points share ``_resolve_path`` so they cannot
+disagree about which backend a manifest selects.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from skillberry_store.modules.file_executor import FileExecutor
+
+ADD_SOURCE = """
+def add(a: int, b: int) -> int:
+    '''Adds two numbers.
+
+    Args:
+        a (int): first.
+        b (int): second.
+
+    Returns:
+        int: the sum.
+    '''
+    return a + b
+"""
+
+
+def _executor(*, language="python", packaging="code", locally=True, name="add"):
+    return FileExecutor(
+        name=name,
+        file_content=ADD_SOURCE,
+        file_manifest={
+            "name": name,
+            "module_name": f"{name}.py",
+            "programming_language": language,
+            "packaging_format": packaging,
+        },
+        execute_python_locally=locally,
+    )
+
+
+# ── _resolve_path ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "language,packaging,locally,expected",
+    [
+        ("python", "code", True, FileExecutor.PATH_PYTHON_LOCAL),
+        ("python", "code", False, FileExecutor.PATH_PYTHON_DOCKER),
+        ("python", "mcp", True, FileExecutor.PATH_MCP),
+        ("bash", "code", True, FileExecutor.PATH_BASH),
+    ],
+    ids=["python_local", "python_docker", "mcp", "bash"],
+)
+def test_resolve_path_covers_every_backend(language, packaging, locally, expected):
+    ex = _executor(language=language, packaging=packaging, locally=locally)
+    assert ex._resolve_path() == expected
+
+
+def test_resolve_path_reads_locally_flag_dynamically():
+    """The flag may be flipped after construction; dispatch must follow."""
+    ex = _executor(locally=False)
+    assert ex._resolve_path() == FileExecutor.PATH_PYTHON_DOCKER
+    ex.execute_python_locally = True
+    assert ex._resolve_path() == FileExecutor.PATH_PYTHON_LOCAL
+
+
+def test_resolve_path_rejects_unknown_language():
+    ex = _executor(language="rust")
+    with pytest.raises(HTTPException) as exc:
+        ex._resolve_path()
+    assert exc.value.status_code == 400
+    assert "programming language" in exc.value.detail
+
+
+def test_resolve_path_rejects_unknown_packaging():
+    ex = _executor(packaging="wheel")
+    with pytest.raises(HTTPException) as exc:
+        ex._resolve_path()
+    assert exc.value.status_code == 400
+    assert "packaging format" in exc.value.detail
+
+
+# ── execute_file_sync ─────────────────────────────────────────────────────────
+
+
+def test_sync_and_async_agree_for_local_python():
+    """The two entry points must produce identical results for the same input."""
+    import asyncio
+
+    sync_result = _executor().execute_file_sync({"a": 5, "b": 8})
+    async_result = asyncio.run(_executor().execute_file({"a": 5, "b": 8}))
+
+    assert sync_result["return value"] == "13"
+    assert sync_result == async_result
+
+
+def test_sync_dispatches_to_docker_when_not_local():
+    ex = _executor(locally=False)
+    with patch.object(
+        ex, "execute_python_file_using_docker", return_value={"return value": "ok"}
+    ) as docker:
+        assert ex.execute_file_sync({"a": 1}, env_id="e") == {"return value": "ok"}
+    docker.assert_called_once_with({"a": 1}, env_id="e")
+
+
+def test_sync_dispatches_to_bash():
+    ex = _executor(language="bash")
+    with patch.object(
+        ex, "execute_bash_file", return_value={"return value": "ok"}
+    ) as bash:
+        assert ex.execute_file_sync({"a": 1}) == {"return value": "ok"}
+    bash.assert_called_once_with(parameters={"a": 1})
+
+
+def test_sync_drives_the_mcp_path_on_a_private_loop():
+    """MCP is natively async; the sync entry point still has to serve it."""
+    ex = _executor(packaging="mcp")
+
+    async def _fake(parameters):
+        return {"return value": f"mcp:{parameters}"}
+
+    with patch.object(ex, "execute_python_file_in_mcp_server", _fake):
+        assert ex.execute_file_sync({"a": 1}) == {"return value": "mcp:{'a': 1}"}
+
+
+def test_sync_reports_backend_failure_as_error_dict():
+    ex = _executor()
+    with patch.object(
+        ex, "execute_python_file_locally", side_effect=RuntimeError("boom")
+    ):
+        result = ex.execute_file_sync({"a": 1})
+    assert "boom" in result["error"]
+
+
+def test_sync_propagates_http_exception():
+    """A 400 from dispatch is a caller error and must not be flattened."""
+    ex = _executor(language="rust")
+    with pytest.raises(HTTPException):
+        ex.execute_file_sync({"a": 1})
+
+
+# ── execute_file delegation ───────────────────────────────────────────────────
+
+
+def test_async_keeps_mcp_on_the_callers_loop():
+    """The MCP session must not be moved to a worker thread's loop."""
+    import asyncio
+
+    ex = _executor(packaging="mcp")
+    seen = {}
+
+    async def _fake(parameters):
+        seen["loop"] = asyncio.get_running_loop()
+        return {"return value": "ok"}
+
+    async def _run():
+        with patch.object(ex, "execute_python_file_in_mcp_server", _fake):
+            result = await ex.execute_file({"a": 1})
+        return result, asyncio.get_running_loop()
+
+    result, caller_loop = asyncio.run(_run())
+    assert result == {"return value": "ok"}
+    assert seen["loop"] is caller_loop
+
+
+def test_async_offloads_blocking_paths_to_a_worker_thread():
+    import asyncio
+    import threading
+
+    ex = _executor()
+    seen = {}
+
+    def _fake(parameters, env_id=None):
+        seen["thread"] = threading.current_thread()
+        return {"return value": "ok"}
+
+    async def _run():
+        with patch.object(ex, "execute_python_file_locally", _fake):
+            return await ex.execute_file({"a": 1})
+
+    assert asyncio.run(_run()) == {"return value": "ok"}
+    assert seen["thread"] is not threading.main_thread()
+
+
+def test_standalone_surface_reexports_file_executor():
+    """Plugins import from ``standalone``, not from ``modules``."""
+    from skillberry_store.standalone import FileExecutor as Exported
+
+    assert Exported is FileExecutor

--- a/src/skillberry_store/tests/modules/test_vmcp_server_standalone.py
+++ b/src/skillberry_store/tests/modules/test_vmcp_server_standalone.py
@@ -1,0 +1,335 @@
+"""Coverage for VirtualMcpServer's standalone (injected-source) mode.
+
+A caller that owns its own server instance must be able to construct one
+without the core server's process-global state: no ``ObjectHandler``
+singletons, no service registry, no shared port range, and no entries in the
+process-wide metric series. These tests assert that — the singleton accessors
+are poisoned so that touching them fails loudly rather than silently working
+because an earlier test initialised them.
+"""
+
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from skillberry_store.modules import vmcp_server as vmcp_mod
+from skillberry_store.modules.vmcp_server import InvokeRecord, VirtualMcpServer
+
+TOOL_A = {
+    "uuid": "uuid-a",
+    "name": "alpha",
+    "module_name": "alpha.py",
+    "packaging_format": "code",
+    "programming_language": "python",
+    "params": {"type": "object", "properties": {}, "required": []},
+}
+TOOL_B = {
+    "uuid": "uuid-b",
+    "name": "beta",
+    "module_name": "beta.py",
+    "packaging_format": "code",
+    "programming_language": "python",
+    "params": {"type": "object", "properties": {}, "required": []},
+}
+
+
+class FakeToolSource:
+    """A ToolSource backed by a dict — no store, no filesystem, no registry."""
+
+    def __init__(self, tools=None, result=None, error=None):
+        self._tools = {t["uuid"]: t for t in (tools or [TOOL_A, TOOL_B])}
+        self._result = result if result is not None else {"return value": "ok"}
+        self._error = error
+        self.executed = []
+
+    def get_manifest(self, uuid):
+        return dict(self._tools[uuid])
+
+    async def execute(self, manifest, parameters, env_id):
+        self.executed.append((manifest.get("name"), parameters, env_id))
+        if self._error is not None:
+            raise self._error
+        return self._result
+
+
+@pytest.fixture(autouse=True)
+def _poison_singletons(monkeypatch):
+    """Fail loudly if standalone construction reaches for core singletons."""
+
+    def _forbidden(*args, **kwargs):  # pragma: no cover - only on regression
+        raise AssertionError("standalone server must not touch core singletons")
+
+    monkeypatch.setattr(vmcp_mod, "get_object_handler", _forbidden)
+    import skillberry_store.services.registry as registry_mod
+
+    monkeypatch.setattr(registry_mod, "get_service", _forbidden)
+
+
+def _server(source=None, **kwargs):
+    kwargs.setdefault("metrics_enabled", False)
+    return VirtualMcpServer(
+        name="standalone-test",
+        description="",
+        port=None,
+        tools=["uuid-a", "uuid-b"],
+        tool_source=source or FakeToolSource(),
+        serve=False,
+        **kwargs,
+    )
+
+
+# ── construction ──────────────────────────────────────────────────────────────
+
+
+def test_manifests_load_without_any_singletons():
+    server = _server()
+    assert server.tool_names() == ["alpha", "beta"]
+    assert server.tool_manifest("alpha")["uuid"] == "uuid-a"
+    assert server.tool_manifest("absent") is None
+
+
+def test_serve_false_takes_no_port_and_starts_no_thread():
+    """No transport means nothing to leak: no port held, no uvicorn thread."""
+    before = set(threading.enumerate())
+
+    server = _server()
+
+    assert server.port is None
+    assert server.mcp is None
+    assert getattr(server, "server_thread", None) is None
+    assert set(threading.enumerate()) == before
+
+
+def test_stop_is_a_noop_without_a_transport():
+    server = _server()
+    server.stop()  # must not raise
+
+
+def test_context_manager_stops_the_server():
+    with _server() as server:
+        assert server.tool_names()
+
+
+def test_unresolvable_tool_is_skipped_not_fatal():
+    class PartialSource(FakeToolSource):
+        def get_manifest(self, uuid):
+            if uuid == "uuid-b":
+                raise KeyError("gone")
+            return super().get_manifest(uuid)
+
+    server = _server(source=PartialSource())
+    assert server.tool_names() == ["alpha"]
+
+
+def test_manifest_without_a_name_is_skipped():
+    source = FakeToolSource(tools=[TOOL_A, {"uuid": "uuid-b"}])
+    server = _server(source=source)
+    assert server.tool_names() == ["alpha"]
+
+
+def test_list_tools_maps_manifests_to_mcp_tools():
+    tools = _server().list_tools()
+    assert sorted(t.name for t in tools) == ["alpha", "beta"]
+
+
+def test_list_tools_skips_a_manifest_it_cannot_convert():
+    """A manifest missing ``params`` must not take out the whole listing."""
+    broken = {"uuid": "uuid-b", "name": "beta", "module_name": "beta.py"}
+    server = _server(source=FakeToolSource(tools=[TOOL_A, broken]))
+
+    tools = server.list_tools()
+
+    assert [t.name for t in tools] == ["alpha"]
+    # still registered for dispatch, even though it has no MCP schema
+    assert server.tool_names() == ["alpha", "beta"]
+
+
+# ── dispatch ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_invoke_tool_delegates_to_the_source():
+    source = FakeToolSource()
+    server = _server(source=source)
+
+    result = await server.invoke_tool("alpha", {"x": 1}, "env-1")
+
+    assert result == {"return value": "ok"}
+    assert source.executed == [("alpha", {"x": 1}, "env-1")]
+
+
+@pytest.mark.asyncio
+async def test_invoke_tool_passes_the_pinned_manifest():
+    """Dispatch uses the manifest captured at registration, not a fresh read."""
+    source = FakeToolSource()
+    server = _server(source=source)
+    source._tools["uuid-a"] = dict(TOOL_A, name="alpha", module_name="swapped.py")
+
+    await server.invoke_tool("alpha", {}, "")
+
+    assert server.tool_manifest("alpha")["module_name"] == "alpha.py"
+
+
+@pytest.mark.asyncio
+async def test_invoke_unknown_tool_raises():
+    with pytest.raises(ValueError, match="not found"):
+        await _server().invoke_tool("nope", {}, "")
+
+
+# ── observation hook ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_on_invoke_records_success():
+    seen = []
+    server = _server(on_invoke=seen.append)
+
+    await server.invoke_tool("alpha", {"x": 1}, "")
+
+    assert len(seen) == 1
+    record = seen[0]
+    assert isinstance(record, InvokeRecord)
+    assert record.tool_name == "alpha"
+    assert record.parameters == {"x": 1}
+    assert record.result == {"return value": "ok"}
+    assert record.failed is False
+
+
+@pytest.mark.asyncio
+async def test_on_invoke_records_failure():
+    """A raising tool must still be observed — those are the interesting calls."""
+    seen = []
+    boom = RuntimeError("boom")
+    server = _server(source=FakeToolSource(error=boom), on_invoke=seen.append)
+
+    with pytest.raises(RuntimeError):
+        await server.invoke_tool("alpha", {"x": 1}, "")
+
+    assert len(seen) == 1
+    assert seen[0].failed is True
+    assert seen[0].error is boom
+    assert seen[0].result is None
+
+
+@pytest.mark.asyncio
+async def test_a_throwing_hook_does_not_break_dispatch():
+    def _bad_hook(record):
+        raise ValueError("observer is broken")
+
+    server = _server(on_invoke=_bad_hook)
+
+    assert await server.invoke_tool("alpha", {}, "") == {"return value": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_a_throwing_hook_does_not_mask_the_original_error():
+    def _bad_hook(record):
+        raise ValueError("observer is broken")
+
+    server = _server(source=FakeToolSource(error=RuntimeError("boom")),
+                     on_invoke=_bad_hook)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await server.invoke_tool("alpha", {}, "")
+
+
+# ── metrics ───────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_metrics_disabled_records_nothing():
+    """Throwaway server names must not accumulate Prometheus label cardinality."""
+    server = _server()
+
+    with patch.object(vmcp_mod, "invoke_vmcp_tool_counter") as attempted, patch.object(
+        vmcp_mod, "invoke_successfully_vmcp_tool_counter"
+    ) as succeeded:
+        await server.invoke_tool("alpha", {}, "")
+
+    attempted.labels.assert_not_called()
+    succeeded.labels.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_metrics_enabled_records_both_counters():
+    server = _server(metrics_enabled=True)
+
+    with patch.object(vmcp_mod, "invoke_vmcp_tool_counter") as attempted, patch.object(
+        vmcp_mod, "invoke_successfully_vmcp_tool_counter"
+    ) as succeeded, patch.object(vmcp_mod, "invoke_successfully_vmcp_tool_latency"):
+        await server.invoke_tool("alpha", {}, "")
+
+    attempted.labels.assert_called_once_with(
+        server_name="standalone-test", tool_name="alpha"
+    )
+    succeeded.labels.assert_called_once_with(
+        server_name="standalone-test", tool_name="alpha"
+    )
+
+
+# ── default (in-process) source ────────────────────────────────────────────────
+
+
+def test_default_source_still_uses_the_core_handler(monkeypatch):
+    """Passing no source must behave exactly as before: core singletons."""
+    handler = MagicMock()
+    handler.read_dict.return_value = TOOL_A
+    monkeypatch.setattr(vmcp_mod, "get_object_handler", lambda _name: handler)
+
+    source = vmcp_mod._HandlerToolSource()
+
+    assert source.get_manifest("uuid-a")["name"] == "alpha"
+    handler.read_dict.assert_called_once_with("uuid-a")
+
+
+@pytest.mark.asyncio
+async def test_default_source_assembles_dependencies_via_the_service(monkeypatch):
+    """The in-process path keeps using the store's own transitive-closure walk."""
+    handler = MagicMock()
+    handler.read_file.return_value = "def alpha(): pass"
+    handler.read_dicts.return_value = [
+        {"uuid": "dep-1", "name": "dep", "module_name": "dep.py"}
+    ]
+    tools_service = MagicMock()
+    tools_service.find_dependencies.return_value = {"dep-1"}
+
+    import skillberry_store.services.registry as registry_mod
+
+    monkeypatch.setattr(registry_mod, "get_service", lambda _t: tools_service)
+
+    source = vmcp_mod._HandlerToolSource(handler=handler)
+    manifest = dict(TOOL_A, dependencies=["dep-1"])
+
+    with patch.object(vmcp_mod, "FastMCP"), patch(
+        "skillberry_store.modules.file_executor.FileExecutor.execute_file"
+    ) as execute_file:
+        execute_file.return_value = {"return value": "ok"}
+        result = await source.execute(manifest, {"x": 1}, "env-1")
+
+    assert result == {"return value": "ok"}
+    tools_service.find_dependencies.assert_called_once_with(["dep-1"], "uuid-a")
+
+
+@pytest.mark.asyncio
+async def test_default_source_rejects_manifest_without_module_name(monkeypatch):
+    handler = MagicMock()
+    source = vmcp_mod._HandlerToolSource(handler=handler)
+
+    with pytest.raises(ValueError, match="no module_name"):
+        await source.execute({"uuid": "uuid-a", "name": "alpha"}, {}, "")
+
+
+@pytest.mark.asyncio
+async def test_default_source_rejects_manifest_without_uuid():
+    handler = MagicMock()
+    source = vmcp_mod._HandlerToolSource(handler=handler)
+
+    with pytest.raises(ValueError, match="no uuid"):
+        await source.execute({"name": "alpha", "module_name": "a.py"}, {}, "")
+
+
+def test_standalone_surface_reexports_the_server():
+    from skillberry_store.standalone import VirtualMcpServer as Exported
+
+    assert Exported is VirtualMcpServer

--- a/src/skillberry_store/tests/plugins/test_base.py
+++ b/src/skillberry_store/tests/plugins/test_base.py
@@ -158,3 +158,40 @@ def test_plugin_base_requires_all_abstract_methods():
         IncompletePlugin()
 
 # Made with Bob
+
+
+def test_plugin_base_store_available():
+    """``store_available`` answers what ``store`` cannot: is the API injected?
+
+    Plugins previously read the private ``_store_api`` to branch on this,
+    because ``store`` raises rather than reporting.
+    """
+    from skillberry_store.plugins.base import PluginBase, PluginMetadata, PluginType
+
+    class TestPlugin(PluginBase):
+        @property
+        def metadata(self) -> PluginMetadata:
+            return PluginMetadata(
+                name="Test",
+                description="Test plugin",
+                version="1.0.0",
+                plugin_type=PluginType.CREATOR,
+            )
+
+        def is_enabled(self) -> bool:
+            return True
+
+        def get_router(self) -> Optional[Any]:
+            return None
+
+        def get_cli_commands(self) -> Optional[Dict[str, Any]]:
+            return None
+
+        def get_ui_config(self) -> Optional[Dict[str, Any]]:
+            return None
+
+    plugin = TestPlugin()
+    assert plugin.store_available is False
+
+    plugin.set_store_api(object())
+    assert plugin.store_available is True

--- a/src/skillberry_store/tests/plugins/test_store_api.py
+++ b/src/skillberry_store/tests/plugins/test_store_api.py
@@ -414,3 +414,80 @@ def test_delete_skill_returns_false_on_unexpected_error(mock_services):
     assert store_api.delete_skill("some-uuid") is False
 
 # Made with Bob
+
+
+# ── module content + execution accessors ──────────────────────────────────────
+
+
+def test_get_tool_module_returns_source(mock_services):
+    """get_tool_module delegates to the service, which resolves the filename."""
+    from skillberry_store.plugins.store_api import StoreAPI
+
+    mock_services["tools"].get_module.return_value = "def t():\n    pass\n"
+    store_api = StoreAPI(mock_services)
+
+    assert store_api.get_tool_module("test-uuid") == "def t():\n    pass\n"
+    mock_services["tools"].get_module.assert_called_once_with("test-uuid")
+
+
+def test_get_tool_module_missing_returns_none(mock_services):
+    """A missing tool yields None rather than raising, matching get_tool."""
+    from skillberry_store.plugins.store_api import StoreAPI
+
+    mock_services["tools"].get_module.side_effect = KeyError("not found")
+    store_api = StoreAPI(mock_services)
+
+    assert store_api.get_tool_module("nonexistent") is None
+
+
+def test_get_tool_module_no_service_returns_none():
+    """Without a tools service the accessor degrades quietly."""
+    from skillberry_store.plugins.store_api import StoreAPI
+
+    assert StoreAPI({}).get_tool_module("test-uuid") is None
+
+
+def test_update_tool_module_writes(mock_services):
+    """update_tool_module passes content through to the service."""
+    from skillberry_store.plugins.store_api import StoreAPI
+
+    store_api = StoreAPI(mock_services)
+
+    assert store_api.update_tool_module("test-uuid", "print('fixed')\n") is True
+    mock_services["tools"].set_module.assert_called_once_with(
+        "test-uuid", "print('fixed')\n"
+    )
+
+
+def test_update_tool_module_failure_returns_false(mock_services):
+    """A service error is reported as False, not raised."""
+    from skillberry_store.plugins.store_api import StoreAPI
+
+    mock_services["tools"].set_module.side_effect = ValueError("no module file")
+    store_api = StoreAPI(mock_services)
+
+    assert store_api.update_tool_module("mcp-tool", "x") is False
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_delegates(mock_services):
+    """execute_tool runs the tool through the store's own execution path."""
+    from skillberry_store.plugins.store_api import StoreAPI
+
+    async def _execute(uuid_or_name, parameters, env_id=""):
+        return {"return value": f"{uuid_or_name}:{parameters}:{env_id}"}
+
+    mock_services["tools"].execute = _execute
+    store_api = StoreAPI(mock_services)
+
+    result = await store_api.execute_tool("test-uuid", {"a": 1}, env_id="env")
+    assert result == {"return value": "test-uuid:{'a': 1}:env"}
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_without_service_raises():
+    """No tools service is a programming error, not a silent no-op."""
+    from skillberry_store.plugins.store_api import StoreAPI
+
+    with pytest.raises(RuntimeError, match="Tools service not available"):
+        await StoreAPI({}).execute_tool("test-uuid")

--- a/src/skillberry_store/tests/plugins/test_store_api.py
+++ b/src/skillberry_store/tests/plugins/test_store_api.py
@@ -491,3 +491,42 @@ async def test_execute_tool_without_service_raises():
 
     with pytest.raises(RuntimeError, match="Tools service not available"):
         await StoreAPI({}).execute_tool("test-uuid")
+
+
+# ── deprecated handler properties ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("name", ["tools", "skills", "snippets"])
+def test_handler_properties_warn(mock_services, name):
+    """The raw-handler accessors still work, but plugins must be steered off them."""
+    import warnings
+
+    from skillberry_store.plugins.store_api import StoreAPI
+
+    store_api = StoreAPI(mock_services)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        handler = getattr(store_api, name)
+
+    assert handler is mock_services[name].handler
+    assert len(caught) == 1
+    assert issubclass(caught[0].category, DeprecationWarning)
+    assert name in str(caught[0].message)
+
+
+def test_store_api_write_paths_do_not_warn(mock_services):
+    """StoreAPI must not trip its own deprecation on internal handler access."""
+    import warnings
+
+    from skillberry_store.plugins.store_api import StoreAPI
+
+    store_api = StoreAPI(mock_services)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        store_api.update_tool("u", {"uuid": "u"})
+        store_api.update_skill("u", {"uuid": "u"})
+        store_api.update_snippet("u", {"uuid": "u"})
+
+    assert [w for w in caught if issubclass(w.category, DeprecationWarning)] == []

--- a/src/skillberry_store/tests/services/test_tools_service.py
+++ b/src/skillberry_store/tests/services/test_tools_service.py
@@ -197,6 +197,45 @@ def test_get_module_returns_file_content():
     assert "def hello" in content
 
 
+def test_set_module_writes_resolved_filename():
+    """The module filename comes from the manifest, not from the caller."""
+    h = _handler()
+    svc = ToolsService(h)
+    svc.set_module("t1", "print('fixed')\n")
+    h.write_file.assert_called_once_with("cccc-3333", "t1.py", "print('fixed')\n")
+
+
+def test_set_module_rejects_mcp_packaged_tool():
+    """MCP tools have no stored module file — their content is synthesized on read."""
+    h = _handler()
+    h.read_dict.return_value = {
+        "uuid": "cccc-3333", "name": "t1", "packaging_format": "mcp",
+    }
+    svc = ToolsService(h)
+    with pytest.raises(ValueError, match="MCP-packaged"):
+        svc.set_module("t1", "x")
+    h.write_file.assert_not_called()
+
+
+def test_set_module_rejects_tool_without_module_name():
+    h = _handler()
+    h.read_dict.return_value = {"uuid": "cccc-3333", "name": "t1"}
+    svc = ToolsService(h)
+    with pytest.raises(ValueError, match="no module file"):
+        svc.set_module("t1", "x")
+    h.write_file.assert_not_called()
+
+
+def test_set_module_raises_key_error_when_not_found():
+    h = _handler()
+    h.resolve_to_uuid_or_error.side_effect = HTTPException(
+        status_code=404, detail="not found"
+    )
+    svc = ToolsService(h)
+    with pytest.raises(KeyError):
+        svc.set_module("missing", "x")
+
+
 def _search_handler_tools(cached_tool):
     h = _handler()
     h.read_dict.return_value = cached_tool

--- a/src/skillberry_store/vdbs/lancedb.py
+++ b/src/skillberry_store/vdbs/lancedb.py
@@ -1,4 +1,5 @@
 import lancedb
+from lancedb.expr import col
 from typing import List, Dict, Any, Optional
 import pandas as pd
 import shutil
@@ -62,7 +63,7 @@ class LanceDB(VectorDBInterface):
         ]
     
     def delete_vector(self, id: str) -> None:
-        self.table.delete(f'id = "{id}"')
+        self.table.delete(col("id") == id)
     
     def load_index(self) -> None:
         if os.path.exists(self.db_path):


### PR DESCRIPTION
Two gaps kept the deterministic, no-LLM security plugins from being
usable in a deployment that deliberately configures no model.

Extras did not pull the engines. `plugin-sast` installed the plugin and
llm-switchboard but not Bandit, and `plugin-dast` did not install
Hypothesis, so both plugins booted disabled ("no configured engine is
installed" / "no input-generator engine installed") while the LLM
plugins were wired by default. Point both extras at the plugins' own
optional groups, and keep `plugins-all` in step so the two paths cannot
drift.

The policy approver had no model-free input. kagenti-approver thresholds
on `<key>:<number>` tags, and SAST's `sast:high:2` partitions at the
first colon into key `sast` and value "high:2" — not a number — so its
findings were invisible to the approver and the only usable criteria
source was the LLM security plugin's score. SAST now also writes numeric
counters (`sast-<severity>:<count>` plus `sast-findings:<total>`),
always including zeros because the approver fails a condition whose tag
is absent: a clean object needs a real 0 to be approvable, while an
object that was never scanned has no counters and fails closed. The
existing display tags are unchanged, and `_strip_sast_tags` now covers
both families so a re-scan replaces rather than accumulates.

Counters are per-severity rather than a single total: Bandit's
low-severity rules fire on ordinary code, so a total-based threshold
would reject nearly everything and leave the chain as decorative as it
was. `DEFAULT_CRITERIA` is untouched, so the model-free chain is opt-in
via `KAGENTI_CRITERIA=sast-high<1,sast-critical<1`.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
