### PR TITLE
Baked container env vars: set application env vars in the image, no Dockerfile edit

### DIFF
--- a/.mk/dev.mk
+++ b/.mk/dev.mk
@@ -98,6 +98,46 @@ ui-dev: $(UI_NM_STAMP) ## Run the Vite dev server with HMR (uses file watchers)
 	@cd $(UI_DIR) && npx vite --host 0.0.0.0 --port $${VITE_UI_PORT:-8002}
 
 
+##@ Container environment
+
+# Application env vars baked into the image, from $(CONTAINER_ENV_FILE).
+#
+# The service picks them up because tools/configure.py calls python-dotenv's
+# load_dotenv() at import time, and its search walks up from the package
+# directory to /app/.env. That places the values in os.environ before any
+# setting is read, so they are set under a plain `docker run <image>`, under a
+# k8s/OpenShift `command:` override, and without going through `make run` --
+# none of which is true of a value exported by a makefile.
+#
+# load_dotenv() does not override an already-set variable, so `docker run -e`,
+# `--env-file` and a k8s `env:` entry still win, exactly as they do over a
+# Dockerfile ENV. The file is a source of deployment *defaults*, not an
+# override, and it must hold no secrets: it is baked into the image.
+#
+# The image cannot just carry the repo's own .env -- that name is in
+# .dockerignore (and .gitignore), so it never enters the build context. Hence a
+# separate, version-controlled file copied to /app/.env via the EXTRA_COPY_FILES
+# hook, which also grants gid 0 the owner's access -- what makes the file
+# readable under the arbitrary UID OpenShift assigns.
+CONTAINER_ENV_FILE ?= container.env
+
+# A literal comma cannot appear unescaped in a $(if ...) argument.
+_cef_comma := ,
+
+# Guarded on the file existing: stage-extra-copy.sh fails hard on a missing
+# source, so an absent (or renamed) env file must drop out of the spec rather
+# than break every image build.
+#
+# `override`, and the existing value folded in, because EXTRA_COPY_FILES is
+# itself a documented user-facing knob: a plain assignment here would be
+# silently discarded by `make docker-build EXTRA_COPY_FILES=<pair>` -- and the
+# env file would then vanish from the image just because the caller also asked
+# to copy something else.
+ifneq ($(wildcard $(CONTAINER_ENV_FILE)),)
+override EXTRA_COPY_FILES := $(EXTRA_COPY_FILES)$(if $(strip $(EXTRA_COPY_FILES)),$(_cef_comma))./$(CONTAINER_ENV_FILE):/app/.env
+endif
+
+
 ##@ Docker image variants
 
 # The default image is core-only (Dockerfile sets ARG PLUGIN_EXTRAS= empty).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,30 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Baked container env vars.** Application environment variables can be given
+  fixed values that ship inside the image, by adding them to `container.env` at
+  the repo root:
+
+  ```
+  SBS_BASE_DIR=/app/store-data
+  OBSERVABILITY=false
+  ```
+
+  `make docker-build` copies the file to `/app/.env`, where the service already
+  picks it up at startup through python-dotenv — so the values are set under a
+  plain `docker run <image>`, with no `--env-file` flag, no `make` in the loop,
+  and no Dockerfile edit (a Dockerfile `ENV` name cannot be computed, so that
+  route costs one line per variable). They are *defaults*: an already-set
+  variable wins, so `docker run -e`, `--env-file` and Kubernetes
+  `env:`/`envFrom:` still override them, exactly as they would a Dockerfile
+  `ENV`. The values are baked into the image, so it must hold **no secrets** —
+  pass those at run time. Build against a different file with `make docker-build
+  CONTAINER_ENV_FILE=prod.env`; if the file is absent the build skips it. Any
+  `EXTRA_COPY_FILES` pair passed on the command line is kept alongside it.
+  Readable under the arbitrary UID OpenShift assigns, and — because the loading
+  happens inside the application rather than in an entrypoint script — it
+  survives a Kubernetes `command:` override. See `docs/config-env-vars.md`.
+
 - **Login information message.** An operator can show a short informational
   message at login — the `/etc/issue.net` tradition — by setting
   `standalone.login_info` in `access_control_config.yaml`:

