### PR TITLE
Surface the introduction blog and live demo on the site and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 <p>
   <a href="https://skillberry-ai.github.io/skillberry-store/"><img src="https://img.shields.io/badge/site-live-0066CC" alt="site"></a>
+  <a href="https://skillberry-store-demo-adv.onrender.com"><img src="https://img.shields.io/badge/demo-live-3E8635" alt="live demo"></a>
   <a href="https://github.com/skillberry-ai/skillberry-store/actions/workflows/push.yml"><img src="https://github.com/skillberry-ai/skillberry-store/actions/workflows/push.yml/badge.svg?branch=main" alt="CI"></a>
   <a href="https://github.com/skillberry-ai/skillberry-store/stargazers"><img src="https://img.shields.io/github/stars/skillberry-ai/skillberry-store?style=flat&label=stars&color=0066CC" alt="GitHub stars"></a>
   <img src="https://img.shields.io/badge/status-beta%20(0.x)-orange" alt="status">
@@ -16,9 +17,13 @@ This service implements a smart skills repository for agentic workflows. Manage,
 
 ▶ [Watch full highlights video](https://github.com/user-attachments/assets/eab2f9f1-1196-4858-b4ca-72d6c664d9f3)
 
-[Inroduction blog](https://itnext.io/skillberry-store-the-open-source-control-plane-for-agent-skills-99be3aab6229?postPublishedType=repub)
+### Try it now
 
-[Live Demo](https://skillberry-store-demo-adv.onrender.com)
+|   |   |
+|---|---|
+| **[▶ Live demo](https://skillberry-store-demo-adv.onrender.com)** | A running instance — no install. Shared free instance, so the first load may take a few seconds to wake. |
+| **[📖 Introduction blog](https://itnext.io/skillberry-store-the-open-source-control-plane-for-agent-skills-99be3aab6229?postPublishedType=repub)** | Skillberry Store: the open-source control plane for agent skills. |
+| **[🌐 Website & docs](https://skillberry-ai.github.io/skillberry-store/)** | Feature tour, architecture, and CLI reference. |
 
 ## Features ✨
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ This service implements a smart skills repository for agentic workflows. Manage,
 
 ▶ [Watch full highlights video](https://github.com/user-attachments/assets/eab2f9f1-1196-4858-b4ca-72d6c664d9f3)
 
+[Inroduction blog](https://itnext.io/skillberry-store-the-open-source-control-plane-for-agent-skills-99be3aab6229?postPublishedType=repub)
+
+[Live Demo](https://skillberry-store-demo-adv.onrender.com)
+
 ## Features ✨
 
 - **Manage tools for agentic workloads**: Add (Persist), Remove, Update, and Delete tools.

--- a/site/README.md
+++ b/site/README.md
@@ -28,12 +28,15 @@ voiceover script, and code) — nothing is borrowed from other projects.
 - **Relative links** between pages and assets (the site is served at the project
   sub-path `/skillberry-store/`). Absolute URLs appear only in
   `canonical` / OpenGraph / `sitemap.xml`.
-- **Nav + footer are duplicated** in every HTML file (no includes/partials). When
-  you change the nav or footer, edit every page. Consider a small build script if
-  the site grows past ~10 pages.
+- **Announcement strip + nav + footer are duplicated** in every HTML file (no
+  includes/partials). When you change any of the three, edit every page. Consider
+  a small build script if the site grows past ~10 pages. The `.announce` strip at
+  the top of each `<body>` carries the current launch news (the introduction
+  blog); retire it by deleting that block from all six pages — the same links
+  live permanently in the footer's **Resources** column.
 - **Cache-busting:** the stylesheet is linked as `style.css?v=YYYYMMDD-N`. Bump
   this query string whenever you edit `style.css`, or browsers serve the stale
-  copy. (Current: `?v=20260722-2`.)
+  copy. (Current: `?v=20260909-1`.)
 - **Fonts** load from Google Fonts (Red Hat Display + JetBrains Mono).
 - Set the `active` class on the current page's nav link.
 

--- a/site/architecture.html
+++ b/site/architecture.html
@@ -16,9 +16,16 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=20260722-2">
+  <link rel="stylesheet" href="style.css?v=20260909-1">
 </head>
 <body>
+
+  <!-- ANNOUNCEMENT (duplicated across pages) -->
+  <a class="announce" href="https://itnext.io/skillberry-store-the-open-source-control-plane-for-agent-skills-99be3aab6229?postPublishedType=repub" target="_blank" rel="noopener">
+    <span class="announce-tag">New</span>
+    <span class="announce-text">Introducing Skillberry Store<span class="hide-sm"> — the open-source control plane for agent skills</span></span>
+    <span class="announce-cta">Read the blog ↗</span>
+  </a>
 
   <nav class="nav">
     <div class="nav-inner">
@@ -29,6 +36,7 @@
         <a href="plugins.html">Plugins</a>
         <a href="architecture.html" class="active hide-sm">Architecture</a>
         <a href="cli.html" class="hide-sm">CLI</a>
+        <a href="https://skillberry-store-demo-adv.onrender.com" class="demo" target="_blank" rel="noopener"><span class="hide-sm">Live </span>Demo ↗</a>
         <a href="https://github.com/skillberry-ai/skillberry-store" class="gh">GitHub ↗</a>
       </div>
     </div>
@@ -131,6 +139,11 @@
         <p>A smart skills repository for agentic workflows. Manage, execute, and organize every tool your AI agents need.</p>
       </div>
       <div class="footer-cols">
+        <div class="footer-col">
+          <h4>Resources</h4>
+          <a href="https://skillberry-store-demo-adv.onrender.com" target="_blank" rel="noopener">Live demo ↗</a>
+          <a href="https://itnext.io/skillberry-store-the-open-source-control-plane-for-agent-skills-99be3aab6229?postPublishedType=repub" target="_blank" rel="noopener">Introduction blog ↗</a>
+        </div>
         <div class="footer-col">
           <h4>Docs</h4>
           <a href="getting-started.html">Getting Started</a>

--- a/site/cli.html
+++ b/site/cli.html
@@ -16,9 +16,16 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=20260722-2">
+  <link rel="stylesheet" href="style.css?v=20260909-1">
 </head>
 <body>
+
+  <!-- ANNOUNCEMENT (duplicated across pages) -->
+  <a class="announce" href="https://itnext.io/skillberry-store-the-open-source-control-plane-for-agent-skills-99be3aab6229?postPublishedType=repub" target="_blank" rel="noopener">
+    <span class="announce-tag">New</span>
+    <span class="announce-text">Introducing Skillberry Store<span class="hide-sm"> — the open-source control plane for agent skills</span></span>
+    <span class="announce-cta">Read the blog ↗</span>
+  </a>
 
   <nav class="nav">
     <div class="nav-inner">
@@ -29,6 +36,7 @@
         <a href="plugins.html">Plugins</a>
         <a href="architecture.html" class="hide-sm">Architecture</a>
         <a href="cli.html" class="active hide-sm">CLI</a>
+        <a href="https://skillberry-store-demo-adv.onrender.com" class="demo" target="_blank" rel="noopener"><span class="hide-sm">Live </span>Demo ↗</a>
         <a href="https://github.com/skillberry-ai/skillberry-store" class="gh">GitHub ↗</a>
       </div>
     </div>
@@ -132,6 +140,11 @@ RESULT=$(sbs execute-tool my-tool --body='{"params":{}}' -o json)</code></pre>
         <p>A smart skills repository for agentic workflows. Manage, execute, and organize every tool your AI agents need.</p>
       </div>
       <div class="footer-cols">
+        <div class="footer-col">
+          <h4>Resources</h4>
+          <a href="https://skillberry-store-demo-adv.onrender.com" target="_blank" rel="noopener">Live demo ↗</a>
+          <a href="https://itnext.io/skillberry-store-the-open-source-control-plane-for-agent-skills-99be3aab6229?postPublishedType=repub" target="_blank" rel="noopener">Introduction blog ↗</a>
+        </div>
         <div class="footer-col">
           <h4>Docs</h4>
           <a href="getting-started.html">Getting Started</a>

--- a/site/features.html
+++ b/site/features.html
@@ -16,9 +16,16 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=20260722-2">
+  <link rel="stylesheet" href="style.css?v=20260909-1">
 </head>
 <body>
+
+  <!-- ANNOUNCEMENT (duplicated across pages) -->
+  <a class="announce" href="https://itnext.io/skillberry-store-the-open-source-control-plane-for-agent-skills-99be3aab6229?postPublishedType=repub" target="_blank" rel="noopener">
+    <span class="announce-tag">New</span>
+    <span class="announce-text">Introducing Skillberry Store<span class="hide-sm"> — the open-source control plane for agent skills</span></span>
+    <span class="announce-cta">Read the blog ↗</span>
+  </a>
 
   <nav class="nav">
     <div class="nav-inner">
@@ -29,6 +36,7 @@
         <a href="plugins.html">Plugins</a>
         <a href="architecture.html" class="hide-sm">Architecture</a>
         <a href="cli.html" class="hide-sm">CLI</a>
+        <a href="https://skillberry-store-demo-adv.onrender.com" class="demo" target="_blank" rel="noopener"><span class="hide-sm">Live </span>Demo ↗</a>
         <a href="https://github.com/skillberry-ai/skillberry-store" class="gh">GitHub ↗</a>
       </div>
     </div>
@@ -190,6 +198,11 @@
         <p>A smart skills repository for agentic workflows. Manage, execute, and organize every tool your AI agents need.</p>
       </div>
       <div class="footer-cols">
+        <div class="footer-col">
+          <h4>Resources</h4>
+          <a href="https://skillberry-store-demo-adv.onrender.com" target="_blank" rel="noopener">Live demo ↗</a>
+          <a href="https://itnext.io/skillberry-store-the-open-source-control-plane-for-agent-skills-99be3aab6229?postPublishedType=repub" target="_blank" rel="noopener">Introduction blog ↗</a>
+        </div>
         <div class="footer-col">
           <h4>Docs</h4>
           <a href="getting-started.html">Getting Started</a>

--- a/site/getting-started.html
+++ b/site/getting-started.html
@@ -16,9 +16,16 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=20260722-2">
+  <link rel="stylesheet" href="style.css?v=20260909-1">
 </head>
 <body>
+
+  <!-- ANNOUNCEMENT (duplicated across pages) -->
+  <a class="announce" href="https://itnext.io/skillberry-store-the-open-source-control-plane-for-agent-skills-99be3aab6229?postPublishedType=repub" target="_blank" rel="noopener">
+    <span class="announce-tag">New</span>
+    <span class="announce-text">Introducing Skillberry Store<span class="hide-sm"> — the open-source control plane for agent skills</span></span>
+    <span class="announce-cta">Read the blog ↗</span>
+  </a>
 
   <nav class="nav">
     <div class="nav-inner">
@@ -29,6 +36,7 @@
         <a href="plugins.html">Plugins</a>
         <a href="architecture.html" class="hide-sm">Architecture</a>
         <a href="cli.html" class="hide-sm">CLI</a>
+        <a href="https://skillberry-store-demo-adv.onrender.com" class="demo" target="_blank" rel="noopener"><span class="hide-sm">Live </span>Demo ↗</a>
         <a href="https://github.com/skillberry-ai/skillberry-store" class="gh">GitHub ↗</a>
       </div>
     </div>
@@ -43,6 +51,10 @@
   </div>
 
   <main class="page-narrow doc section">
+
+    <div class="callout teal">
+      <p><strong>Want to look before you install?</strong> <a href="https://skillberry-store-demo-adv.onrender.com" target="_blank" rel="noopener">Try the live demo ↗</a> — a running Skillberry Store with sample skills, nothing to set up. It is a shared free instance, so the first load may take a few seconds to wake.</p>
+    </div>
 
     <h2>1. Prerequisites</h2>
     <ul>
@@ -149,6 +161,11 @@ curl -X POST "http://localhost:8000/vmcp_servers/?name=my-skill&skill_uuid=&lt;u
         <p>A smart skills repository for agentic workflows. Manage, execute, and organize every tool your AI agents need.</p>
       </div>
       <div class="footer-cols">
+        <div class="footer-col">
+          <h4>Resources</h4>
+          <a href="https://skillberry-store-demo-adv.onrender.com" target="_blank" rel="noopener">Live demo ↗</a>
+          <a href="https://itnext.io/skillberry-store-the-open-source-control-plane-for-agent-skills-99be3aab6229?postPublishedType=repub" target="_blank" rel="noopener">Introduction blog ↗</a>
+        </div>
         <div class="footer-col">
           <h4>Docs</h4>
           <a href="getting-started.html">Getting Started</a>

--- a/site/index.html
+++ b/site/index.html
@@ -41,9 +41,16 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=20260722-2">
+  <link rel="stylesheet" href="style.css?v=20260909-1">
 </head>
 <body>
+
+  <!-- ANNOUNCEMENT (duplicated across pages) -->
+  <a class="announce" href="https://itnext.io/skillberry-store-the-open-source-control-plane-for-agent-skills-99be3aab6229?postPublishedType=repub" target="_blank" rel="noopener">
+    <span class="announce-tag">New</span>
+    <span class="announce-text">Introducing Skillberry Store<span class="hide-sm"> — the open-source control plane for agent skills</span></span>
+    <span class="announce-cta">Read the blog ↗</span>
+  </a>
 
   <!-- NAV (duplicated across pages) -->
   <nav class="nav">
@@ -58,6 +65,7 @@
         <a href="plugins.html">Plugins</a>
         <a href="architecture.html" class="hide-sm">Architecture</a>
         <a href="cli.html" class="hide-sm">CLI</a>
+        <a href="https://skillberry-store-demo-adv.onrender.com" class="demo" target="_blank" rel="noopener"><span class="hide-sm">Live </span>Demo ↗</a>
         <a href="https://github.com/skillberry-ai/skillberry-store" class="gh">GitHub ↗</a>
       </div>
     </div>
@@ -77,8 +85,9 @@
         <p class="lead">Skillberry Store is a central place to manage every tool your AI agents need. Upload once, execute anywhere, and manage everything from a single service — tools, skills, and snippets with semantic search, lifecycle management, virtual MCP servers, and a rich plugin ecosystem.</p>
         <div class="cta">
           <a class="btn btn-primary" href="getting-started.html">Get started →</a>
-          <a class="btn btn-ghost" href="features.html">Explore features</a>
+          <a class="btn btn-ghost" href="https://skillberry-store-demo-adv.onrender.com" target="_blank" rel="noopener">Try the live demo ↗</a>
         </div>
+        <p class="caption" style="text-align:left;margin:-.4rem 0 1.2rem">Shared free instance — the first load may take a few seconds to wake.</p>
         <pre><code>pip install skillberry-store
 make docker-run   <span style="color:#7f90ad"># UI → :8002 · API docs → :8000/docs</span></code></pre>
       </div>
@@ -212,6 +221,7 @@ make docker-run   <span style="color:#7f90ad"># UI → :8002 · API docs → :80
 make docker-run</code></pre>
         <div class="cta" style="justify-content:center">
           <a class="btn btn-primary" href="getting-started.html">Get started →</a>
+          <a class="btn btn-ghost" href="https://skillberry-store-demo-adv.onrender.com" target="_blank" rel="noopener">Try the live demo ↗</a>
           <a class="btn btn-ghost" href="https://github.com/skillberry-ai/skillberry-store">View on GitHub ↗</a>
         </div>
       </div>
@@ -226,6 +236,11 @@ make docker-run</code></pre>
         <p>A smart skills repository for agentic workflows. Manage, execute, and organize every tool your AI agents need.</p>
       </div>
       <div class="footer-cols">
+        <div class="footer-col">
+          <h4>Resources</h4>
+          <a href="https://skillberry-store-demo-adv.onrender.com" target="_blank" rel="noopener">Live demo ↗</a>
+          <a href="https://itnext.io/skillberry-store-the-open-source-control-plane-for-agent-skills-99be3aab6229?postPublishedType=repub" target="_blank" rel="noopener">Introduction blog ↗</a>
+        </div>
         <div class="footer-col">
           <h4>Docs</h4>
           <a href="getting-started.html">Getting Started</a>

--- a/site/plugins.html
+++ b/site/plugins.html
@@ -16,9 +16,16 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=20260722-2">
+  <link rel="stylesheet" href="style.css?v=20260909-1">
 </head>
 <body>
+
+  <!-- ANNOUNCEMENT (duplicated across pages) -->
+  <a class="announce" href="https://itnext.io/skillberry-store-the-open-source-control-plane-for-agent-skills-99be3aab6229?postPublishedType=repub" target="_blank" rel="noopener">
+    <span class="announce-tag">New</span>
+    <span class="announce-text">Introducing Skillberry Store<span class="hide-sm"> — the open-source control plane for agent skills</span></span>
+    <span class="announce-cta">Read the blog ↗</span>
+  </a>
 
   <nav class="nav">
     <div class="nav-inner">
@@ -29,6 +36,7 @@
         <a href="plugins.html" class="active">Plugins</a>
         <a href="architecture.html" class="hide-sm">Architecture</a>
         <a href="cli.html" class="hide-sm">CLI</a>
+        <a href="https://skillberry-store-demo-adv.onrender.com" class="demo" target="_blank" rel="noopener"><span class="hide-sm">Live </span>Demo ↗</a>
         <a href="https://github.com/skillberry-ai/skillberry-store" class="gh">GitHub ↗</a>
       </div>
     </div>
@@ -218,6 +226,11 @@ class MyPlugin(PluginBase):
         <p>A smart skills repository for agentic workflows. Manage, execute, and organize every tool your AI agents need.</p>
       </div>
       <div class="footer-cols">
+        <div class="footer-col">
+          <h4>Resources</h4>
+          <a href="https://skillberry-store-demo-adv.onrender.com" target="_blank" rel="noopener">Live demo ↗</a>
+          <a href="https://itnext.io/skillberry-store-the-open-source-control-plane-for-agent-skills-99be3aab6229?postPublishedType=repub" target="_blank" rel="noopener">Introduction blog ↗</a>
+        </div>
         <div class="footer-col">
           <h4>Docs</h4>
           <a href="getting-started.html">Getting Started</a>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -2,32 +2,32 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://skillberry-ai.github.io/skillberry-store/</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-09-09</lastmod>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://skillberry-ai.github.io/skillberry-store/getting-started.html</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-09-09</lastmod>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://skillberry-ai.github.io/skillberry-store/features.html</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-09-09</lastmod>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skillberry-ai.github.io/skillberry-store/plugins.html</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-09-09</lastmod>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skillberry-ai.github.io/skillberry-store/architecture.html</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-09-09</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://skillberry-ai.github.io/skillberry-store/cli.html</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-09-09</lastmod>
     <priority>0.7</priority>
   </url>
 </urlset>

--- a/site/style.css
+++ b/site/style.css
@@ -88,6 +88,38 @@ pre code { background: none; color: inherit; padding: 0; font-size: inherit; }
 
 hr { border: none; border-top: 1px solid var(--border); margin: 2.5rem 0; }
 
+/* ---------- Announcement strip ---------- */
+/* Sits above the sticky nav on every page and scrolls away with the hero.
+   Retire it by deleting the .announce block from each HTML file. */
+.announce {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: .6rem;
+  padding: .55rem 1.5rem;
+  background: var(--navy);
+  color: #cfdcf0;
+  font-size: .92rem;
+  font-weight: 500;
+  text-align: center;
+}
+.announce:hover { color: #fff; text-decoration: none; }
+.announce:hover .announce-cta { text-decoration: underline; }
+.announce-tag {
+  font-family: var(--mono);
+  font-size: .68rem;
+  font-weight: 700;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  padding: .18rem .55rem;
+  border-radius: 100px;
+  background: var(--accent);
+  color: #fff;
+  flex-shrink: 0;
+}
+.announce-cta { font-weight: 700; color: #fff; white-space: nowrap; }
+
 /* ---------- Nav ---------- */
 .nav {
   position: sticky;
@@ -140,6 +172,14 @@ hr { border: none; border-top: 1px solid var(--border); margin: 2.5rem 0; }
   gap: .4rem;
 }
 .nav-links a.gh:hover { border-color: var(--accent); }
+/* Filled pill — the nav's primary action. Never hidden on small screens;
+   below 620px the inner .hide-sm span drops so it reads just "Demo". */
+.nav-links a.demo {
+  background: var(--accent);
+  color: #fff;
+  white-space: nowrap;
+}
+.nav-links a.demo:hover { background: var(--accent-dark); color: #fff; }
 
 /* ---------- Layout ---------- */
 .page { max-width: var(--maxw); margin: 0 auto; padding: 0 1.5rem; }
@@ -421,6 +461,9 @@ table.table code { white-space: nowrap; }
   .nav-links { gap: .1rem; }
   .nav-links a { padding: .35rem .5rem; font-size: .88rem; }
   .nav-links a.hide-sm { display: none; }
+  .nav-links a .hide-sm { display: none; }   /* 'Live Demo' → 'Demo' */
+  .announce { padding: .5rem 1rem; font-size: .84rem; gap: .45rem; }
+  .announce .hide-sm { display: none; }
   .cta-band { padding: 2rem 1.25rem; }
   .footer .page { flex-direction: column; }
 }


### PR DESCRIPTION
The introduction blog and the live demo appeared nowhere on the published site, and in the README they sat as two bare markdown lines below the highlights video (with an `Inroduction` typo). A first-time visitor's only options were *install something* or *read more*.

## Placement

| Resource | Where | Why |
|---|---|---|
| **Live demo** | Accent pill in the nav (all 6 pages) + hero CTA + bottom CTA band + footer + a callout on Getting Started | A hosted, zero-install demo is the highest-value link an OSS landing page has, so it earns a permanent slot *and* a button — not a text link. |
| **Introduction blog** | Slim announcement strip above the sticky nav (all 6 pages) + footer | A single article does not justify a seventh nav item — "Blog" promises an index readers will not find, and the nav is already tight enough that Architecture and CLI hide on mobile. A strip is more visible than a nav link and retires cleanly once it stops being news; the footer's new **Resources** column keeps both links permanently. |

## Changes

**Site** (`site/`, deployed verbatim by `pages.yml`):

- Announcement strip (`.announce`) above the nav on all six pages, linking the blog.
- `Live Demo ↗` accent pill in the nav on all six pages. Below 620px the label shortens to `Demo ↗` — the full label pushed the mobile nav from two rows to three, and shortening it restores the original 96px height exactly.
- Hero CTA row is now `Get started →` + `Try the live demo ↗`; this replaces `Explore features`, keeping one clear primary and one secondary (Features remains in the nav, the footer, and the doc-tile grid on the same page).
- `Try the live demo ↗` added to the bottom CTA band; teal callout at the top of Getting Started, where install friction begins.
- New footer **Resources** column (live demo + blog) on every page.
- Microcopy noting the demo is a shared free instance that may take a few seconds to wake, so a cold start does not read as a broken link.
- Stylesheet cache-buster bumped to `?v=20260909-1`; `sitemap.xml` `lastmod` dates refreshed; `site/README.md` records the strip as a third duplicated block.

**README**: a **Try it now** table replacing the two bare links (typo fixed), plus a `demo-live` badge beside the existing site badge.

## Verification

Checked in a browser via `scripts/preview-site.sh` at 1280 / 768 / 390px:

- Strip sits above the sticky nav and scrolls away while the nav sticks.
- Mobile: strip stays one line (trailing clause hidden), `Demo ↗` stays visible while Architecture/CLI hide, nav height unchanged from before at 96px, no horizontal overflow.
- Footer's three columns and the getting-started callout render cleanly.
- Announcement + nav blocks are byte-identical across all six pages (modulo the pre-existing `active` class and index's multi-line brand); footer blocks are identical.
- Both URLs resolve. The blog 403s to `curl` (Medium bot protection) but loads fine in a browser.
- `make lint` passes. `make test` not run — nothing outside HTML/CSS/Markdown changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)