### PR TITLE
Point the simulate plugin at the external simulation-harness

### DIFF
--- a/plugins/skillberry-plugin-simulate/.env.example
+++ b/plugins/skillberry-plugin-simulate/.env.example
@@ -2,11 +2,21 @@
 SIMULATE_LLM_API_KEY=
 # Optional: set for Azure/OpenAI-compatible base URL
 SIMULATE_LLM_API_BASE=
-# Container image for the simulation harness
-SIMULATION_HARNESS_IMAGE=simulation-harness:latest
+# Container image for the simulation harness. Default tracks the newest v0.1.x
+# *release* of github.com/skillberry-ai/simulation-harness. Do not use :latest —
+# upstream tags that from every push to main, so it runs ahead of any release.
+SIMULATION_HARNESS_IMAGE=ghcr.io/skillberry-ai/simulation-harness:0.1
+# Optional: override the harness's own LLM settings (its image defaults to
+# provider `openai` with `gpt-4.1` for both models). Set these when
+# SIMULATE_LLM_API_BASE points at a gateway that namespaces model ids
+# differently; leave unset to keep the image's harness.yaml defaults.
+SIMULATE_LLM_PROVIDER=
+SIMULATE_LLM_SKILL_GENERATION_MODEL=
+SIMULATE_LLM_SIMULATION_MODEL=
 # Where the plugin stores its active-vMCP registry
 SIMULATE_DATA_DIR=~/.skillberry/simulate
-# Host paths mounted into the harness container
+# Host paths mounted into the harness container. skills-store is mounted
+# read-write: the harness generates (and then caches) its skill artifacts there.
 SIMULATE_SKILLS_STORE_PATH=
 SIMULATE_LOGS_PATH=
 # Seconds to wait for harness to become ready (default: 600)

--- a/plugins/skillberry-plugin-simulate/README.md
+++ b/plugins/skillberry-plugin-simulate/README.md
@@ -1,8 +1,9 @@
 # Skillberry "Simulate This" Plugin
 
 Stand up a **simulated parallel vMCP** for a skill — a second vMCP whose tools are