--- a/container.env
+++ b/container.env
@@ -1,0 +1,23 @@
+# Application environment variables baked into the container image.
+#
+# Every uncommented KEY=VALUE line here is present in the service environment
+# whenever the image runs -- under a plain `docker run <image>`, under
+# `make docker-run`, and under Kubernetes/OpenShift -- with no Dockerfile edit
+# and no `--env-file` flag. The build copies this file to /app/.env inside the
+# image, and the service loads it at startup via python-dotenv (load_dotenv()
+# in src/skillberry_store/tools/configure.py).
+#
+# Precedence: a variable that is already set in the real environment WINS over
+# the value here, exactly as it would over a Dockerfile ENV. So these are
+# deployment defaults, and `docker run -e VAR=...`, `--env-file`, and a k8s
+# `env:` / `envFrom:` entry all still override them.
+#
+# Do NOT put secrets here: the values are baked into the image, so anyone who
+# can pull it can read them. Pass secrets at run time instead (`-e`, k8s
+# Secret + envFrom).
+#
+# See docs/config-env-vars.md for the full list of supported variables, and for
+# how to point the build at a different file (CONTAINER_ENV_FILE).
+
+# Example -- uncomment to move all persistent storage off /tmp:
+#SBS_BASE_DIR=/app/store-data

--- a/docs/config-env-vars.md
+++ b/docs/config-env-vars.md
@@ -105,3 +105,72 @@ non-anonymous import, the host matching the fetched URL is resolved in order:
 3. Neither — fall back to the `gh` CLI token in `~/.config/gh/hosts.yml`, if
    present (when `gh` stores it in the OS keyring it is not in the file, so this
    falls through to anonymous).
+
+## Setting these variables in a container
+
+Every variable in the tables above can be given a value that is **baked into the
+image**, so it is set under a plain `docker run <image>` with no `--env-file`
+flag, no `make` in the loop, and no Dockerfile edit.
+
+Put it in [`container.env`](../container.env) at the repo root:
+
+```sh
+# container.env
+SBS_BASE_DIR=/app/store-data
+SBS_VDB=faiss
+OBSERVABILITY=false
+```
+
+Then build and run normally:
+
+```sh
+make docker-build
+docker run -d --network=host ghcr.io/skillberry-ai/skillberry-store:latest
+```
+
+`make docker-build` copies the file to `/app/.env` inside the image (through the
+`EXTRA_COPY_FILES` hook — any pair you pass on the command line is kept as
+well), and the service loads it at startup with python-dotenv. Build against a
+different file with `make docker-build CONTAINER_ENV_FILE=prod.env`; if the file
+is absent the build simply skips it.
+
+### Precedence
+
+Highest wins:
+
+1. `docker run -e VAR=…` / `docker run --env-file …`, and Kubernetes `env:` /
+   `envFrom:` — per-deployment overrides.
+2. The image's own Dockerfile `ENV` (`APP_HOME`, `APP_DATA_DIR`, …).
+3. `container.env`, baked to `/app/.env` — deployment defaults.
+4. The default in the tables above, compiled into the code.
+
+So `container.env` behaves like a Dockerfile `ENV` would: it supplies a default
+and never fights a value the deployment sets explicitly. `make docker-run`
+additionally passes the host's own (git-ignored) `.env` with `--env-file`, which
+therefore overrides `container.env` — use the host `.env` for local, throwaway
+values and `container.env` for what should ship with the image.
+
+> **Never put secrets in `container.env`.** The values ride inside the image, so
+> anyone who can pull it can read them. Pass secrets at run time: `-e`, or a k8s
+> Secret via `envFrom:`.
+
+### Kubernetes and OpenShift
+
+Both are supported with no extra work:
+
+- **`env:` / `envFrom:` still override**, per the precedence above, so a
+  ConfigMap or Secret behaves exactly as it would against a Dockerfile `ENV`.
+- **Arbitrary UIDs (OpenShift) work.** The file is staged with the group given
+  the owner's access and lands under `$APP_HOME`, which the image `chgrp 0`s and
+  `chmod g=u`s — so the random UID OpenShift assigns (always in gid 0) can read
+  it. Verified by running the image as `--user 1000670000:0`.
+- **A `command:` override still gets the variables**, because the loading
+  happens inside the application rather than in an entrypoint script — unlike an
+  `ENTRYPOINT` wrapper, which `command:` replaces.
+- **`readOnlyRootFilesystem: true` is fine** — the file is only ever read.
+
+Two limits worth knowing: the variables reach the *application* process (and
+anything it spawns), so an interactive `docker exec … sh` will not see them; and
+a variable consumed at Python *import* time by a module imported before
+`skillberry_store.tools.configure` would miss them. Use a Dockerfile `ENV` for
+either case.


