### PR TITLE
Stop tagging imported items with each segment of their own file path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,19 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Anthropic skill import no longer turns every path segment into a tag.**
+  Importing a skill tagged each generated tool and snippet with `file:<path>`
+  *and* with one bare tag per segment of that same path — so
+  `scripts/check_bounding_boxes.py` produced `scripts` and
+  `check_bounding_boxes.py` alongside it. Nothing consumed the bare tags (the
+  exporter reads the `file:` tag to rebuild the skill layout), but they
+  dominated the UI's tag picker: on a 580-snippet store, 239 of 638 distinct
+  tags were file names. The file extension (`md`, `py`) is still tagged; the
+  path is now recorded only in `file:<path>`.
+
+  Items imported before this change keep their old tags — the store is not
+  migrated. Re-import a skill to drop them, or strip any tag that exactly
+  matches a segment of the item's own `file:` tag.
 - UI sourcemaps are no longer emitted by default. The bundle is served on the same
   unauthenticated port as the API, so shipping maps published the frontend source to
   anyone who could reach the service. Build with `VITE_SOURCEMAP=true make ui-build`

--- a/src/skillberry_store/tests/tools/test_anthropic_parsers.py
+++ b/src/skillberry_store/tests/tools/test_anthropic_parsers.py
@@ -56,12 +56,21 @@ class TestTextParser:
         assert description.endswith("...")
     
     def test_extract_tags(self):
-        """Test extracting tags from file path."""
+        """Test extracting tags from a file name."""
         tags = extract_tags("skills/pptx/utils.py", "utils.py", "test_skill")
         assert "py" in tags
         assert "anthropic" in tags
-        assert "pptx" in tags
-        assert "utils.py" in tags
+
+    def test_extract_tags_omits_path_segments(self):
+        """Path segments and the bare file name are not tags of their own.
+
+        The path is carried by the ``file:<path>`` tag the callers prepend, so
+        re-emitting each segment only cluttered the tag picker.
+        """
+        tags = extract_tags("skills/pptx/utils.py", "utils.py", "test_skill")
+        assert tags == ["py", "anthropic"]
+        for absent in ("skills", "pptx", "utils.py", "test_skill"):
+            assert absent not in tags
     
     def test_strip_frontmatter(self):
         """Test stripping YAML frontmatter."""
@@ -107,7 +116,10 @@ This is the actual content."""
         assert snippets[0].content == content
         assert "file:docs/test.md" in snippets[0].tags
         assert "skill:test_skill" in snippets[0].tags
-    
+        # The path lives only in the file: tag - no bare segment tags.
+        assert "test.md" not in snippets[0].tags
+        assert "docs" not in snippets[0].tags
+
     def test_parse_text_file_multiple_paragraphs(self):
         """Test parsing text file into multiple snippets."""
         content = "First paragraph.\n\nSecond paragraph."
@@ -254,6 +266,10 @@ def subtract(a, b):
         assert tools[0].programming_language == "python"
         assert "file:scripts/utils.py" in tools[0].tags
         assert "skill:test_skill" in tools[0].tags
+        # The path lives only in the file: tag - no bare segment tags.
+        for tool in tools:
+            assert "utils.py" not in tool.tags
+            assert "scripts" not in tool.tags
 
     def test_parse_code_file_python_multi_function_module_content_is_full_file(self):
         """Test that each tool's module_content is the full file when multiple functions exist."""
