### PR TITLE
Wrap description text in list views instead of truncating to one line

### DIFF
--- a/src/skillberry_store/ui/src/components/SkillCard.tsx
+++ b/src/skillberry_store/ui/src/components/SkillCard.tsx
@@ -72,15 +72,11 @@ export function SkillCard({ skill, isSelected, onSelect }: SkillCardProps) {
         </div>
 
         {/* Description — 3-line clamp */}
-        <p style={{
+        <p className="description-clamp" style={{
           color: '#151515',
           margin: '0 0 10px',
           lineHeight: '1.5',
           fontSize: '13px',
-          display: '-webkit-box',
-          WebkitLineClamp: 3,
-          WebkitBoxOrient: 'vertical',
-          overflow: 'hidden',
           paddingLeft: '22px',
         }}>
           {skill.description || 'No description'}

--- a/src/skillberry_store/ui/src/components/SkillListView.tsx
+++ b/src/skillberry_store/ui/src/components/SkillListView.tsx
@@ -35,7 +35,7 @@ export function SkillListView({
             }}
           />
           <Th sort={getSortParams(0)} width={20}>Name</Th>
-          <Th sort={getSortParams(1)} width={35} modifier="truncate">Description</Th>
+          <Th sort={getSortParams(1)} width={35}>Description</Th>
           <Th width={15}>Tags</Th>
           <Th width={10}>Tools</Th>
           <Th width={10}>Snippets</Th>
@@ -61,11 +61,12 @@ export function SkillListView({
             </Td>
             <Td
               dataLabel="Description"
-              modifier="truncate"
               onClick={() => navigate(`/skills/${skill.uuid}`)}
               style={{ cursor: 'pointer' }}
             >
-              {skill.description || 'No description'}
+              <span className="description-clamp" title={skill.description || undefined}>
+                {skill.description || 'No description'}
+              </span>
             </Td>
             <Td
               dataLabel="Tags"

--- a/src/skillberry_store/ui/src/pages/SnippetsPage.tsx
+++ b/src/skillberry_store/ui/src/pages/SnippetsPage.tsx
@@ -445,7 +445,7 @@ export function SnippetsPage() {
                   }}
                 />
                 <Th sort={getSortParams(0)} width={20}>Name</Th>
-                <Th sort={getSortParams(1)} width={35} modifier="truncate">Description</Th>
+                <Th sort={getSortParams(1)} width={35}>Description</Th>
                 <Th sort={getSortParams(2)} width={10}>State</Th>
                 <Th width={15}>Tags</Th>
                 <Th sort={getSortParams(3)} width={10}>Content Type</Th>
@@ -471,11 +471,12 @@ export function SnippetsPage() {
                   </Td>
                   <Td
                     dataLabel="Description"
-                    modifier="truncate"
                     onClick={() => navigate(`/snippets/${snippet.uuid}`)}
                     style={{ cursor: 'pointer' }}
                   >
-                    {snippet.description || 'No description'}
+                    <span className="description-clamp" title={snippet.description || undefined}>
+                      {snippet.description || 'No description'}
+                    </span>
                   </Td>
                   <Td
                     dataLabel="State"

--- a/src/skillberry_store/ui/src/pages/ToolDetailPage.tsx
+++ b/src/skillberry_store/ui/src/pages/ToolDetailPage.tsx
@@ -352,7 +352,7 @@ export function ToolDetailPage() {
                           <Thead>
                             <Tr>
                               <Th width={20}>Name</Th>
-                              <Th width={40} modifier="truncate">Description</Th>
+                              <Th width={40}>Description</Th>
                               <Th width={10}>State</Th>
                               <Th width={10}>Tags</Th>
                               <Th width={10}>Module Name</Th>
@@ -384,11 +384,12 @@ export function ToolDetailPage() {
                                   </Td>
                                   <Td
                                     dataLabel="Description"
-                                    modifier="truncate"
                                     onClick={() => navigate(`/tools/${depUuid}`)}
                                     style={{ cursor: 'pointer' }}
                                   >
-                                    {depTool.description || 'No description'}
+                                    <span className="description-clamp" title={depTool.description || undefined}>
+                                      {depTool.description || 'No description'}
+                                    </span>
                                   </Td>
                                   <Td
                                     dataLabel="State"

--- a/src/skillberry_store/ui/src/pages/ToolsPage.tsx
+++ b/src/skillberry_store/ui/src/pages/ToolsPage.tsx
@@ -401,7 +401,7 @@ export function ToolsPage() {
                   }}
                 />
                 <Th sort={getSortParams(0)} width={20}>Name</Th>
-                <Th sort={getSortParams(1)} width={40} modifier="truncate">Description</Th>
+                <Th sort={getSortParams(1)} width={40}>Description</Th>
                 <Th sort={getSortParams(2)} width={10}>State</Th>
                 <Th width={10}>Tags</Th>
                 <Th sort={getSortParams(3)} width={10}>Module Name</Th>
@@ -427,11 +427,12 @@ export function ToolsPage() {
                   </Td>
                   <Td
                     dataLabel="Description"
-                    modifier="truncate"
                     onClick={() => navigate(`/tools/${tool.uuid}`)}
                     style={{ cursor: 'pointer' }}
                   >
-                    {tool.description || 'No description'}
+                    <span className="description-clamp" title={tool.description || undefined}>
+                      {tool.description || 'No description'}
+                    </span>
                   </Td>
                   <Td
                     dataLabel="State"

--- a/src/skillberry_store/ui/src/pages/VMCPServersPage.tsx
+++ b/src/skillberry_store/ui/src/pages/VMCPServersPage.tsx
@@ -468,7 +468,7 @@ export function VMCPServersPage() {
                   }}
                 />
                 <Th sort={getSortParams(0)} width={15}>Name</Th>
-                <Th sort={getSortParams(1)} width={30} modifier="truncate">Description</Th>
+                <Th sort={getSortParams(1)} width={30}>Description</Th>
                 <Th sort={getSortParams(2)} width={10}>State</Th>
                 <Th width={15}>Tags</Th>
                 <Th sort={getSortParams(3)} width={10}>Port</Th>
@@ -495,11 +495,12 @@ export function VMCPServersPage() {
                   </Td>
                   <Td
                     dataLabel="Description"
-                    modifier="truncate"
                     onClick={() => navigate(`/vmcp-servers/${server.uuid}`)}
                     style={{ cursor: 'pointer' }}
                   >
-                    {server.description || 'No description'}
+                    <span className="description-clamp" title={server.description || undefined}>
+                      {server.description || 'No description'}
+                    </span>
                   </Td>
                   <Td
                     dataLabel="State"

--- a/src/skillberry_store/ui/src/pages/VNFSServersPage.tsx
+++ b/src/skillberry_store/ui/src/pages/VNFSServersPage.tsx
@@ -375,7 +375,7 @@ export function VNFSServersPage() {
               <Tr>
                 <Th select={{ onSelect: (_e, isSelected) => handleSelectAll(isSelected), isSelected: selectedServers.length === totalFiltered && totalFiltered > 0 }} />
                 <Th sort={getSortParams(0)} width={15}>Name</Th>
-                <Th sort={getSortParams(1)} width={25} modifier="truncate">Description</Th>
+                <Th sort={getSortParams(1)} width={25}>Description</Th>
                 <Th sort={getSortParams(2)} width={10}>State</Th>
                 <Th width={10}>Tags</Th>
                 <Th sort={getSortParams(3)} width={10}>Port</Th>
@@ -389,7 +389,7 @@ export function VNFSServersPage() {
                 <Tr key={server.uuid}>
                   <Td select={{ rowIndex: index, onSelect: (_e, isSelected) => handleSelectServer(server.name, isSelected), isSelected: selectedServers.includes(server.name) }} />
                   <Td dataLabel="Name" onClick={() => navigate(`/vnfs-servers/${server.uuid}`)} style={{ cursor: 'pointer' }}>{server.name}</Td>
-                  <Td dataLabel="Description" modifier="truncate" onClick={() => navigate(`/vnfs-servers/${server.uuid}`)} style={{ cursor: 'pointer' }}>{server.description || 'No description'}</Td>
+                  <Td dataLabel="Description" onClick={() => navigate(`/vnfs-servers/${server.uuid}`)} style={{ cursor: 'pointer' }}><span className="description-clamp" title={server.description || undefined}>{server.description || 'No description'}</span></Td>
                   <Td dataLabel="State" onClick={() => navigate(`/vnfs-servers/${server.uuid}`)} style={{ cursor: 'pointer' }}>{server.state || '-'}</Td>
                   <Td dataLabel="Tags" onClick={() => navigate(`/vnfs-servers/${server.uuid}`)} style={{ cursor: 'pointer' }}>
                     {server.tags && server.tags.length > 0 ? (

--- a/src/skillberry_store/ui/src/styles/global.css
+++ b/src/skillberry_store/ui/src/styles/global.css
@@ -119,6 +119,21 @@ code[style*="backgroundColor"],
   white-space: nowrap;
 }
 
+/*
+ * Description cells in list/table views: wrap onto multiple lines, but cap the
+ * height so row heights stay uniform. Matches the 3-line clamp used by the
+ * card views (see SkillCard). Pair with a `title` attribute so the full text
+ * remains reachable on hover.
+ */
+.description-clamp {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  /* Keep an unbreakable token (long URL, identifier) from widening the column. */
+  overflow-wrap: anywhere;
+}
+
 /* Loading spinner container */
 .loading-container {
   display: flex;


### PR DESCRIPTION
## Problem

In list (table) views, the Description column is cut off at the end of the first line with an ellipsis. The same skills show multi-line descriptions correctly in card view.

## Cause

Not a missing wrap rule — an explicit opt-in. Every Description column passed PatternFly's `modifier="truncate"` on both the `<Th>` and the `<Td>`, which emits `pf-m-truncate`:

```css
--pf-v5-c-table--cell--MaxWidth: 1px;      /* collapses the column */
--pf-v5-c-table--cell--Overflow: hidden;
--pf-v5-c-table--cell--TextOverflow: ellipsis;
--pf-v5-c-table--cell--WhiteSpace: nowrap; /* the single line */
```

PatternFly's default for table cells is `WhiteSpace: normal` / `Overflow: visible`, so cells wrap fine without the modifier. Card view has no modifier and clamps to 3 lines via `-webkit-line-clamp` (`SkillCard.tsx`), which is why it renders correctly.

The problem was present in all six list/table views, not just skills:

| Object | File |
| --- | --- |
| Skills | `components/SkillListView.tsx` |
| Tools | `pages/ToolsPage.tsx` |
| Snippets | `pages/SnippetsPage.tsx` |
| vMCP servers | `pages/VMCPServersPage.tsx` |
| vNFS servers | `pages/VNFSServersPage.tsx` |
| Dependent tools (tool detail) | `pages/ToolDetailPage.tsx` |

The catalog-import results table was the only description column without the modifier, and it already wrapped correctly.

## Fix

- Drop `modifier="truncate"` from the Description `<Th>`/`<Td>` in all six tables. The `width={N}` hint still governs the column once `MaxWidth: 1px` is gone.
- Add a shared `.description-clamp` rule in `styles/global.css`: a 3-line `-webkit-line-clamp` box matching card view, plus `overflow-wrap: anywhere` so an unbreakable token (long URL or identifier) wraps rather than widening the column.
- Wrap the description text in `<span className="description-clamp" title={description}>` so the full text stays reachable on hover.
- `SkillCard` now uses the same class instead of its own inline clamp, so the line count is defined in one place.

Descriptions wrap to at most 3 lines with an ellipsis, matching card view; row heights stay uniform.

## Verification

- Rendered the resulting markup against PatternFly's table CSS in a browser: description wraps to 3 lines with the ellipsis on line 3, the column holds its width percentage, short descriptions stay on one line, and a 100-character unbreakable token wraps instead of stretching the column.
- `vite build` passes.
- `tsc --noEmit`: 152 pre-existing errors before and after the change, byte-identical — no new type errors.
- `vitest run`: 8 failed files / 49 failed tests both before and after (verified against a stashed baseline) — all pre-existing and unrelated to the touched files.
- `eslint` on the seven touched files: identical warning set before and after, differing only by line-number offsets from the added lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)