### PR DESCRIPTION
## Problem

There was no way to give a running container a subset of application env vars with
fixed values without either `make` or a Dockerfile edit:

| Existing mechanism | plain `docker run <image>` | command override / k8s `command:` |
|---|---|---|
| Host `.env` via `--env-file` | ✗ — the flag comes from `make docker-run` only | ✗ |
| `export` in `.mk/process.mk` | ✓ — only because CMD is `sh -c "make run"` | ✗ |
| Dockerfile `ENV` | ✓ | ✓ — but one literal line per variable |

Dockerfile `ENV` names cannot be computed — there is no bulk `ENV` and no
build-time `--env-file` — so that route means editing the Dockerfile for every
variable.

## What this does

Adds `container.env` at the repo root. `make docker-build` copies it to
`/app/.env` in the image, and the service already loads it at startup:
`tools/configure.py` has always called python-dotenv's `load_dotenv()`, whose
search walks up from the package directory and resolves `/app/.env`. **No
Dockerfile change, no new runtime code.**

```sh
echo 'SBS_BASE_DIR=/app/store-data' >> container.env
make docker-build
docker run -d --network=host ghcr.io/skillberry-ai/skillberry-store:latest   # value is set
```

The only missing piece was getting a file *to* `/app/.env`: the repo's own `.env`
cannot serve, since that name is in `.dockerignore` and never enters the build
context. Hence a separate, version-controlled file routed through the existing
`EXTRA_COPY_FILES` hook.

### Precedence — defaults, not overrides

`load_dotenv()` does not override an already-set variable, so `docker run -e`,
`--env-file` and k8s `env:`/`envFrom:` all still win, exactly as they would over
a Dockerfile `ENV`. Highest first: run-time env → the image's own Dockerfile
`ENV` → `container.env` → the code default.

Because the values are baked into the image, the file must hold **no secrets**;
this is stated in the file header, the docs and the CHANGELOG.

## Notes on the wiring

- `override`, with any caller value folded in, because `EXTRA_COPY_FILES` is a
  documented user-facing knob — this project already passes `plugin_config.json`
  through it. A plain assignment would be silently discarded by `make
  docker-build EXTRA_COPY_FILES=<pair>`, dropping the env file from the image
  just because the caller also asked to copy something else.
- Guarded on the file existing: `stage-extra-copy.sh` fails hard on a missing
  source, so a renamed or absent env file must drop out of the spec rather than
  break every image build. `CONTAINER_ENV_FILE=prod.env` selects another file.

## Kubernetes / OpenShift

- `env:` / `envFrom:` override it, per the precedence above.
- Readable under the arbitrary UID OpenShift assigns: staging applies `chmod
  g=u` and the file lands under `$APP_HOME`, which the image already `chgrp 0`s.
- **A `command:` override still gets the variables** — the loading happens
  inside the application, so unlike an `ENTRYPOINT` wrapper (which `command:`
  replaces) it cannot be bypassed.
- `readOnlyRootFilesystem: true` is fine; the file is only read.

Documented limits: an interactive `docker exec … sh` will not see them, and a
variable consumed at Python *import* time by a module imported before
`skillberry_store.tools.configure` would miss them. Use a Dockerfile `ENV` for
either case.

## Verification

Tested against a real local image, not only reasoned about:

| Case | Result |
|---|---|
| plain `docker run <image>` | value from file ✓ |
| `docker run -e VAR=x` | `x` — real env wins ✓ |
| `--user 1000670000:0` (arbitrary OpenShift UID) | value from file ✓ |
| `--entrypoint python` (command override) | value from file ✓ |

Also verified that `.dockerignore`'s `.env` pattern excludes only the root file
and not the staged `.extra-copy/app/.env`; that `EXTRA_COPY_FILES` composes
correctly in all four cases (default / caller pair / missing file / alternate
file); and that staging lands `.extra-copy/app/.env` with the group given the
owner's access.

`container.env` ships with its example commented out, so this changes no runtime
behavior until values are chosen.

`make test`: 2058 passed, 5 skipped, 1 failed — `test_login_info.py::test_shipped_configs_document_the_key_without_enabling_it`, pre-existing on this checkout from a local `access_control_config.yaml` edit that enables the demo login banner, unrelated to this change. `make lint`: clean (44 files unchanged; no Python touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)