@@ -320,6 +336,11 @@ calculate() {
         assert tools[0].name == "greet"
         assert tools[1].name == "calculate"
         assert tools[0].programming_language == "bash"
+        # The path lives only in the file: tag - no bare segment tags.
+        for tool in tools:
+            assert "file:scripts/script.sh" in tool.tags
+            assert "script.sh" not in tool.tags
+            assert "scripts" not in tool.tags
 
     def test_parse_code_file_bash_multi_function_module_content_is_full_file(self):
         """Test that each bash tool's module_content is the full file when multiple functions exist."""

--- a/src/skillberry_store/tools/anthropic/code_parser.py
+++ b/src/skillberry_store/tools/anthropic/code_parser.py
@@ -513,7 +513,7 @@ def parse_code_file(
                 "python",
                 "anthropic",
                 "script",
-            ] + [p for p in file_path.split("/") if p and p not in (".", "..")]
+            ]
 
             tools.append(
                 ParsedTool(
@@ -559,7 +559,7 @@ def parse_code_file(
                 f"skill:{skill_name}",
                 "python",
                 "anthropic",
-            ] + [p for p in file_path.split("/") if p and p not in (".", "..")]
+            ]
 
             tools.append(
                 ParsedTool(
@@ -601,7 +601,7 @@ def parse_code_file(
                     f"skill:{skill_name}",
                     "python",
                     "anthropic",
-                ] + [p for p in file_path.split("/") if p and p not in (".", "..")]
+                ]
 
                 tools.append(
                     ParsedTool(
@@ -642,7 +642,7 @@ def parse_code_file(
                 "bash",
                 "anthropic",
                 "script",
-            ] + [p for p in file_path.split("/") if p and p not in (".", "..")]
+            ]
 
             tools.append(
                 ParsedTool(
@@ -671,7 +671,7 @@ def parse_code_file(
                 f"skill:{skill_name}",
                 "bash",
                 "anthropic",
-            ] + [p for p in file_path.split("/") if p and p not in (".", "..")]
+            ]
 
             tools.append(
                 ParsedTool(
@@ -696,7 +696,7 @@ def parse_code_file(
                     f"skill:{skill_name}",
                     "bash",
                     "anthropic",
-                ] + [p for p in file_path.split("/") if p and p not in (".", "..")]
+                ]
 
                 tools.append(
                     ParsedTool(

--- a/src/skillberry_store/tools/anthropic/text_parser.py
+++ b/src/skillberry_store/tools/anthropic/text_parser.py
@@ -69,12 +69,22 @@ def generate_description(content: str) -> str:
 
 
 def extract_tags(file_path: str, file_name: str, skill_name: str = "") -> List[str]:
-    """Extract tags from filename and path.
+    """Extract tags from a file name.
+
+    The source path is *not* split into per-segment tags. It is already
+    recorded verbatim in the ``file:<path>`` tag the callers prepend, and that
+    tag is what :mod:`skillberry_store.tools.anthropic.exporter` reads back to
+    reconstruct the skill layout. Emitting the segments as well produced one
+    bare tag per directory and per file name (``scripts``,
+    ``check_bounding_boxes.py``), which nothing consumed and which crowded the
+    UI's tag picker out of usefulness.
 
     Args:
-        file_path: The full file path
+        file_path: The full file path. Retained for signature compatibility;
+            no tags are derived from it.
         file_name: The file name
-        skill_name: The skill name (optional)
+        skill_name: The skill name (optional). Callers add their own
+            ``skill:<name>`` tag; nothing is derived from it here.
 
     Returns:
         List of extracted tags
@@ -85,11 +95,6 @@ def extract_tags(file_path: str, file_name: str, skill_name: str = "") -> List[s
     parts = file_name.split(".")
     if len(parts) > 1:
         tags.append(parts[-1])
-
-    # Add directory names as tags (excluding common ones)
-    excluded_dirs = {".", "..", "src", "docs"}
-    path_parts = [p for p in file_path.split("/") if p and p not in excluded_dirs]
-    tags.extend(path_parts)
 
     # Add 'anthropic' tag to identify source
     tags.append("anthropic")


### PR DESCRIPTION
## Problem

Browsing tools or snippets in the UI, "Filter by tags..." opens a list dominated by
values that are not really tags: bare file names (`check_bounding_boxes.py`), bare
directory names (`scripts`, `references`), and a `file:<path>` entry for every source
file in the store.

The Anthropic skill parsers were stamping each generated tool and snippet with
`file:<path>` **and** with one bare tag per segment of that same path:

```python
tags = [
    f"file:{file_path}",
    f"skill:{skill_name}",
    "python", "anthropic", "script",
] + [p for p in file_path.split("/") if p and p not in (".", "..")]
```

`extract_tags()` in `text_parser.py` did the same thing, under a comment that says
"Add directory names as tags" — but `file_path.split("/")` never dropped the last
segment, so the file name came along too. So `scripts/check_bounding_boxes.py`
yielded `file:scripts/check_bounding_boxes.py`, `scripts`, **and**
`check_bounding_boxes.py`.

Nothing consumed the bare tags. `exporter.py` reconstructs the skill's directory
layout by reading the `file:` tag (`extract_file_path_from_tags`), and it is the only
consumer of path information. The segment tags were pure import residue — while
being numerous enough to make the picker useless. Measured on a demo store:

| kind | items | distinct tags | of which file names / path segments |
|---|---|---|---|
| tools | 474 | 135 | 45 |
| snippets | 580 | 638 | **239** |

## Fix

Drop the path-segment expansion at all seven sites (six in `code_parser.py` covering
the python/bash × script/single-function/multi-function paths, one in
`text_parser.py`). The path is now recorded once, in `file:<path>`.

Kept deliberately:

- `file:<path>` — load-bearing for export round-trip
- `skill:<name>`, and the literals `python` / `bash` / `anthropic` / `script`
- the file **extension** (`md`, `py`, `json`) — a genuine type facet, ~10 distinct
  values, and not a path segment

`extract_tags()` keeps its signature; `file_path` and `skill_name` are now unused for
derivation and documented as such, so callers and the existing test import don't move.

## Verification

Parsed real skill folders from `skill-sets/advertising/skills` through the actual
parsers:

- 139 tools (107 python, 32 bash — exercising the multi-function fallback path too)
  and 33 snippets
- **0** items carry any segment of their own `file:` path as a bare tag
- non-`file:` tags across all 139 tools collapse to exactly:
  `anthropic`, `bash`, `python`, `script`, `skill:advertising`

Tests: 1260 passed. (`test_login_info.py::test_shipped_configs_document_the_key_without_enabling_it`
fails in my tree from an unrelated local edit to `access_control_config.yaml`, which is
not part of this branch; it passes with that file clean.) `black --check` clean over the
linted paths.

Added regression coverage: `test_extract_tags_omits_path_segments`, plus assertions in
the text/python/bash `parse_*` tests that no path segment appears as a bare tag.

## Not included

**Existing stores are not migrated** — items imported before this change keep their old
tags, so an existing instance's picker stays cluttered until those skills are
re-imported. Called out in the CHANGELOG. A one-off cleanup can strip any tag that
exactly matches a segment of the item's own `file:` tag; happy to add that as a
follow-up if it's wanted.

**`file:*` entries still appear in the picker** (252 distinct ones for snippets here).
Those tags are used, so removing them is not an option — but the facet endpoint could
hide reserved prefixes the way it already splits `namespace:` out
(`services/facets.py`), and `TagFilter.tsx` would then stop synthesizing a `file:*`
wildcard option. That's a display change, separate from this one, and not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
