### PR TITLE
Carry the caller's context into DAST's bounded worker thread

### DIFF
--- a/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/plugin.py
+++ b/plugins/skillberry-plugin-dast/src/skillberry_plugin_dast/plugin.py
@@ -429,7 +429,15 @@ class SkillberryPluginDast(PluginBase):
         nested ``asyncio.to_thread``), so a blocking call (sync ``time.sleep``,
         hung subprocess, infinite loop) is abandoned cleanly when we stop waiting
         — it does not keep an event-loop executor alive and deadlock scan exit.
+
+        The work runs inside a *copy of the caller's context*, because a bare
+        ``threading.Thread`` starts with an empty one. ``asyncio.to_thread``
+        copies the context for you; ``threading.Thread`` does not. Anything the
+        work reaches that reads ambient context — the store's request-scoped
+        state, and the twin's store-backed tool execution in particular — would
+        otherwise observe defaults instead of the caller's values.
         """
+        import contextvars
         import threading
 
         box: Dict[str, Any] = {}
@@ -440,7 +448,8 @@ class SkillberryPluginDast(PluginBase):
             except Exception as e:  # surface the error to the caller
                 box["error"] = e
 
-        th = threading.Thread(target=_worker, daemon=True)
+        ctx = contextvars.copy_context()
+        th = threading.Thread(target=ctx.run, args=(_worker,), daemon=True)
         th.start()
         th.join(self._exec_timeout)
         if th.is_alive():

--- a/plugins/skillberry-plugin-dast/tests/test_dast_plugin.py
+++ b/plugins/skillberry-plugin-dast/tests/test_dast_plugin.py
@@ -390,6 +390,50 @@ async def test_scan_missing_object_raises(monkeypatch):
         await p.scan("skill", "nope")
 
 
+def test_run_bounded_propagates_context(monkeypatch):
+    """Bounded work sees the caller's contextvars, not a fresh empty context.
+
+    A bare ``threading.Thread`` starts with an empty context, so anything the
+    work reaches that reads ambient state — the twin's store-backed tool
+    execution above all — would observe defaults instead of the caller's values.
+    """
+    import contextvars
+
+    var = contextvars.ContextVar("dast_test_var", default="unset")
+    var.set("set-by-caller")
+
+    p = _plugin(FakeStore(), monkeypatch)
+    assert p._run_bounded(var.get) == "set-by-caller"
+
+
+def test_run_bounded_isolates_writes_from_the_caller(monkeypatch):
+    """The copy is a copy: a ``set`` inside the work does not leak back out."""
+    import contextvars
+
+    var = contextvars.ContextVar("dast_test_var2", default="unset")
+    var.set("caller")
+
+    def _work():
+        var.set("worker")
+        return var.get()
+
+    p = _plugin(FakeStore(), monkeypatch)
+    assert p._run_bounded(_work) == "worker"
+    assert var.get() == "caller"
+
+
+def test_run_bounded_still_surfaces_errors_and_results(monkeypatch):
+    """Context propagation must not disturb the result/exception plumbing."""
+    p = _plugin(FakeStore(), monkeypatch)
+    assert p._run_bounded(lambda: 42) == 42
+
+    def _boom():
+        raise RuntimeError("from the worker")
+
+    with pytest.raises(RuntimeError, match="from the worker"):
+        p._run_bounded(_boom)
+
+
 @pytest.mark.asyncio
 async def test_scan_records_coverage_caveats(monkeypatch):
     store = FakeStore(


### PR DESCRIPTION
## What

`SkillberryPluginDast._run_bounded` runs its work in a raw daemon `threading.Thread`. That is deliberate — it is what lets a hung tool be abandoned without keeping a non-daemon `to_thread` worker alive and deadlocking scan exit. But a bare `threading.Thread` starts with an **empty** `contextvars` context, unlike the two offloads used elsewhere in the plugin and the store:

| Offload | Propagates context? |
|---|---|
| `asyncio.to_thread(fn)` — `plugin.py:578`, the scan offload | **yes**, copies it explicitly |
| Starlette's `run_in_threadpool` — the `def`-endpoint path, via anyio | **yes** |
| `loop.run_in_executor(None, fn)` | no |
| `threading.Thread(target=fn)` — `_run_bounded` | no |

(Measured, not assumed — `run_in_executor` in particular does *not* propagate, which is easy to get backwards.)

## Why it matters now

It was harmless while that thread's work was self-contained. It no longer is: the MCP-scope path runs `twin.drive_tool(...)` inside it, and the twin's `StoreApiToolSource` executes through `StoreAPI.execute_tool` — so the thread now reaches the store with a context the caller never set.

Nothing in the store reads ambient context today, so this is **latent rather than a live failure**. It stops being latent as soon as any request-scoped state is threaded through `contextvars`. The access-control design (`docs/design/plugin-identity.md` §4.2a) puts the caller's tenant there, and at that point every twin-mediated tool call in a live scan (`DAST_LIVE`) would observe a default instead of the caller's value — surfacing as an identity error swallowed into a log line on the event path.

## The change

Run the work inside `contextvars.copy_context()`, so the thread starts from the caller's context. It is a *copy*, so a `set()` inside the work still cannot leak back to the caller.

## Tests

Three cases added to `test_dast_plugin.py`:

- the caller's contextvar is visible inside `_run_bounded` (fails on `main`, passes here)
- a `set()` inside the work does not leak back out
- results and exceptions still propagate to the caller unchanged

Full suite: **1676 passed, 5 skipped**. `make lint` clean; both changed files are `black`-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)