-backed by a containerized simulation-harness instead of the real backends — and flip a
-plugin-owned switch deciding whether consumers reach the real or the simulated vMCP.
+backed by a containerized [simulation-harness](https://github.com/skillberry-ai/simulation-harness)
+instead of the real backends — and flip a plugin-owned switch deciding whether
+consumers reach the real or the simulated vMCP.
 
 ## How it works
 
@@ -20,6 +21,21 @@ plugin-owned switch deciding whether consumers reach the real or the simulated v
   each use and connect to the returned `mcp_url`. The response includes `mode` (`real`/`sim`).
 - **Tear down** deletes the sim vMCP, its tools and skill, stops the harness, and reverts.
 
+## The harness
+
+The harness is [`skillberry-ai/simulation-harness`](https://github.com/skillberry-ai/simulation-harness),
+published to `ghcr.io/skillberry-ai/simulation-harness` (public — no registry
+login needed). The plugin drives its REST control plane on container port `8086`
+(`POST`/`GET`/`DELETE /api/v1/simulation`) and passes a dedicated `mcp_port`, so
+each simulation's MCP server runs on its own port as a sidecar. The harness
+returns that sidecar's SSE URL (`http://127.0.0.1:<mcp_port>/mcp/sse`), which is
+what the simulated tool manifests point at.
+
+**Image tag.** The default is `:0.1` — the newest `v0.1.x` *release*. Do not use
+`:latest`: upstream tags that from every push to `main`, so it runs ahead of any
+release and can change the REST contract between runs. The plugin's contract is
+verified against v0.1.2; a `v0.2.0` release will need a deliberate bump here.
+
 ## Configuration
 
 See `.env.example`. Requires `SIMULATE_LLM_API_KEY` and a reachable Docker runtime.
@@ -28,11 +44,31 @@ See `.env.example`. Requires `SIMULATE_LLM_API_KEY` and a reachable Docker runti
 |---|---|---|---|
 | `SIMULATE_LLM_API_KEY` | yes | — | API key for the harness simulation LLM |
 | `SIMULATE_LLM_API_BASE` | no | — | Azure/OpenAI-compatible base URL |
-| `SIMULATION_HARNESS_IMAGE` | no | `simulation-harness:latest` | Container image to launch |
+| `SIMULATION_HARNESS_IMAGE` | no | `ghcr.io/skillberry-ai/simulation-harness:0.1` | Container image to launch |
+| `SIMULATE_LLM_PROVIDER` | no | — | Harness `HARNESS_LLM_PROVIDER` override |
+| `SIMULATE_LLM_SKILL_GENERATION_MODEL` | no | — | Harness `HARNESS_LLM_SKILL_GENERATION_MODEL` override |
+| `SIMULATE_LLM_SIMULATION_MODEL` | no | — | Harness `HARNESS_LLM_SIMULATION_MODEL` override |
 | `SIMULATE_DATA_DIR` | no | `~/.skillberry/simulate` | Path for the active-vMCP registry |
-| `SIMULATE_SKILLS_STORE_PATH` | no | — | Host path mounted into the harness |
-| `SIMULATE_LOGS_PATH` | no | — | Host path mounted into the harness |
+| `SIMULATE_SKILLS_STORE_PATH` | no | — | Host path bind-mounted at `/app/skills-store` (**read-write**) |
+| `SIMULATE_LOGS_PATH` | no | — | Host path bind-mounted at `/app/logs` |
 | `SIMULATE_READY_TIMEOUT_SECONDS` | no | `600` | Seconds to wait for harness to become ready |
+
+The harness image ships a `harness.yaml` defaulting to provider `openai` with
+`gpt-4.1` for both its skill-generation and simulation models. If
+`SIMULATE_LLM_API_BASE` points at a gateway that namespaces model ids
+differently, set the three `SIMULATE_LLM_*_MODEL` / `_PROVIDER` variables;
+unset means "leave the image's defaults alone".
+
+### Generated-skill cache
+
+The harness generates a skill (`SKILL.md`, `schema.json`, `db.json`, `api.json`)
+from the synthesized OpenAPI spec and caches it under
+`<skills-store>/<simulation name>/`, skipping the (slow, LLM-driven) generation
+on a cache hit. Every simulation shares whatever `SIMULATE_SKILLS_STORE_PATH`
+points at, so the plugin names each simulation `<skill-slug>-<tools-fingerprint>`:
+unique per skill *and* per tool surface, so same-named skills never collide and
+changing a skill's tools regenerates rather than silently reusing stale
+artifacts. This mount must be read-write or generation fails.
 
 ## Limitations (v1)
 
@@ -40,5 +76,7 @@ See `.env.example`. Requires `SIMULATE_LLM_API_KEY` and a reachable Docker runti
 - Between-runs switching only (no mid-session real↔sim redirection).
 - Response fidelity is bounded by input-schema-only OpenAPI synthesis; the synthesizer is
   pluggable for a future "enhanced" generator.
-- Harness session limits (≈100 messages, ~1h idle, queue depth 8) apply; the plugin
-  auto-resets on session expiry, so simulated throughput is lower than the real backend.
+- Harness session limits (≈100 messages, ~1h idle, queue depth 8) apply, so simulated
+  throughput is lower than the real backend. The **harness** resets its own session on
+  expiry and fails just the one call that tripped the limit; the plugin is not in the
+  tool-call path and neither sees nor handles this.

--- a/plugins/skillberry-plugin-simulate/src/skillberry_plugin_simulate/config.py
+++ b/plugins/skillberry-plugin-simulate/src/skillberry_plugin_simulate/config.py
@@ -13,6 +13,12 @@ from dotenv import load_dotenv
 _PLUGIN_ENV = Path(__file__).resolve().parents[2] / ".env"
 load_dotenv(_PLUGIN_ENV, override=False)
 
+# The harness is published from github.com/skillberry-ai/simulation-harness.
+# Pinned to the release line (`0.1` == the newest v0.1.x release), NOT `latest`
+# — upstream tags `latest` from every push to main, so it is ahead of the
+# newest release and can change the REST contract between runs.
+DEFAULT_HARNESS_IMAGE = "ghcr.io/skillberry-ai/simulation-harness:0.1"
+
 
 @dataclass
 class SimulateConfig:
@@ -26,6 +32,13 @@ class SimulateConfig:
     logs_path: Optional[str] = None
     ready_timeout_seconds: int = 600
     poll_interval_seconds: float = 2.0
+    # Optional overrides for the harness's own LLM settings. The harness image
+    # ships config/harness.yaml defaulting to provider `openai` with `gpt-4.1`
+    # for both models; behind a gateway that namespaces model ids differently
+    # those defaults do not resolve, so they are overridable per deployment.
+    llm_provider: Optional[str] = None
+    llm_skill_generation_model: Optional[str] = None
+    llm_simulation_model: Optional[str] = None
 
     @classmethod
     def from_env(cls) -> "SimulateConfig":
@@ -33,11 +46,14 @@ class SimulateConfig:
         return cls(
             llm_api_key=os.getenv("SIMULATE_LLM_API_KEY"),
             llm_api_base=os.getenv("SIMULATE_LLM_API_BASE"),
-            harness_image=os.getenv("SIMULATION_HARNESS_IMAGE", "simulation-harness:latest"),
+            harness_image=os.getenv("SIMULATION_HARNESS_IMAGE", DEFAULT_HARNESS_IMAGE),
             data_dir=os.getenv("SIMULATE_DATA_DIR", os.path.expanduser("~/.skillberry/simulate")),
             skills_store_path=os.getenv("SIMULATE_SKILLS_STORE_PATH"),
             logs_path=os.getenv("SIMULATE_LOGS_PATH"),
             ready_timeout_seconds=int(raw_timeout) if raw_timeout else 600,
+            llm_provider=os.getenv("SIMULATE_LLM_PROVIDER"),
+            llm_skill_generation_model=os.getenv("SIMULATE_LLM_SKILL_GENERATION_MODEL"),
+            llm_simulation_model=os.getenv("SIMULATE_LLM_SIMULATION_MODEL"),
         )
 
     def is_configured(self) -> bool:

--- a/plugins/skillberry-plugin-simulate/src/skillberry_plugin_simulate/harness_client.py
+++ b/plugins/skillberry-plugin-simulate/src/skillberry_plugin_simulate/harness_client.py
@@ -1,4 +1,7 @@
-"""Async HTTP client for the simulation-harness REST API."""
+"""Async HTTP client for the simulation-harness REST API.
+
+Contract verified against github.com/skillberry-ai/simulation-harness v0.1.2.
+"""
 import asyncio
 import logging
 from typing import Any, Dict, Optional
@@ -19,29 +22,38 @@ class HarnessTimeout(HarnessError):
 
 
 class HarnessClient:
-    """Wraps the harness REST endpoints with transparent 410 session reset."""
+    """Wraps the harness REST endpoints.
+
+    Session expiry is NOT handled here: the harness raises SessionExpiredError
+    only inside its own tool execution path, where it resets the session itself
+    and fails just that one call (core/simulation_instance.py). It never surfaces
+    on the status endpoint, and tool calls reach the harness directly from the
+    vMCP, so this client never observes it.
+    """
 
     def __init__(self, client: httpx.AsyncClient):
         self._client = client
-        self._last_spec: Optional[Dict[str, Any]] = None
-        self._last_mcp_port: Optional[int] = None
 
     async def create_simulation(
         self,
         openapi_spec: Dict[str, Any],
         mcp_port: int,
         *,
+        name: Optional[str] = None,
         startup_retries: int = 10,
         startup_delay: float = 2.0,
     ) -> None:
-        """POST the simulation spec, retrying on connection errors to handle harness startup lag."""
-        self._last_spec = openapi_spec
-        self._last_mcp_port = mcp_port
+        """POST the simulation spec, retrying on connection errors to handle harness startup lag.
+
+        Returns as soon as the harness accepts the request (202); creation then
+        runs in the background — poll `wait_until_ready`.
+        """
+        payload: Dict[str, Any] = {"openapi_spec": openapi_spec, "mcp_port": mcp_port}
+        if name:
+            payload["name"] = name
         for attempt in range(startup_retries + 1):
             try:
-                resp = await self._client.post(
-                    SIM_PATH, json={"openapi_spec": openapi_spec, "mcp_port": mcp_port}
-                )
+                resp = await self._client.post(SIM_PATH, json=payload)
                 break
             except (
                 httpx.ConnectError,
@@ -63,25 +75,38 @@ class HarnessClient:
                     attempt + 1, startup_retries, exc, startup_delay,
                 )
                 await asyncio.sleep(startup_delay)
+        if resp.status_code == 409:
+            raise HarnessError(
+                f"create_simulation rejected (409): the harness already has an active "
+                f"simulation, or MCP port {mcp_port} is already bound inside the "
+                f"container (a leaked harness container may still hold it). "
+                f"Harness said: {resp.text}"
+            )
+        if resp.status_code == 422:
+            raise HarnessError(
+                f"create_simulation rejected (422): the harness would not accept the "
+                f"synthesized OpenAPI spec. Harness said: {resp.text}"
+            )
         if resp.status_code >= 400:
             raise HarnessError(f"create_simulation failed: {resp.status_code} {resp.text}")
 
-    async def _resubmit(self) -> None:
-        if self._last_spec is None or self._last_mcp_port is None:
-            raise HarnessError("Cannot resubmit: no prior simulation spec recorded")
-        logger.warning("Harness session expired (410); resubmitting simulation spec")
-        await self.create_simulation(self._last_spec, self._last_mcp_port)
-
     async def get_status(self) -> Dict[str, Any]:
         resp = await self._client.get(SIM_PATH)
-        if resp.status_code == 410:
-            await self._resubmit()
-            resp = await self._client.get(SIM_PATH)
+        if resp.status_code == 404:
+            raise HarnessError(
+                "get_status: the harness has no active simulation — it was deleted "
+                "or the harness restarted mid-creation"
+            )
         if resp.status_code >= 400:
             raise HarnessError(f"get_status failed: {resp.status_code} {resp.text}")
         return resp.json()
 
     async def wait_until_ready(self, timeout: float = 600.0, interval: float = 2.0) -> str:
+        """Poll until status is `ready`, returning the harness's mcp_url.
+
+        Transitional statuses (`pending`, `generating_skill`, `initializing`) are
+        just "not yet"; only `ready` and `failed` are terminal here.
+        """
         elapsed = 0.0
         while True:
             status = await self.get_status()
@@ -92,10 +117,12 @@ class HarnessClient:
                     raise HarnessError("Harness ready but returned no mcp_url")
                 return mcp_url
             if sim_status == "failed":
-                error = status.get("error") or "unknown error"
-                raise HarnessError(f"Harness simulation failed: {error}")
+                raise HarnessError(f"Harness simulation failed: {_format_error(status)}")
             if elapsed >= timeout:
-                raise HarnessTimeout(f"Harness not ready after {timeout}s")
+                raise HarnessTimeout(
+                    f"Harness not ready after {timeout}s (last status: {sim_status}"
+                    f"{_format_phase(status)})"
+                )
             await asyncio.sleep(interval)
             elapsed += interval
 
@@ -103,3 +130,18 @@ class HarnessClient:
         resp = await self._client.delete(SIM_PATH)
         if resp.status_code >= 400 and resp.status_code != 404:
             raise HarnessError(f"delete_simulation failed: {resp.status_code} {resp.text}")
+
+
+def _format_error(status: Dict[str, Any]) -> str:
+    """Render the harness's error payload, which is an object as of v0.1.x."""
+    error = status.get("error")
+    if isinstance(error, dict):
+        message = error.get("message") or error.get("code") or "unknown error"
+        code = error.get("code")
+        return f"{message} ({code})" if code and code != message else str(message)
+    return str(error) if error else "unknown error"
+
+
+def _format_phase(status: Dict[str, Any]) -> str:
+    phase = (status.get("progress") or {}).get("phase")
+    return f", phase: {phase}" if phase else ""

--- a/plugins/skillberry-plugin-simulate/src/skillberry_plugin_simulate/harness_manager.py
+++ b/plugins/skillberry-plugin-simulate/src/skillberry_plugin_simulate/harness_manager.py
@@ -9,6 +9,12 @@ logger = logging.getLogger(__name__)
 
 HARNESS_REST_CONTAINER_PORT = 8086  # fixed inside the harness image
 
+# Mount points inside the harness image. Its Dockerfile bakes
+# HARNESS_SKILLS_FOLDER=/app/skills-store and HARNESS_LOG_DESTINATION=/app/logs,
+# so a bind anywhere else is simply ignored by the harness.
+HARNESS_SKILLS_MOUNT = "/app/skills-store"
+HARNESS_LOGS_MOUNT = "/app/logs"
+
 
 def find_free_port(port_range: Tuple[int, int], exclude: Set[int]) -> int:
     """Return the first bindable TCP port in [lo, hi] not in `exclude`."""
@@ -44,12 +50,23 @@ class HarnessManager:
         environment = {"LLM_API_KEY": self._config.llm_api_key}
         if self._config.llm_api_base:
             environment["LLM_API_BASE"] = self._config.llm_api_base
+        # HARNESS_* overrides win over the harness.yaml baked into the image.
+        for var, value in (
+            ("HARNESS_LLM_PROVIDER", self._config.llm_provider),
+            ("HARNESS_LLM_SKILL_GENERATION_MODEL", self._config.llm_skill_generation_model),
+            ("HARNESS_LLM_SIMULATION_MODEL", self._config.llm_simulation_model),
+        ):
+            if value:
+                environment[var] = value
 
         volumes: Dict[str, Dict[str, str]] = {}
         if self._config.skills_store_path:
-            volumes[self._config.skills_store_path] = {"bind": "/skills-store", "mode": "ro"}
+            # Read-write: the harness generates its skill artifacts (SKILL.md,
+            # schema.json, db.json, api.json) into this directory, and reuses
+            # them as a cache on later runs. A read-only bind fails generation.
+            volumes[self._config.skills_store_path] = {"bind": HARNESS_SKILLS_MOUNT, "mode": "rw"}
         if self._config.logs_path:
-            volumes[self._config.logs_path] = {"bind": "/logs", "mode": "rw"}
+            volumes[self._config.logs_path] = {"bind": HARNESS_LOGS_MOUNT, "mode": "rw"}
 
         container = self._docker.containers.run(
             self._config.harness_image,

--- a/plugins/skillberry-plugin-simulate/src/skillberry_plugin_simulate/orchestrator.py
+++ b/plugins/skillberry-plugin-simulate/src/skillberry_plugin_simulate/orchestrator.py
@@ -1,7 +1,9 @@
 """Orchestrates the simulate/teardown/toggle/resolve flows for the plugin."""
+import asyncio
 import hashlib
 import json
 import logging
+import re
 from typing import Any, Callable, Dict, List, Optional
 
 from skillberry_plugin_simulate.config import SimulateConfig
@@ -24,6 +26,34 @@ def tools_fingerprint(tools: List[Dict[str, Any]]) -> str:
         (t.get("name", ""), json.dumps(t.get("params", {}), sort_keys=True)) for t in tools
     )
     return hashlib.sha256(json.dumps(basis, sort_keys=True).encode()).hexdigest()
+
+
+# The harness sanitizes the simulation name with its own Agent-Skills rules and
+# truncates to 64 chars (skills/generation/naming.py). Mirroring that here keeps
+# the name we compute identical to the one it stores artifacts under, and
+# reserving room for the suffix stops truncation from eating the fingerprint.
+_MAX_HARNESS_NAME_LEN = 64
+_FINGERPRINT_LEN = 8
+_NON_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _slugify(raw: str) -> str:
+    return _NON_SLUG_RE.sub("-", (raw or "").lower()).strip("-")
+
+
+def simulation_name(base_name: str, fingerprint: str) -> str:
+    """Harness simulation name for a skill's current tool surface.
+
+    The harness caches generated skill artifacts under
+    `<skills-store>/<name>/` and skips LLM generation on a hit. Every
+    simulation shares one mounted skills-store, so the name has to be unique
+    per skill *and* per tool surface: without the fingerprint, two skills
+    with the same display name collide, and re-simulating a skill whose tools
+    changed silently reuses stale artifacts.
+    """
+    suffix = f"-{fingerprint[:_FINGERPRINT_LEN]}"
+    stem = _slugify(base_name)[: _MAX_HARNESS_NAME_LEN - len(suffix)].strip("-")
+    return f"{stem or 'simulation'}{suffix}"
 
 
 class SimulateOrchestrator:
@@ -91,16 +121,23 @@ class SimulateOrchestrator:
 
         if self._registry.get(skill_uuid):
             logger.info("Tearing down existing simulation for skill %s before re-simulating", skill_uuid)
-            self.teardown(skill_uuid)
+            await self.teardown(skill_uuid)
 
+        fingerprint = tools_fingerprint(tools)
         spec = self._synth.synthesize(tools, title=base_name)
         rest_port, mcp_port = self._harness_manager.allocate_ports()
-        harness = self._harness_manager.start(rest_port=rest_port, mcp_port=mcp_port)
+        # docker-py is synchronous and pulls the image when it is missing, which
+        # on a cold host is a multi-hundred-MB download — never on the event loop.
+        harness = await asyncio.to_thread(
+            self._harness_manager.start, rest_port=rest_port, mcp_port=mcp_port
+        )
         container_id = harness["container_id"]
 
         try:
             client = self._harness_client_factory(harness["rest_url"])
-            await client.create_simulation(spec, mcp_port=mcp_port)
+            await client.create_simulation(
+                spec, mcp_port=mcp_port, name=simulation_name(base_name, fingerprint)
+            )
             harness_mcp_url = await client.wait_until_ready(
                 timeout=self._config.ready_timeout_seconds,
                 interval=self._config.poll_interval_seconds,
@@ -133,7 +170,7 @@ class SimulateOrchestrator:
                         "simulation_of": real_vmcp_uuid,
                         "simulation_of_skill": skill_uuid,
                         "sim_skill_uuid": sim_skill["uuid"],
-                        "tools_fingerprint": tools_fingerprint(tools),
+                        "tools_fingerprint": fingerprint,
                         "harness": {
                             "container_id": container_id,
                             "rest_url": harness["rest_url"],
@@ -151,7 +188,7 @@ class SimulateOrchestrator:
             )
         except Exception:
             logger.warning("simulate() failed after harness start — stopping container %s", container_id)
-            self._harness_manager.stop(container_id)
+            await asyncio.to_thread(self._harness_manager.stop, container_id)
             raise
 
         logger.info("Simulated vMCP %s created for skill %s", sim_vmcp["uuid"], skill_uuid)
@@ -187,7 +224,7 @@ class SimulateOrchestrator:
         new_active = self._registry.toggle(skill_uuid)
         return {"success": True, "skill_uuid": skill_uuid, "active": new_active}
 
-    def teardown(self, skill_uuid: str) -> Dict[str, Any]:
+    async def teardown(self, skill_uuid: str) -> Dict[str, Any]:
         entry = self._registry.get(skill_uuid)
         if entry is None:
             raise KeyError(skill_uuid)
@@ -204,7 +241,7 @@ class SimulateOrchestrator:
                     self._store.delete_tool(tool_uuid)
                 self._store.delete_skill(sim_skill_uuid)
             if container_id:
-                self._harness_manager.stop(container_id)
+                await asyncio.to_thread(self._harness_manager.stop, container_id)
         self._registry.remove(skill_uuid)
         return {"success": True, "skill_uuid": skill_uuid}
 

--- a/plugins/skillberry-plugin-simulate/src/skillberry_plugin_simulate/plugin.py
+++ b/plugins/skillberry-plugin-simulate/src/skillberry_plugin_simulate/plugin.py
@@ -134,7 +134,7 @@ class SkillberryPluginSimulate(PluginBase):
         @router.post("/teardown")
         async def teardown(request: SkillRequest):
             try:
-                return self._get_orchestrator().teardown(request.skill_uuid)
+                return await self._get_orchestrator().teardown(request.skill_uuid)
             except KeyError:
                 raise HTTPException(status_code=404, detail=f"No simulation for skill {request.skill_uuid}")
 

--- a/plugins/skillberry-plugin-simulate/tests/test_config.py
+++ b/plugins/skillberry-plugin-simulate/tests/test_config.py
@@ -1,15 +1,17 @@
-from skillberry_plugin_simulate.config import SimulateConfig
+from skillberry_plugin_simulate.config import DEFAULT_HARNESS_IMAGE, SimulateConfig
 
 
 def test_from_env_reads_values(monkeypatch):
     monkeypatch.setenv("SIMULATE_LLM_API_KEY", "sk-test")
     monkeypatch.setenv("SIMULATE_LLM_API_BASE", "https://azure.example/v1")
-    monkeypatch.setenv("SIMULATION_HARNESS_IMAGE", "kaegis/simulation-harness:1.2")
+    monkeypatch.setenv(
+        "SIMULATION_HARNESS_IMAGE", "ghcr.io/skillberry-ai/simulation-harness:0.1.2"
+    )
     monkeypatch.setenv("SIMULATE_DATA_DIR", "/tmp/sim")
     cfg = SimulateConfig.from_env()
     assert cfg.llm_api_key == "sk-test"
     assert cfg.llm_api_base == "https://azure.example/v1"
-    assert cfg.harness_image == "kaegis/simulation-harness:1.2"
+    assert cfg.harness_image == "ghcr.io/skillberry-ai/simulation-harness:0.1.2"
     assert cfg.data_dir == "/tmp/sim"
 
 
@@ -17,8 +19,41 @@ def test_defaults(monkeypatch):
     monkeypatch.delenv("SIMULATION_HARNESS_IMAGE", raising=False)
     monkeypatch.delenv("SIMULATE_LLM_API_BASE", raising=False)
     cfg = SimulateConfig.from_env()
-    assert cfg.harness_image == "simulation-harness:latest"
+    assert cfg.harness_image == DEFAULT_HARNESS_IMAGE
     assert cfg.llm_api_base is None
+
+
+def test_default_image_is_the_external_release_line():
+    """The harness ships from skillberry-ai/simulation-harness on GHCR.
+
+    `latest` there tracks main, not releases, so the default must not use it.
+    """
+    assert DEFAULT_HARNESS_IMAGE == "ghcr.io/skillberry-ai/simulation-harness:0.1"
+    assert not DEFAULT_HARNESS_IMAGE.endswith(":latest")
+
+
+def test_harness_llm_overrides_read_from_env(monkeypatch):
+    monkeypatch.setenv("SIMULATE_LLM_PROVIDER", "openai")
+    monkeypatch.setenv("SIMULATE_LLM_SKILL_GENERATION_MODEL", "gateway/gpt-4.1")
+    monkeypatch.setenv("SIMULATE_LLM_SIMULATION_MODEL", "gateway/gpt-4.1-mini")
+    cfg = SimulateConfig.from_env()
+    assert cfg.llm_provider == "openai"
+    assert cfg.llm_skill_generation_model == "gateway/gpt-4.1"
+    assert cfg.llm_simulation_model == "gateway/gpt-4.1-mini"
+
+
+def test_harness_llm_overrides_default_to_none(monkeypatch):
+    """Unset means "leave the harness's own harness.yaml defaults alone"."""
+    for var in (
+        "SIMULATE_LLM_PROVIDER",
+        "SIMULATE_LLM_SKILL_GENERATION_MODEL",
+        "SIMULATE_LLM_SIMULATION_MODEL",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    cfg = SimulateConfig.from_env()
+    assert cfg.llm_provider is None
+    assert cfg.llm_skill_generation_model is None
+    assert cfg.llm_simulation_model is None
 
 
 def test_is_configured_requires_key(monkeypatch):

--- a/plugins/skillberry-plugin-simulate/tests/test_harness_client.py
+++ b/plugins/skillberry-plugin-simulate/tests/test_harness_client.py
@@ -1,7 +1,11 @@
 import httpx
 import pytest
 
-from skillberry_plugin_simulate.harness_client import HarnessClient, HarnessError
+from skillberry_plugin_simulate.harness_client import (
+    HarnessClient,
+    HarnessError,
+    HarnessTimeout,
+)
 
 
 def _client(handler):
@@ -44,22 +48,105 @@ async def test_wait_until_ready_returns_mcp_url():
 
 
 @pytest.mark.asyncio
-async def test_410_triggers_resubmit():
-    calls = {"post": 0}
+async def test_create_simulation_sends_name_when_given():
+    """The name keys the harness's generated-skill cache directory."""
+    seen = {}
 
     def handler(request):
-        if request.method == "POST":
-            calls["post"] += 1
-            return httpx.Response(200, json={"status": "starting"})
-        if calls["post"] == 1:
-            return httpx.Response(410, json={"error": "SessionExpiredError"})
-        return httpx.Response(200, json={"status": "ready", "mcp_url": "http://h/sse"})
+        import json
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(202, json={"status": "pending"})
+
+    hc = HarnessClient(_client(handler))
+    await hc.create_simulation({"openapi": "3.0.3"}, mcp_port=8701, name="weather-1a2b3c4d")
+    assert seen["body"]["name"] == "weather-1a2b3c4d"
+
+
+@pytest.mark.asyncio
+async def test_create_simulation_omits_name_when_not_given():
+    seen = {}
+
+    def handler(request):
+        import json
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(202, json={"status": "pending"})
 
     hc = HarnessClient(_client(handler))
     await hc.create_simulation({"openapi": "3.0.3"}, mcp_port=8701)
-    mcp_url = await hc.wait_until_ready(timeout=5, interval=0)
-    assert calls["post"] == 2  # auto-resubmitted after 410
-    assert mcp_url == "http://h/sse"
+    assert "name" not in seen["body"]
+
+
+@pytest.mark.asyncio
+async def test_transitional_statuses_are_not_terminal():
+    """pending / generating_skill / initializing all mean "keep polling"."""
+    states = iter([
+        httpx.Response(200, json={"status": "pending"}),
+        httpx.Response(200, json={"status": "generating_skill",
+                                  "progress": {"phase": "analyze"}}),
+        httpx.Response(200, json={"status": "initializing"}),
+        httpx.Response(200, json={"status": "ready",
+                                  "mcp_url": "http://127.0.0.1:8701/mcp/sse"}),
+    ])
+
+    hc = HarnessClient(_client(lambda request: next(states)))
+    assert await hc.wait_until_ready(timeout=5, interval=0) == "http://127.0.0.1:8701/mcp/sse"
+
+
+@pytest.mark.asyncio
+async def test_create_simulation_409_names_both_causes():
+    def handler(request):
+        return httpx.Response(409, json={"detail": "Port 8701 is already in use"})
+
+    hc = HarnessClient(_client(handler))
+    with pytest.raises(HarnessError, match="409"):
+        await hc.create_simulation({"openapi": "3.0.3"}, mcp_port=8701)
+
+
+@pytest.mark.asyncio
+async def test_create_simulation_422_blames_the_spec():
+    def handler(request):
+        return httpx.Response(422, json={"detail": "OpenAPI validation failed"})
+
+    hc = HarnessClient(_client(handler))
+    with pytest.raises(HarnessError, match="synthesized OpenAPI spec"):
+        await hc.create_simulation({"openapi": "3.0.3"}, mcp_port=8701)
+
+
+@pytest.mark.asyncio
+async def test_get_status_404_says_no_active_simulation():
+    def handler(request):
+        return httpx.Response(404, json={"detail": "No simulation is active"})
+
+    hc = HarnessClient(_client(handler))
+    with pytest.raises(HarnessError, match="no active simulation"):
+        await hc.get_status()
+
+
+@pytest.mark.asyncio
+async def test_failed_status_renders_structured_error_payload():
+    """As of v0.1.x the harness reports `error` as an object, not a string."""
+    def handler(request):
+        return httpx.Response(200, json={
+            "status": "failed",
+            "error": {"code": "sidecar_start_failed",
+                      "message": "Port 8701 is already in use",
+                      "details": None},
+        })
+
+    hc = HarnessClient(_client(handler))
+    with pytest.raises(HarnessError, match="Port 8701 is already in use"):
+        await hc.wait_until_ready(timeout=10, interval=0)
+
+
+@pytest.mark.asyncio
+async def test_timeout_reports_last_status_and_phase():
+    def handler(request):
+        return httpx.Response(200, json={"status": "generating_skill",
+                                         "progress": {"phase": "operations"}})
+
+    hc = HarnessClient(_client(handler))
+    with pytest.raises(HarnessTimeout, match="operations"):
+        await hc.wait_until_ready(timeout=0, interval=0)
 
 
 @pytest.mark.asyncio

--- a/plugins/skillberry-plugin-simulate/tests/test_harness_manager.py
+++ b/plugins/skillberry-plugin-simulate/tests/test_harness_manager.py
@@ -2,7 +2,12 @@ import socket
 from unittest.mock import MagicMock, patch
 
 from skillberry_plugin_simulate.config import SimulateConfig
-from skillberry_plugin_simulate.harness_manager import HarnessManager, find_free_port
+from skillberry_plugin_simulate.harness_manager import (
+    HARNESS_LOGS_MOUNT,
+    HARNESS_SKILLS_MOUNT,
+    HarnessManager,
+    find_free_port,
+)
 
 
 def _config():
@@ -59,6 +64,62 @@ def test_llm_api_base_included_only_when_set():
     mgr.start(rest_port=8600, mcp_port=8700)
     env = docker_client.containers.run.call_args.kwargs["environment"]
     assert env["LLM_API_BASE"] == "https://azure/v1"
+
+
+def test_volumes_use_the_image_mount_points_and_are_writable():
+    """The harness image bakes HARNESS_SKILLS_FOLDER=/app/skills-store and
+    HARNESS_LOG_DESTINATION=/app/logs, so a bind anywhere else is ignored.
+    skills-store must be rw — the harness generates its skill artifacts there."""
+    docker_client = MagicMock()
+    docker_client.containers.run.return_value = MagicMock(id="x")
+    mgr = HarnessManager(_config(), docker_client=docker_client)
+    mgr.start(rest_port=8600, mcp_port=8700)
+
+    volumes = docker_client.containers.run.call_args.kwargs["volumes"]
+    assert volumes["/data/skills"] == {"bind": "/app/skills-store", "mode": "rw"}
+    assert volumes["/data/logs"] == {"bind": "/app/logs", "mode": "rw"}
+    assert HARNESS_SKILLS_MOUNT == "/app/skills-store"
+    assert HARNESS_LOGS_MOUNT == "/app/logs"
+
+
+def test_unset_mount_paths_are_omitted():
+    docker_client = MagicMock()
+    docker_client.containers.run.return_value = MagicMock(id="x")
+    cfg = _config()
+    cfg.skills_store_path = None
+    cfg.logs_path = None
+    mgr = HarnessManager(cfg, docker_client=docker_client)
+    mgr.start(rest_port=8600, mcp_port=8700)
+    assert docker_client.containers.run.call_args.kwargs["volumes"] == {}
+
+
+def test_harness_llm_overrides_passed_through_when_set():
+    docker_client = MagicMock()
+    docker_client.containers.run.return_value = MagicMock(id="x")
+    cfg = _config()
+    cfg.llm_provider = "openai"
+    cfg.llm_skill_generation_model = "gateway/gpt-4.1"
+    cfg.llm_simulation_model = "gateway/gpt-4.1-mini"
+    mgr = HarnessManager(cfg, docker_client=docker_client)
+    mgr.start(rest_port=8600, mcp_port=8700)
+
+    env = docker_client.containers.run.call_args.kwargs["environment"]
+    assert env["HARNESS_LLM_PROVIDER"] == "openai"
+    assert env["HARNESS_LLM_SKILL_GENERATION_MODEL"] == "gateway/gpt-4.1"
+    assert env["HARNESS_LLM_SIMULATION_MODEL"] == "gateway/gpt-4.1-mini"
+
+
+def test_harness_llm_overrides_omitted_when_unset():
+    """Unset overrides must not appear at all, so the image's harness.yaml wins."""
+    docker_client = MagicMock()
+    docker_client.containers.run.return_value = MagicMock(id="x")
+    mgr = HarnessManager(_config(), docker_client=docker_client)
+    mgr.start(rest_port=8600, mcp_port=8700)
+
+    env = docker_client.containers.run.call_args.kwargs["environment"]
+    assert "HARNESS_LLM_PROVIDER" not in env
+    assert "HARNESS_LLM_SKILL_GENERATION_MODEL" not in env
+    assert "HARNESS_LLM_SIMULATION_MODEL" not in env
 
 
 def test_stop_removes_container():

--- a/plugins/skillberry-plugin-simulate/tests/test_orchestrator.py
+++ b/plugins/skillberry-plugin-simulate/tests/test_orchestrator.py
@@ -6,7 +6,11 @@ import pytest
 from skillberry_plugin_simulate.config import SimulateConfig
 from skillberry_plugin_simulate.harness_client import HarnessClient
 from skillberry_plugin_simulate.openapi_synth import OpenApiSynthesizer
-from skillberry_plugin_simulate.orchestrator import SimulateOrchestrator
+from skillberry_plugin_simulate.orchestrator import (
+    SimulateOrchestrator,
+    simulation_name,
+    tools_fingerprint,
+)
 from skillberry_plugin_simulate.registry import ActiveVmcpRegistry
 from skillberry_plugin_simulate.sim_manifests import SIMULATION_TAG
 
@@ -38,14 +42,20 @@ def _orch(tmp_path, store):
         "container_id": "c1", "rest_port": 8600, "mcp_port": 8700, "rest_url": "http://127.0.0.1:8600",
     }
 
+    created = {}
+
     def ready_handler(request):
         if request.method == "POST":
-            return httpx.Response(200, json={"status": "starting"})
+            import json
+            created["body"] = json.loads(request.content)
+            return httpx.Response(202, json={"status": "pending"})
         return httpx.Response(200, json={"status": "ready", "mcp_url": "http://127.0.0.1:8700/sse"})
 
     def client_factory(rest_url):
         transport = httpx.MockTransport(ready_handler)
         return HarnessClient(httpx.AsyncClient(transport=transport, base_url=rest_url))
+
+    harness_mgr.created = created
 
     reg = ActiveVmcpRegistry(str(tmp_path / "reg.json"))
     return SimulateOrchestrator(
@@ -213,3 +223,58 @@ async def test_simulate_tears_down_existing_simulation_before_starting_new(tmp_p
     store.delete_skill.assert_any_call("old-sim-skill")
     store.delete_tool.assert_any_call("old-sim-t1")
     assert reg.get("skill-1") is not None  # new simulation registered
+
+
+# --- harness simulation name (generated-skill cache key) ---
+
+@pytest.mark.asyncio
+async def test_simulate_names_the_simulation_after_skill_and_tool_surface(tmp_path):
+    """The harness caches generated artifacts under <skills-store>/<name>/ and
+    skips LLM generation on a hit, so the name must change when tools change."""
+    store = _store()
+    orch, harness_mgr, _ = _orch(tmp_path, store)
+
+    await orch.simulate("skill-1")
+
+    tools = [store.get_tool.return_value]
+    assert harness_mgr.created["body"]["name"] == simulation_name(
+        "weather", tools_fingerprint(tools)
+    )
+
+
+def test_simulation_name_changes_with_the_tool_surface():
+    base = [{"name": "get_weather", "params": {"type": "object"}}]
+    changed = [{"name": "get_weather", "params": {"type": "object", "properties": {"city": {}}}}]
+    assert simulation_name("weather", tools_fingerprint(base)) != simulation_name(
+        "weather", tools_fingerprint(changed)
+    )
+
+
+def test_simulation_name_distinguishes_same_named_skills():
+    """Two skills sharing a display name must not share a cache directory."""
+    a = [{"name": "alpha", "params": {}}]
+    b = [{"name": "beta", "params": {}}]
+    assert simulation_name("weather", tools_fingerprint(a)) != simulation_name(
+        "weather", tools_fingerprint(b)
+    )
+
+
+def test_simulation_name_survives_the_harness_64_char_cap():
+    """The harness truncates names to 64 chars; the fingerprint must not be the
+    part that gets cut, or long-named skills would all collide."""
+    fingerprint = "abcdef1234567890"
+    name = simulation_name("x" * 200, fingerprint)
+    assert len(name) <= 64
+    assert name.endswith(f"-{fingerprint[:8]}")
+
+
+def test_simulation_name_is_a_valid_agent_skills_name():
+    """Must match what the harness's own sanitizer would produce, so the name we
+    compute is the directory it actually uses."""
+    import re
+    name = simulation_name("Weather / Forecast  (v2)!!", "abcdef1234567890")
+    assert re.fullmatch(r"[a-z0-9]+(-[a-z0-9]+)*", name), name
+
+
+def test_simulation_name_falls_back_when_base_is_all_punctuation():
+    assert simulation_name("///", "abcdef1234567890") == "simulation-abcdef12"

--- a/plugins/skillberry-plugin-simulate/tests/test_orchestrator_routing.py
+++ b/plugins/skillberry-plugin-simulate/tests/test_orchestrator_routing.py
@@ -69,7 +69,8 @@ def test_toggle_delegates_to_registry(tmp_path):
     assert orch.toggle("skill-1")["active"] == "sim"
 
 
-def test_teardown_deletes_sim_artifacts_and_stops_harness(tmp_path):
+@pytest.mark.asyncio
+async def test_teardown_deletes_sim_artifacts_and_stops_harness(tmp_path):
     store = MagicMock()
     harness_mgr = MagicMock()
     store.get_vmcp.return_value = {
@@ -80,7 +81,7 @@ def test_teardown_deletes_sim_artifacts_and_stops_harness(tmp_path):
     orch, reg = _orch(tmp_path, store, harness_mgr=harness_mgr)
     reg.upsert("skill-1", real_vmcp_uuid="real-vmcp", sim_vmcp_uuid="sim-vmcp")
 
-    out = orch.teardown("skill-1")
+    out = await orch.teardown("skill-1")
 
     store.delete_vmcp.assert_called_once_with("sim-vmcp")
     store.delete_tool.assert_called_once_with("sim-t1")

--- a/plugins/skillberry-plugin-simulate/tests/test_plugin_endpoints.py
+++ b/plugins/skillberry-plugin-simulate/tests/test_plugin_endpoints.py
@@ -75,7 +75,7 @@ def test_toggle_endpoint():
 
 def test_teardown_endpoint():
     orch = MagicMock()
-    orch.teardown.return_value = {"success": True, "skill_uuid": "skill-1"}
+    orch.teardown = AsyncMock(return_value={"success": True, "skill_uuid": "skill-1"})
     client = _app_with_plugin(orch)
     resp = client.post("/plugins/simulate/teardown", json={"skill_uuid": "skill-1"})
     assert resp.status_code == 200


### PR DESCRIPTION
## What

The simulation harness has moved out of the internal repo. It now lives at
[**skillberry-ai/simulation-harness**](https://github.com/skillberry-ai/simulation-harness)
and publishes to `ghcr.io/skillberry-ai/simulation-harness` (public — no registry
login). This points `skillberry-plugin-simulate` at that image and aligns it with
the image's **actual** contract, verified by reading the harness source at v0.1.2
rather than trusting the old assumptions.

Four of those assumptions were wrong, and the plugin would have failed against the
external image:

| # | Assumption in the plugin | Reality in the external harness |
|---|---|---|
| 1 | image `simulation-harness:latest` (local build) | `ghcr.io/skillberry-ai/simulation-harness` |
| 2 | mounts at `/skills-store` (**ro**) and `/logs` | image reads `/app/skills-store` and `/app/logs`, and **writes** to the former |
| 3 | session expiry arrives as `410` on the status endpoint | never surfaces there; the harness self-heals per tool call |
| 4 | harness may be handed an unnamed simulation | name keys a generated-skill cache shared by every simulation |

The parts that still line up are worth stating, since they are what the whole
design hangs on and they needed no change: REST port `8086`,
`POST`/`GET`/`DELETE /api/v1/simulation`, and `mcp_port` as a create field. With
`mcp_port` set, `_build_mcp_url` derives the sidecar URL from the request Host —
which is exactly the `127.0.0.1:<rest_port>` the plugin dials — so it returns
`http://127.0.0.1:<mcp_port>/mcp/sse`, the harness defaults to `sse`, and the
store connects with `sse_client` (`server_utils.py:148`). The 1:1 port publish and
the tool-manifest `mcp_url` keep working untouched.

## The change

**1. Image tag — `:0.1`, deliberately not `:latest`.** Upstream tags `latest` from
every push to `main` (`type=raw,value=latest,enable={{is_default_branch}}`), so it
is the *least* stable tag despite being the name one reaches for by convention. It
has already diverged from the newest release:

```
latest  sha256:49746ffa4bef…   # main
main    sha256:49746ffa4bef…
0.1     sha256:07be14cd236f…   # v0.1.2
0.1.2   sha256:07be14cd236f…
```

`:0.1` is the newest `v0.1.x` release and the closest thing to "latest release"
that exists today. It does stall silently on the next minor, so I filed
[simulation-harness#3](https://github.com/skillberry-ai/simulation-harness/issues/3)
asking for a `release` tag; until that lands, a `v0.2.0` needs a deliberate bump
here, which the README now says.

**2. Mount points — and read-write.** The image bakes
`HARNESS_SKILLS_FOLDER=/app/skills-store` and `HARNESS_LOG_DESTINATION=/app/logs`,
so the old `/skills-store` and `/logs` binds landed nowhere and were silently
ignored. `skills-store` also has to be **rw**: the harness generates `SKILL.md`,
`schema.json`, `db.json` and `api.json` into it, so a read-only bind fails
generation outright.

**3. Removed the resubmit-on-410 path.** `SessionExpiredError` is raised only
inside the harness's own `execute_tool`, where it resets the session itself and
fails just the one call that tripped the limit
(`core/simulation_instance.py:130-146`). It never reaches the `410` handler from a
status poll, and tool calls go from the vMCP straight to the harness, so this
client could never observe it — the code and its test were unreachable. The README
claimed *the plugin* auto-resets; corrected to say the harness does, per call.

**4. Named simulations, keyed by tool surface.** The harness caches generated skill
artifacts under `<skills-store>/<name>/` and skips the slow LLM generation on a
hit. Every simulation shares one mounted skills-store, so an unnamed simulation
(name derived from `info.title`) means two skills with the same display name
collide, and re-simulating a skill whose tools changed silently reuses stale
artifacts. Each simulation is now `<skill-slug>-<tools-fingerprint[:8]>`, reusing
the `tools_fingerprint()` that already existed for drift detection. The slug
mirrors the harness's own `sanitize_skill_name` and reserves room for the suffix,
so its 64-char truncation cannot eat the fingerprint.

**Docker calls move off the event loop.** `simulate()` is async but called
`harness_manager.start()` synchronously. That was cheap against a locally-built
image; against a registry, docker-py pulls on first use — a multi-hundred-MB
download stalling the store's event loop. Both start and stop go through
`asyncio.to_thread`, which makes `teardown()` async (its only two callers await it).

**Two smaller contract fixes.** `409` (busy harness *or* `mcp_port` already bound —
plausible when a leaked container holds it) and `422` (rejected OpenAPI spec) now
get distinct, actionable messages instead of one opaque `HarnessError`. And a
`failed` status renders the harness's structured `error` object — it is
`{code, message, details}` now, where the old code would have stringified a dict
into the exception message.

**Config passthrough.** Optional `SIMULATE_LLM_PROVIDER` /
`_SKILL_GENERATION_MODEL` / `_SIMULATION_MODEL` forward as `HARNESS_LLM_*`. The
image defaults to provider `openai` with `gpt-4.1` for both models, which need not
resolve behind a gateway that namespaces model ids. Unset means "leave the image's
`harness.yaml` alone".

## Tests

Plugin suite **62 → 82**, all passing.

I checked the two most load-bearing new tests are real regressions rather than
tautologies: reverting just the mount config and just the `name=` kwarg makes
exactly those two fail and nothing else.

New coverage: the image default is the release line and never `:latest`; mounts use
the image's paths and are writable; `HARNESS_LLM_*` appear only when set;
transitional statuses (`pending` / `generating_skill` / `initializing`) keep
polling; `409` / `422` / `404` map to distinct messages; a structured `error`
object renders; a timeout reports the last status and generation phase; and five
cases pinning the simulation-name rules (changes with the tool surface,
distinguishes same-named skills, survives the 64-char cap, is a valid Agent Skills
name, falls back when the base is all punctuation).

`make lint` clean. Note it only covers `src/skillberry_store/**`, not the plugin
tree — so I also checked `black` on the plugin separately: the tree is **16
reformat / 4 clean** both before and after this PR, i.e. it was never
black-formatted and this change does not add to that. One file I touched had
regressed to non-clean; it is formatted back.

Full `make test` shows 22 failed / 146 errors, all in `src/skillberry_store/tests/**`
(e2e wanting a live service, UI-serving tests wanting a `dist` bundle that
`make test` does not build). **These are pre-existing and unrelated.** I verified
that rather than assuming it — running the failing subset in one fixed environment
with only the plugin swapped between this branch and `origin/main` gives an
identical 22 failed / 9 passed / 43 errors either way. The plugin's own 82 tests are
collected by `make test` and pass within it.

## Not covered

Everything here is unit-level. The mount paths, the cold-start pull and the cache
naming only truly prove out end-to-end, and a smoke run means a ~500MB pull plus
real LLM spend, so it has not been done. Worth one manual run before anyone relies
on this in anger: pull the image, simulate a sample skill, confirm the sim vMCP
answers a tool call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
